### PR TITLE
refactor: change masterKey to primaryKey

### DIFF
--- a/.github/ISSUE_TEMPLATE/---1-report-an-issue.md
+++ b/.github/ISSUE_TEMPLATE/---1-report-an-issue.md
@@ -15,9 +15,8 @@ assignees: ''
 -->
 
 - [ ] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
-- [ ] I am not just asking a [question](https://github.com/netreconlab/.github/blob/main/SUPPORT.md).
 - [ ] I have searched through [existing issues](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).
-- [ ] I can reproduce the issue with the latest versions of [Parse Server](https://github.com/netreconlab/parse-server/releases) and the [Parse Swift SDK](https://github.com/netreconlab/Parse-Swift/releases). <!-- We don't investigate issues for outdated releases. -->
+- [ ] I can reproduce the issue with the latest versions of [Parse Server](https://github.com/parse-community/parse-server/releases) and the [Parse Swift SDK](https://github.com/netreconlab/Parse-Swift/releases). <!-- We don't investigate issues for outdated releases. -->
 
 ### Issue Description
 <!-- What is the specific issue? -->

--- a/.github/ISSUE_TEMPLATE/---2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---2-feature-request.md
@@ -15,7 +15,6 @@ assignees: ''
 -->
 
 - [ ] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
-- [ ] I am not just asking a [question](https://github.com/netreconlab/.github/blob/main/SUPPORT.md).
 - [ ] I have searched through [existing issues](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).
 
 ### Current Limitation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.14.2...main), [Documentation](https://swiftpackageindex.com/parse-community/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/4.14.2...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 4.14.2
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/4.14.2...4.15.0), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/4.15.0/documentation/parseswift)
+
+__New features__
+- Addressed an issue that prevented updating ParseObjects with saveAll ([#2](https://github.com/netrecolab/Parse-Swift/pull/2)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 4.14.2
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.14.1...4.14.2), [Documentation](https://swiftpackageindex.com/parse-community/Parse-Swift/4.14.2/documentation/parseswift)

--- a/ParseSwift.playground/Pages/21 - Cloud Push Notifications.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/21 - Cloud Push Notifications.xcplaygroundpage/Contents.swift
@@ -175,7 +175,7 @@ let query = ParsePushStatus<ParsePushPayloadAny>
  Be sure to add the `.userMasterKey option when doing
  anything with `ParsePushStatus` directly.
 */
-query.findAll(options: [.useMasterKey]) { result in
+query.findAll(options: [.usePrimaryKey]) { result in
     switch result {
     case .success(let pushStatus):
         print("All matching statuses: \"\(pushStatus)\"")

--- a/ParseSwift.playground/Sources/Common.swift
+++ b/ParseSwift.playground/Sources/Common.swift
@@ -4,7 +4,7 @@ import ParseSwift
 public func initializeParse(customObjectId: Bool = false) {
     ParseSwift.initialize(applicationId: "applicationId",
                           clientKey: "clientKey",
-                          masterKey: "masterKey",
+                          primaryKey: "primaryKey",
                           serverURL: URL(string: "http://localhost:1337/1")!,
                           allowingCustomObjectIds: customObjectId,
                           usingEqualQueryConstraint: false,

--- a/Sources/ParseSwift/API/API.swift
+++ b/Sources/ParseSwift/API/API.swift
@@ -135,7 +135,10 @@ public struct API {
     /// Options available to send to Parse Server.
     public enum Option: Hashable {
 
+        /// Use the primaryKey/masterKey if it was provided during initial configuraration.
+        case usePrimaryKey
         /// Use the masterKey if it was provided during initial configuraration.
+        @available(*, deprecated, renamed: "usePrimaryKey")
         case useMasterKey // swiftlint:disable:this inclusive_language
         /// Use a specific session token.
         /// - note: The session token of the current user is provided by default.
@@ -167,7 +170,7 @@ public struct API {
 
         public func hash(into hasher: inout Hasher) {
             switch self {
-            case .useMasterKey:
+            case .usePrimaryKey, .useMasterKey:
                 hasher.combine(1)
             case .sessionToken:
                 hasher.combine(2)
@@ -216,8 +219,8 @@ public struct API {
 
         options.forEach { (option) in
             switch option {
-            case .useMasterKey:
-                headers["X-Parse-Master-Key"] = Parse.configuration.masterKey
+            case .usePrimaryKey, .useMasterKey:
+                headers["X-Parse-Master-Key"] = Parse.configuration.primaryKey
             case .sessionToken(let sessionToken):
                 headers["X-Parse-Session-Token"] = sessionToken
             case .installationId(let installationId):

--- a/Sources/ParseSwift/LiveQuery/Messages.swift
+++ b/Sources/ParseSwift/LiveQuery/Messages.swift
@@ -13,7 +13,7 @@ struct StandardMessage: LiveQueryable, Codable {
     var op: ClientOperation // swiftlint:disable:this identifier_name
     var applicationId: String?
     var clientKey: String?
-    var masterKey: String? // swiftlint:disable:this inclusive_language
+    var primaryKey: String?
     var sessionToken: String?
     var installationId: String?
     var requestId: Int?
@@ -22,7 +22,7 @@ struct StandardMessage: LiveQueryable, Codable {
         self.op = operation
         if additionalProperties {
             self.applicationId = Parse.configuration.applicationId
-            self.masterKey = Parse.configuration.masterKey
+            self.primaryKey = Parse.configuration.primaryKey
             self.clientKey = Parse.configuration.clientKey
             self.sessionToken = BaseParseUser.currentContainer?.sessionToken
             self.installationId = BaseParseInstallation.currentContainer.installationId
@@ -32,6 +32,16 @@ struct StandardMessage: LiveQueryable, Codable {
     init(operation: ClientOperation, requestId: RequestId) {
         self.init(operation: operation)
         self.requestId = requestId.value
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case op // swiftlint:disable:this identifier_name
+        case applicationId
+        case clientKey
+        case primaryKey = "masterKey"
+        case sessionToken
+        case installationId
+        case requestId
     }
 }
 

--- a/Sources/ParseSwift/Objects/ParsePushStatusable.swift
+++ b/Sources/ParseSwift/Objects/ParsePushStatusable.swift
@@ -12,7 +12,7 @@ import Foundation
  Objects that conform to the `ParsePushStatusable` protocol represent
  PushStatus on the Parse Server.
  - warning: These objects are only read-only.
- - requires: `.useMasterKey` has to be available. It is recommended to only
+ - requires: `.usePrimaryKey` has to be available. It is recommended to only
  use the master key in server-side applications where the key is kept secure and not
  exposed to the public.
  */

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -14,7 +14,7 @@ internal struct Parse {
 
 internal func initialize(applicationId: String,
                          clientKey: String? = nil,
-                         masterKey: String? = nil,
+                         primaryKey: String? = nil,
                          serverURL: URL,
                          liveQueryServerURL: URL? = nil,
                          requiringCustomObjectIds: Bool = false,
@@ -36,7 +36,7 @@ internal func initialize(applicationId: String,
                                            URLCredential?) -> Void) -> Void)? = nil) {
     var configuration = ParseConfiguration(applicationId: applicationId,
                                            clientKey: clientKey,
-                                           masterKey: masterKey,
+                                           primaryKey: primaryKey,
                                            serverURL: serverURL,
                                            liveQueryServerURL: liveQueryServerURL,
                                            requiringCustomObjectIds: requiringCustomObjectIds,
@@ -86,7 +86,7 @@ public var configuration: ParseConfiguration {
  Configure the Parse Swift client. This should only be used when starting your app. Typically in the
  `application(... didFinishLaunchingWithOptions launchOptions...)`.
  - parameter configuration: The Parse configuration.
- - important: It is recomended to only specify `masterKey` when using the SDK on a server. Do not use this key on the client.
+ - important: It is recomended to only specify `primaryKey/masterKey` when using the SDK on a server. Do not use this key on the client.
  - note: Setting `usingPostForQuery` to **true**  will require all queries to access the server instead of following the `requestCachePolicy`.
  - warning: `usingTransactions` is experimental.
  - warning: Setting `usingDataProtectionKeychain` to **true** is known to cause issues in Playgrounds or in
@@ -179,6 +179,98 @@ public func initialize(configuration: ParseConfiguration) {
  `application(... didFinishLaunchingWithOptions launchOptions...)`.
  - parameter applicationId: The application id for your Parse application.
  - parameter clientKey: The client key for your Parse application.
+ - parameter primaryKey: The primary key for your Parse application. This key should only be
+ specified when using the SDK on a server. This has been renamed from `masterKey` to reflect
+ inclusive language.
+ - parameter serverURL: The server URL to connect to Parse Server.
+ - parameter liveQueryServerURL: The live query server URL to connect to Parse Server.
+ - parameter requiringCustomObjectIds: Requires `objectId`'s to be created on the client
+ side for each object. Must be enabled on the server to work.
+ - parameter usingTransactions: Use transactions when saving/updating multiple objects.
+ - parameter usingEqualQueryConstraint: Use the **$eq** query constraint when querying.
+ - parameter usingPostForQuery: Use **POST** instead of **GET** when making query calls.
+ Defaults to **false**.
+ - parameter primitiveStore: A key/value store that conforms to the `ParseKeyValueStore`
+ protocol. Defaults to `nil` in which one will be created an memory, but never persisted. For Linux, this
+ this is the only store available since there is no Keychain. Linux, Android, and Windows users should
+ replace this store with an encrypted one.
+ - parameter requestCachePolicy: The default caching policy for all http requests that determines
+ when to return a response from the cache. Defaults to `useProtocolCachePolicy`. See Apple's [documentation](https://developer.apple.com/documentation/foundation/url_loading_system/accessing_cached_data)
+ for more info.
+ - parameter cacheMemoryCapacity: The memory capacity of the cache, in bytes. Defaults to 512KB.
+ - parameter cacheDiskCapacity: The disk capacity of the cache, in bytes. Defaults to 10MB.
+ - parameter usingDataProtectionKeychain: Sets `kSecUseDataProtectionKeychain` to **true**. See Apple's [documentation](https://developer.apple.com/documentation/security/ksecusedataprotectionkeychain)
+ for more info. Defaults to **false**.
+ - parameter deletingKeychainIfNeeded: Deletes the Parse Keychain when the app is running for the first time.
+ Defaults to **false**.
+ - parameter httpAdditionalHeaders: A dictionary of additional headers to send with requests. See Apple's
+ [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
+ for more info.
+ - parameter maxConnectionAttempts: Maximum number of times to try to connect to Parse Server.
+ Defaults to 5.
+ - parameter parseFileTransfer: Override the default transfer behavior for `ParseFile`'s.
+ Allows for direct uploads to other file storage providers.
+ - parameter authentication: A callback block that will be used to receive/accept/decline network challenges.
+ Defaults to `nil` in which the SDK will use the default OS authentication methods for challenges.
+ It should have the following argument signature: `(challenge: URLAuthenticationChallenge,
+ completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void`.
+ See Apple's [documentation](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411595-urlsession) for more for details.
+ - important: It is recomended to only specify `primaryKey/masterKey` when using the SDK on a server. Do not use this key on the client.
+ - note: Setting `usingPostForQuery` to **true**  will require all queries to access the server instead of following the `requestCachePolicy`.
+ - warning: `usingTransactions` is experimental.
+ - warning: Setting `usingDataProtectionKeychain` to **true** is known to cause issues in Playgrounds or in
+ situtations when apps do not have credentials to setup a Keychain.
+ */
+public func initialize(
+    applicationId: String,
+    clientKey: String? = nil,
+    primaryKey: String? = nil,
+    serverURL: URL,
+    liveQueryServerURL: URL? = nil,
+    requiringCustomObjectIds: Bool = false,
+    usingTransactions: Bool = false,
+    usingEqualQueryConstraint: Bool = false,
+    usingPostForQuery: Bool = false,
+    primitiveStore: ParsePrimitiveStorable? = nil,
+    requestCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
+    cacheMemoryCapacity: Int = 512_000,
+    cacheDiskCapacity: Int = 10_000_000,
+    usingDataProtectionKeychain: Bool = false,
+    deletingKeychainIfNeeded: Bool = false,
+    httpAdditionalHeaders: [AnyHashable: Any]? = nil,
+    maxConnectionAttempts: Int = 5,
+    parseFileTransfer: ParseFileTransferable? = nil,
+    authentication: ((URLAuthenticationChallenge,
+                      (URLSession.AuthChallengeDisposition,
+                       URLCredential?) -> Void) -> Void)? = nil
+) {
+    let configuration = ParseConfiguration(applicationId: applicationId,
+                                           clientKey: clientKey,
+                                           primaryKey: primaryKey,
+                                           serverURL: serverURL,
+                                           liveQueryServerURL: liveQueryServerURL,
+                                           requiringCustomObjectIds: requiringCustomObjectIds,
+                                           usingTransactions: usingTransactions,
+                                           usingEqualQueryConstraint: usingEqualQueryConstraint,
+                                           usingPostForQuery: usingPostForQuery,
+                                           primitiveStore: primitiveStore,
+                                           requestCachePolicy: requestCachePolicy,
+                                           cacheMemoryCapacity: cacheMemoryCapacity,
+                                           cacheDiskCapacity: cacheDiskCapacity,
+                                           usingDataProtectionKeychain: usingDataProtectionKeychain,
+                                           deletingKeychainIfNeeded: deletingKeychainIfNeeded,
+                                           httpAdditionalHeaders: httpAdditionalHeaders,
+                                           maxConnectionAttempts: maxConnectionAttempts,
+                                           parseFileTransfer: parseFileTransfer,
+                                           authentication: authentication)
+    initialize(configuration: configuration)
+}
+
+/**
+ Configure the Parse Swift client. This should only be used when starting your app. Typically in the
+ `application(... didFinishLaunchingWithOptions launchOptions...)`.
+ - parameter applicationId: The application id for your Parse application.
+ - parameter clientKey: The client key for your Parse application.
  - parameter masterKey: The master key for your Parse application. This key should only be
  specified when using the SDK on a server.
  - parameter serverURL: The server URL to connect to Parse Server.
@@ -214,12 +306,13 @@ public func initialize(configuration: ParseConfiguration) {
  It should have the following argument signature: `(challenge: URLAuthenticationChallenge,
  completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void`.
  See Apple's [documentation](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411595-urlsession) for more for details.
- - important: It is recomended to only specify `masterKey` when using the SDK on a server. Do not use this key on the client.
+ - important: It is recomended to only specify `primaryKey/masterKey` when using the SDK on a server. Do not use this key on the client.
  - note: Setting `usingPostForQuery` to **true**  will require all queries to access the server instead of following the `requestCachePolicy`.
  - warning: `usingTransactions` is experimental.
  - warning: Setting `usingDataProtectionKeychain` to **true** is known to cause issues in Playgrounds or in
  situtations when apps do not have credentials to setup a Keychain.
  */
+@available(*, deprecated, message: "Change: masterKey->primaryKey")
 public func initialize(
     applicationId: String,
     clientKey: String? = nil,
@@ -243,26 +336,25 @@ public func initialize(
                       (URLSession.AuthChallengeDisposition,
                        URLCredential?) -> Void) -> Void)? = nil
 ) {
-    let configuration = ParseConfiguration(applicationId: applicationId,
-                                           clientKey: clientKey,
-                                           masterKey: masterKey,
-                                           serverURL: serverURL,
-                                           liveQueryServerURL: liveQueryServerURL,
-                                           requiringCustomObjectIds: requiringCustomObjectIds,
-                                           usingTransactions: usingTransactions,
-                                           usingEqualQueryConstraint: usingEqualQueryConstraint,
-                                           usingPostForQuery: usingPostForQuery,
-                                           primitiveStore: primitiveStore,
-                                           requestCachePolicy: requestCachePolicy,
-                                           cacheMemoryCapacity: cacheMemoryCapacity,
-                                           cacheDiskCapacity: cacheDiskCapacity,
-                                           usingDataProtectionKeychain: usingDataProtectionKeychain,
-                                           deletingKeychainIfNeeded: deletingKeychainIfNeeded,
-                                           httpAdditionalHeaders: httpAdditionalHeaders,
-                                           maxConnectionAttempts: maxConnectionAttempts,
-                                           parseFileTransfer: parseFileTransfer,
-                                           authentication: authentication)
-    initialize(configuration: configuration)
+    initialize(applicationId: applicationId,
+               clientKey: clientKey,
+               primaryKey: masterKey,
+               serverURL: serverURL,
+               liveQueryServerURL: liveQueryServerURL,
+               requiringCustomObjectIds: requiringCustomObjectIds,
+               usingTransactions: usingTransactions,
+               usingEqualQueryConstraint: usingEqualQueryConstraint,
+               usingPostForQuery: usingPostForQuery,
+               primitiveStore: primitiveStore,
+               requestCachePolicy: requestCachePolicy,
+               cacheMemoryCapacity: cacheMemoryCapacity,
+               cacheDiskCapacity: cacheDiskCapacity,
+               usingDataProtectionKeychain: usingDataProtectionKeychain,
+               deletingKeychainIfNeeded: deletingKeychainIfNeeded,
+               httpAdditionalHeaders: httpAdditionalHeaders,
+               maxConnectionAttempts: maxConnectionAttempts,
+               parseFileTransfer: parseFileTransfer,
+               authentication: authentication)
 }
 
 /**
@@ -305,7 +397,7 @@ public func initialize(
  It should have the following argument signature: `(challenge: URLAuthenticationChallenge,
  completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void`.
  See Apple's [documentation](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411595-urlsession) for more for details.
- - important: It is recomended to only specify `masterKey` when using the SDK on a server. Do not use this key on the client.
+ - important: It is recomended to only specify `primaryKey/masterKey` when using the SDK on a server. Do not use this key on the client.
  - note: Setting `usingPostForQuery` to **true**  will require all queries to access the server instead of following the `requestCachePolicy`.
  - warning: `usingTransactions` is experimental.
  - warning: Setting `usingDataProtectionKeychain` to **true** is known to cause issues in Playgrounds or in
@@ -398,7 +490,7 @@ public func initialize(
  It should have the following argument signature: `(challenge: URLAuthenticationChallenge,
  completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void`.
  See Apple's [documentation](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411595-urlsession) for more for details.
- - important: It is recomended to only specify `masterKey` when using the SDK on a server. Do not use this key on the client.
+ - important: It is recomended to only specify `primaryKey/masterKey` when using the SDK on a server. Do not use this key on the client.
  - note: Setting `usingPostForQuery` to **true**  will require all queries to access the server instead of following the `requestCachePolicy`.
  - warning: `usingTransactions` is experimental.
  - warning: Setting `usingDataProtectionKeychain` to **true** is known to cause issues in Playgrounds or in

--- a/Sources/ParseSwift/Protocols/ParseHookFunctionable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookFunctionable.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
  Conforming to `ParseHookFunctionable` allows the creation of hooks
  which are Cloud Code functions.
- - requires: `.useMasterKey` has to be available. It is recommended to only
+ - requires: `.usePrimaryKey` has to be available. It is recommended to only
  use the master key in server-side applications where the key is kept secure and not
  exposed to the public.
  */
@@ -66,7 +66,7 @@ extension ParseHookFunctionable {
                       callbackQueue: DispatchQueue = .main,
                       completion: @escaping (Result<Self, ParseError>) -> Void) {
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         do {
             try fetchCommand().executeAsync(options: options,
@@ -121,7 +121,7 @@ extension ParseHookFunctionable {
                                 callbackQueue: DispatchQueue = .main,
                                 completion: @escaping (Result<[Self], ParseError>) -> Void) {
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         fetchAllCommand().executeAsync(options: options,
                                        callbackQueue: callbackQueue) { result in
@@ -153,7 +153,7 @@ extension ParseHookFunctionable {
                        callbackQueue: DispatchQueue = .main,
                        completion: @escaping (Result<Self, ParseError>) -> Void) {
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         do {
             try createCommand().executeAsync(options: options,
@@ -195,7 +195,7 @@ extension ParseHookFunctionable {
                        callbackQueue: DispatchQueue = .main,
                        completion: @escaping (Result<Self, ParseError>) -> Void) {
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         do {
             try updateCommand().executeAsync(options: options,
@@ -236,7 +236,7 @@ extension ParseHookFunctionable {
                        callbackQueue: DispatchQueue = .main,
                        completion: @escaping (Result<Void, ParseError>) -> Void) {
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         do {
             try deleteCommand().executeAsync(options: options,

--- a/Sources/ParseSwift/Protocols/ParseHookRequestable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookRequestable.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
  Conforming to `ParseHookRequestable` allows you to create types that
  can decode requests when `ParseHookFunctionable` functions are called.
- - requires: `.useMasterKey` has to be available. It is recommended to only
+ - requires: `.usePrimaryKey` has to be available. It is recommended to only
  use the master key in server-side applications where the key is kept secure and not
  exposed to the public.
  */
@@ -21,7 +21,7 @@ public protocol ParseHookRequestable: ParseTypeable {
      Specifies if the **masterKey** was used in the
      Parse hook call.
      */
-    var masterKey: Bool? { get }
+    var primaryKey: Bool? { get }
     /**
      A `ParseUser` that contains additional attributes
      needed for Parse hook calls. If **nil** a user with
@@ -49,9 +49,9 @@ extension ParseHookRequestable {
      */
     public func options() -> API.Options {
         var options = API.Options()
-        if let masterKey = masterKey,
-            masterKey {
-            options.insert(.useMasterKey)
+        if let primaryKey = primaryKey,
+           primaryKey {
+            options.insert(.usePrimaryKey)
         } else if let sessionToken = user?.sessionToken {
             options.insert(.sessionToken(sessionToken))
             if let installationId = installationId {

--- a/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
  Conforming to `ParseHookFunctionable` allows the creation of hooks which
  are Cloud Code triggers.
- - requires: `.useMasterKey` has to be available. It is recommended to only
+ - requires: `.usePrimaryKey` has to be available. It is recommended to only
  use the master key in server-side applications where the key is kept secure and not
  exposed to the public.
  */
@@ -101,7 +101,7 @@ extension ParseHookTriggerable {
                       callbackQueue: DispatchQueue = .main,
                       completion: @escaping (Result<Self, ParseError>) -> Void) {
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         do {
             try fetchCommand().executeAsync(options: options,
@@ -158,7 +158,7 @@ extension ParseHookTriggerable {
                                 callbackQueue: DispatchQueue = .main,
                                 completion: @escaping (Result<[Self], ParseError>) -> Void) {
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         fetchAllCommand().executeAsync(options: options,
                                        callbackQueue: callbackQueue) { result in
@@ -190,7 +190,7 @@ extension ParseHookTriggerable {
                        callbackQueue: DispatchQueue = .main,
                        completion: @escaping (Result<Self, ParseError>) -> Void) {
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         do {
             try createCommand().executeAsync(options: options,
@@ -231,7 +231,7 @@ extension ParseHookTriggerable {
                        callbackQueue: DispatchQueue = .main,
                        completion: @escaping (Result<Self, ParseError>) -> Void) {
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         do {
             try updateCommand().executeAsync(options: options,
@@ -272,7 +272,7 @@ extension ParseHookTriggerable {
                        callbackQueue: DispatchQueue = .main,
                        completion: @escaping (Result<Void, ParseError>) -> Void) {
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         do {
             try deleteCommand().executeAsync(options: options,

--- a/Sources/ParseSwift/Protocols/QueryObservable.swift
+++ b/Sources/ParseSwift/Protocols/QueryObservable.swift
@@ -63,7 +63,7 @@ public protocol QueryObservable: ObservableObject {
 
     /**
       Executes an aggregate query *asynchronously* and updates the view model when complete.
-        - requires: `.useMasterKey` has to be available. It is recommended to only
+        - requires: `.usePrimaryKey` has to be available. It is recommended to only
         use the master key in server-side applications where the key is kept secure and not
         exposed to the public.
         - parameter pipeline: A pipeline of stages to process query.

--- a/Sources/ParseSwift/Types/ParseConfig.swift
+++ b/Sources/ParseSwift/Types/ParseConfig.swift
@@ -92,7 +92,7 @@ extension ParseConfig {
                      callbackQueue: DispatchQueue = .main,
                      completion: @escaping (Result<Bool, ParseError>) -> Void) {
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         updateCommand()
             .executeAsync(options: options, callbackQueue: callbackQueue) { result in

--- a/Sources/ParseSwift/Types/ParseConfiguration.swift
+++ b/Sources/ParseSwift/Types/ParseConfiguration.swift
@@ -30,13 +30,8 @@ public struct ParseConfiguration {
     /// The master key for your Parse application. This key should only
     /// be specified when using the SDK on a server.
     @available(*, deprecated, renamed: "primaryKey")
-    public internal(set) var masterKey: String? { // swiftlint:disable:this inclusive_language
-        get {
-            primaryKey
-        }
-        set {
-            primaryKey = newValue
-        }
+    public var masterKey: String? { // swiftlint:disable:this inclusive_language
+        primaryKey
     }
 
     /// The primary key for your Parse application. This key should only

--- a/Sources/ParseSwift/Types/ParseConfiguration.swift
+++ b/Sources/ParseSwift/Types/ParseConfiguration.swift
@@ -16,7 +16,7 @@ import FoundationNetworking
 /**
  The Configuration for a Parse client.
 
- - important: It is recomended to only specify `masterKey` when using the SDK on a server. Do not use this key on the client.
+ - important: It is recomended to only specify `primaryKey` when using the SDK on a server. Do not use this key on the client.
  - note: Setting `usingPostForQuery` to **true**  will require all queries to access the server instead of following the `requestCachePolicy`.
  - warning: `usingTransactions` is experimental.
  - warning: Setting `usingDataProtectionKeychain` to **true** is known to cause issues in Playgrounds or in
@@ -29,7 +29,20 @@ public struct ParseConfiguration {
 
     /// The master key for your Parse application. This key should only
     /// be specified when using the SDK on a server.
-    public internal(set) var masterKey: String? // swiftlint:disable:this inclusive_language
+    @available(*, deprecated, renamed: "primaryKey")
+    public internal(set) var masterKey: String? { // swiftlint:disable:this inclusive_language
+        get {
+            primaryKey
+        }
+        set {
+            primaryKey = newValue
+        }
+    }
+
+    /// The primary key for your Parse application. This key should only
+    /// be specified when using the SDK on a server.
+    /// - note: This has been renamed from `masterKey` to reflect [inclusive language](https://github.com/dialpad/inclusive-language#motivation)
+    public internal(set) var primaryKey: String?
 
     /// The client key for your Parse application.
     public internal(set) var clientKey: String?
@@ -119,6 +132,97 @@ public struct ParseConfiguration {
      Create a Parse Swift configuration.
      - parameter applicationId: The application id for your Parse application.
      - parameter clientKey: The client key for your Parse application.
+     - parameter primaryKey: The master key for your Parse application. This key should only be
+     specified when using the SDK on a server.
+     - parameter serverURL: The server URL to connect to Parse Server.
+     - parameter liveQueryServerURL: The live query server URL to connect to Parse Server.
+     - parameter requiringCustomObjectIds: Requires `objectId`'s to be created on the client
+     side for each object. Must be enabled on the server to work.
+     - parameter usingTransactions: Use transactions when saving/updating multiple objects.
+     - parameter usingEqualQueryConstraint: Use the **$eq** query constraint when querying.
+     - parameter usingPostForQuery: Use **POST** instead of **GET** when making query calls.
+     Defaults to **false**.
+     - parameter primitiveStore: A key/value store that conforms to the `ParsePrimitiveStorable`
+     protocol. Defaults to `nil` in which one will be created an memory, but never persisted. For Linux, this
+     this is the only store available since there is no Keychain. Linux, Android, and Windows users should
+     replace this store with an encrypted one.
+     - parameter requestCachePolicy: The default caching policy for all http requests that determines
+     when to return a response from the cache. Defaults to `useProtocolCachePolicy`. See Apple's [documentation](https://developer.apple.com/documentation/foundation/url_loading_system/accessing_cached_data)
+     for more info.
+     - parameter cacheMemoryCapacity: The memory capacity of the cache, in bytes. Defaults to 512KB.
+     - parameter cacheDiskCapacity: The disk capacity of the cache, in bytes. Defaults to 10MB.
+     - parameter usingDataProtectionKeychain: Sets `kSecUseDataProtectionKeychain` to **true**. See Apple's [documentation](https://developer.apple.com/documentation/security/ksecusedataprotectionkeychain)
+     for more info. Defaults to **false**.
+     - parameter deletingKeychainIfNeeded: Deletes the Parse Keychain when the app is running for the first time.
+     Defaults to **false**.
+     - parameter httpAdditionalHeaders: A dictionary of additional headers to send with requests. See Apple's
+     [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
+     for more info.
+     - parameter maxConnectionAttempts: Maximum number of times to try to connect to Parse Server.
+     Defaults to 5.
+     - parameter parseFileTransfer: Override the default transfer behavior for `ParseFile`'s.
+     Allows for direct uploads to other file storage providers.
+     - parameter authentication: A callback block that will be used to receive/accept/decline network challenges.
+     Defaults to `nil` in which the SDK will use the default OS authentication methods for challenges.
+     It should have the following argument signature: `(challenge: URLAuthenticationChallenge,
+     completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void`.
+     See Apple's [documentation](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411595-urlsession) for more for details.
+     - important: It is recomended to only specify `primaryKey` when using the SDK on a server. Do not use this key on the client.
+     - note: Setting `usingPostForQuery` to **true**  will require all queries to access the server instead of following the `requestCachePolicy`.
+     - warning: `usingTransactions` is experimental.
+     - warning: Setting `usingDataProtectionKeychain` to **true** is known to cause issues in Playgrounds or in
+     situtations when apps do not have credentials to setup a Keychain.
+     */
+    public init(applicationId: String,
+                clientKey: String? = nil,
+                primaryKey: String? = nil,
+                webhookKey: String? = nil,
+                serverURL: URL,
+                liveQueryServerURL: URL? = nil,
+                requiringCustomObjectIds: Bool = false,
+                usingTransactions: Bool = false,
+                usingEqualQueryConstraint: Bool = false,
+                usingPostForQuery: Bool = false,
+                primitiveStore: ParsePrimitiveStorable? = nil,
+                requestCachePolicy: URLRequest.CachePolicy = .useProtocolCachePolicy,
+                cacheMemoryCapacity: Int = 512_000,
+                cacheDiskCapacity: Int = 10_000_000,
+                usingDataProtectionKeychain: Bool = false,
+                deletingKeychainIfNeeded: Bool = false,
+                httpAdditionalHeaders: [AnyHashable: Any]? = nil,
+                maxConnectionAttempts: Int = 5,
+                parseFileTransfer: ParseFileTransferable? = nil,
+                authentication: ((URLAuthenticationChallenge,
+                                  (URLSession.AuthChallengeDisposition,
+                                   URLCredential?) -> Void) -> Void)? = nil) {
+        self.applicationId = applicationId
+        self.clientKey = clientKey
+        self.primaryKey = primaryKey
+        self.serverURL = serverURL
+        self.liveQuerysServerURL = liveQueryServerURL
+        self.isRequiringCustomObjectIds = requiringCustomObjectIds
+        self.isUsingTransactions = usingTransactions
+        self.isUsingEqualQueryConstraint = usingEqualQueryConstraint
+        self.isUsingPostForQuery = usingPostForQuery
+        self.mountPath = "/" + serverURL.pathComponents
+            .filter { $0 != "/" }
+            .joined(separator: "/")
+        self.authentication = authentication
+        self.requestCachePolicy = requestCachePolicy
+        self.cacheMemoryCapacity = cacheMemoryCapacity
+        self.cacheDiskCapacity = cacheDiskCapacity
+        self.isUsingDataProtectionKeychain = usingDataProtectionKeychain
+        self.isDeletingKeychainIfNeeded = deletingKeychainIfNeeded
+        self.httpAdditionalHeaders = httpAdditionalHeaders
+        self.maxConnectionAttempts = maxConnectionAttempts
+        self.parseFileTransfer = parseFileTransfer ?? ParseFileDefaultTransfer()
+        ParseStorage.shared.use(primitiveStore ?? InMemoryKeyValueStore())
+    }
+
+    /**
+     Create a Parse Swift configuration.
+     - parameter applicationId: The application id for your Parse application.
+     - parameter clientKey: The client key for your Parse application.
      - parameter masterKey: The master key for your Parse application. This key should only be
      specified when using the SDK on a server.
      - parameter serverURL: The server URL to connect to Parse Server.
@@ -160,6 +264,7 @@ public struct ParseConfiguration {
      - warning: Setting `usingDataProtectionKeychain` to **true** is known to cause issues in Playgrounds or in
      situtations when apps do not have credentials to setup a Keychain.
      */
+    @available(*, deprecated, message: "Change: masterKey->primaryKey.")
     public init(applicationId: String,
                 clientKey: String? = nil,
                 masterKey: String? = nil,
@@ -182,28 +287,26 @@ public struct ParseConfiguration {
                 authentication: ((URLAuthenticationChallenge,
                                   (URLSession.AuthChallengeDisposition,
                                    URLCredential?) -> Void) -> Void)? = nil) {
-        self.applicationId = applicationId
-        self.clientKey = clientKey
-        self.masterKey = masterKey
-        self.serverURL = serverURL
-        self.liveQuerysServerURL = liveQueryServerURL
-        self.isRequiringCustomObjectIds = requiringCustomObjectIds
-        self.isUsingTransactions = usingTransactions
-        self.isUsingEqualQueryConstraint = usingEqualQueryConstraint
-        self.isUsingPostForQuery = usingPostForQuery
-        self.mountPath = "/" + serverURL.pathComponents
-            .filter { $0 != "/" }
-            .joined(separator: "/")
-        self.authentication = authentication
-        self.requestCachePolicy = requestCachePolicy
-        self.cacheMemoryCapacity = cacheMemoryCapacity
-        self.cacheDiskCapacity = cacheDiskCapacity
-        self.isUsingDataProtectionKeychain = usingDataProtectionKeychain
-        self.isDeletingKeychainIfNeeded = deletingKeychainIfNeeded
-        self.httpAdditionalHeaders = httpAdditionalHeaders
-        self.maxConnectionAttempts = maxConnectionAttempts
-        self.parseFileTransfer = parseFileTransfer ?? ParseFileDefaultTransfer()
-        ParseStorage.shared.use(primitiveStore ?? InMemoryKeyValueStore())
+        self.init(applicationId: applicationId,
+                  clientKey: clientKey,
+                  primaryKey: masterKey,
+                  webhookKey: webhookKey,
+                  serverURL: serverURL,
+                  liveQueryServerURL: liveQueryServerURL,
+                  requiringCustomObjectIds: requiringCustomObjectIds,
+                  usingTransactions: usingTransactions,
+                  usingEqualQueryConstraint: usingEqualQueryConstraint,
+                  usingPostForQuery: usingPostForQuery,
+                  primitiveStore: primitiveStore,
+                  requestCachePolicy: requestCachePolicy,
+                  cacheMemoryCapacity: cacheMemoryCapacity,
+                  cacheDiskCapacity: cacheDiskCapacity,
+                  usingDataProtectionKeychain: usingDataProtectionKeychain,
+                  deletingKeychainIfNeeded: deletingKeychainIfNeeded,
+                  httpAdditionalHeaders: httpAdditionalHeaders,
+                  maxConnectionAttempts: maxConnectionAttempts,
+                  parseFileTransfer: parseFileTransfer ?? ParseFileDefaultTransfer(),
+                  authentication: authentication)
     }
 
     /**

--- a/Sources/ParseSwift/Types/ParseFile+async.swift
+++ b/Sources/ParseSwift/Types/ParseFile+async.swift
@@ -92,7 +92,7 @@ public extension ParseFile {
 
     /**
      Deletes the file from the Parse Server.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.

--- a/Sources/ParseSwift/Types/ParseFile+combine.swift
+++ b/Sources/ParseSwift/Types/ParseFile+combine.swift
@@ -86,7 +86,7 @@ public extension ParseFile {
 
     /**
      Deletes the file from the Parse Server. Publishes when complete.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.

--- a/Sources/ParseSwift/Types/ParseFile.swift
+++ b/Sources/ParseSwift/Types/ParseFile.swift
@@ -216,7 +216,7 @@ extension ParseFile {
 extension ParseFile {
     /**
      Deletes the file from the Parse cloud.
-     - requires: `.useMasterKey` has to be available.  It is recommended to only
+     - requires: `.usePrimaryKey` has to be available.  It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -228,7 +228,7 @@ extension ParseFile {
     public func delete(options: API.Options,
                        callbackQueue: DispatchQueue) throws {
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         options = options.union(self.options)
 
@@ -237,7 +237,7 @@ extension ParseFile {
 
     /**
      Deletes the file from the Parse cloud.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
@@ -249,7 +249,7 @@ extension ParseFile {
 
     /**
      Deletes the file from the Parse cloud. Completes with `nil` if successful.
-     - requires: `.useMasterKey` has to be available.
+     - requires: `.usePrimaryKey` has to be available.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - parameter callbackQueue: The queue to return to after completion. Default value of .main.
      - parameter completion: A block that will be called when file deletes or fails.
@@ -261,7 +261,7 @@ extension ParseFile {
                        callbackQueue: DispatchQueue = .main,
                        completion: @escaping (Result<Void, ParseError>) -> Void) {
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         options = options.union(self.options)
 

--- a/Sources/ParseSwift/Types/ParseHookFunctionRequest.swift
+++ b/Sources/ParseSwift/Types/ParseHookFunctionRequest.swift
@@ -10,13 +10,17 @@ import Foundation
 
 /**
  A type that can decode requests when `ParseHookFunctionable` functions are called.
- - requires: `.useMasterKey` has to be available. It is recommended to only
+ - requires: `.usePrimaryKey` has to be available. It is recommended to only
  use the master key in server-side applications where the key is kept secure and not
  exposed to the public.
  */
 public struct ParseHookFunctionRequest<U: ParseCloudUser, P: ParseHookParametable>: ParseHookRequestable {
     public typealias UsertType = U
-    public var masterKey: Bool?
+    @available(*, deprecated, renamed: "primaryKey")
+    public var masterKey: Bool? {
+        primaryKey
+    }
+    public var primaryKey: Bool?
     public var user: U?
     public var installationId: String?
     public var ipAddress: String?
@@ -30,7 +34,7 @@ public struct ParseHookFunctionRequest<U: ParseCloudUser, P: ParseHookParametabl
     var context: AnyCodable?
 
     enum CodingKeys: String, CodingKey {
-        case masterKey = "master"
+        case primaryKey = "master"
         case parameters = "params"
         case ipAddress = "ip"
         case user, installationId,

--- a/Sources/ParseSwift/Types/ParseHookTriggerRequest.swift
+++ b/Sources/ParseSwift/Types/ParseHookTriggerRequest.swift
@@ -10,13 +10,17 @@ import Foundation
 
 /**
  A type that can decode requests when `ParseHookTriggerable` triggers are called.
- - requires: `.useMasterKey` has to be available. It is recommended to only
+ - requires: `.usePrimaryKey` has to be available. It is recommended to only
  use the master key in server-side applications where the key is kept secure and not
  exposed to the public.
  */
 public struct ParseHookTriggerRequest<U: ParseCloudUser, T: ParseObject>: ParseHookRequestable {
     public typealias UserType = U
-    public var masterKey: Bool?
+    @available(*, deprecated, renamed: "primaryKey")
+    public var masterKey: Bool? {
+        primaryKey
+    }
+    public var primaryKey: Bool?
     public var user: U?
     public var installationId: String?
     public var ipAddress: String?
@@ -52,7 +56,7 @@ public struct ParseHookTriggerRequest<U: ParseCloudUser, T: ParseObject>: ParseH
     var context: AnyCodable?
 
     enum CodingKeys: String, CodingKey {
-        case masterKey = "master"
+        case primaryKey = "master"
         case ipAddress = "ip"
         case user, installationId, headers,
              log, context, object, objects,

--- a/Sources/ParseSwift/Types/ParsePush+async.swift
+++ b/Sources/ParseSwift/Types/ParsePush+async.swift
@@ -17,7 +17,7 @@ public extension ParsePush {
      - throws: An error of type `ParseError`.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
     */
@@ -36,7 +36,7 @@ public extension ParsePush {
      - throws: An error of type `ParseError`.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
     */

--- a/Sources/ParseSwift/Types/ParsePush+combine.swift
+++ b/Sources/ParseSwift/Types/ParsePush+combine.swift
@@ -17,7 +17,7 @@ public extension ParsePush {
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
     */
@@ -35,7 +35,7 @@ public extension ParsePush {
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
     */

--- a/Sources/ParseSwift/Types/ParsePush.swift
+++ b/Sources/ParseSwift/Types/ParsePush.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /**
  Send and check the status of push notificaitons.
- - requires: `.useMasterKey` has to be available. It is recommended to only
+ - requires: `.usePrimaryKey` has to be available. It is recommended to only
  use the master key in server-side applications where the key is kept secure and not
  exposed to the public.
  */
@@ -77,7 +77,7 @@ public struct ParsePush<V: ParsePushPayloadable>: ParseTypeable {
      - parameter payload: The payload information to send.
      - parameter pushTime: When to send the notification.  Defaults to **nil**.
      - parameter expirationDate: The date to expire the notification. Defaults to **nil**.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
      - warning: `expirationTime` and `expirationInterval` cannot be set at the same time.
@@ -95,7 +95,7 @@ public struct ParsePush<V: ParsePushPayloadable>: ParseTypeable {
      - parameter payload: The payload information to send.
      - parameter pushTime: When to send the notification.  Defaults to **nil**.
      - parameter expirationInterval: How many seconds to expire the notification after now.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
      - warning: `expirationTime` and `expirationInterval` cannot be set at the same time.
@@ -115,7 +115,7 @@ public struct ParsePush<V: ParsePushPayloadable>: ParseTypeable {
      Defaults to **nil**.
      - parameter pushTime: When to send the notification.  Defaults to **nil**.
      - parameter expirationDate: The date to expire the notification. Defaults to **nil**.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
      - warning: `expirationTime` and `expirationInterval` cannot be set at the same time.
@@ -137,7 +137,7 @@ public struct ParsePush<V: ParsePushPayloadable>: ParseTypeable {
      Defaults to **nil**.
      - parameter pushTime: When to send the notification.  Defaults to **nil**.
      - parameter expirationInterval: How many seconds to expire the notification after now.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
      - warning: `expirationTime` and `expirationInterval` cannot be set at the same time.
@@ -165,7 +165,7 @@ extension ParsePush {
      It should have the following argument signature: `(Result<Self, ParseError>)`.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
      - warning: expirationTime and expirationInterval cannot be set at the same time.
@@ -186,7 +186,7 @@ extension ParsePush {
             return
         }
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         sendCommand()
             .executeAsync(options: options,
@@ -229,7 +229,7 @@ public extension ParsePush {
      It should have the following argument signature: `(Result<Self, ParseError>)`.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
     */
@@ -238,7 +238,7 @@ public extension ParsePush {
                      callbackQueue: DispatchQueue = .main,
                      completion: @escaping (Result<ParsePushStatus<V>, ParseError>) -> Void) {
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         let query = ParsePushStatus<V>.query("objectId" == statusId)
         query.first(options: options, completion: completion)

--- a/Sources/ParseSwift/Types/ParsePushStatus.swift
+++ b/Sources/ParseSwift/Types/ParsePushStatus.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
  The PushStatus on the Parse Server.
  - warning: These objects are only read-only.
- - requires: `.useMasterKey` has to be available. It is recommended to only
+ - requires: `.usePrimaryKey` has to be available. It is recommended to only
  use the master key in server-side applications where the key is kept secure and not
  exposed to the public.
  */

--- a/Sources/ParseSwift/Types/ParseSchema+async.swift
+++ b/Sources/ParseSwift/Types/ParseSchema+async.swift
@@ -17,7 +17,7 @@ public extension ParseSchema {
      - throws: An error of type `ParseError`.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
     */
@@ -35,7 +35,7 @@ public extension ParseSchema {
      - throws: An error of type `ParseError`.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
     */
@@ -53,7 +53,7 @@ public extension ParseSchema {
      - throws: An error of type `ParseError`.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
     */
@@ -72,7 +72,7 @@ public extension ParseSchema {
      - warning: This will delete all objects for this `ParseSchema` and cannot be reversed.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
     */
@@ -95,7 +95,7 @@ public extension ParseSchema {
      currently contains objects, run `purge()` first.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
     */

--- a/Sources/ParseSwift/Types/ParseSchema+combine.swift
+++ b/Sources/ParseSwift/Types/ParseSchema+combine.swift
@@ -17,7 +17,7 @@ public extension ParseSchema {
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
     */
@@ -35,7 +35,7 @@ public extension ParseSchema {
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
     */
@@ -53,7 +53,7 @@ public extension ParseSchema {
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
     */
@@ -72,7 +72,7 @@ public extension ParseSchema {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
      - warning: This will delete all objects for this `ParseSchema` and cannot be reversed.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
     */
@@ -92,7 +92,7 @@ public extension ParseSchema {
      desires a different policy, it should be inserted in `options`.
      - warning: This can only be used on a `ParseSchema` without objects. If the `ParseSchema`
      currently contains objects, run `purge()` first.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
     */

--- a/Sources/ParseSwift/Types/ParseSchema.swift
+++ b/Sources/ParseSwift/Types/ParseSchema.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /**
  `ParseSchema` is used for handeling your schemas.
- - requires: `.useMasterKey` has to be available. It is recommended to only
+ - requires: `.usePrimaryKey` has to be available. It is recommended to only
  use the master key in server-side applications where the key is kept secure and not
  exposed to the public.
  */
@@ -255,7 +255,7 @@ extension ParseSchema {
      It should have the following argument signature: `(Result<Self, ParseError>)`.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
     */
@@ -263,7 +263,7 @@ extension ParseSchema {
                       callbackQueue: DispatchQueue = .main,
                       completion: @escaping (Result<Self, ParseError>) -> Void) {
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         fetchCommand()
             .executeAsync(options: options,
@@ -292,7 +292,7 @@ extension ParseSchema {
      It should have the following argument signature: `(Result<Self, ParseError>)`.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
     */
@@ -300,7 +300,7 @@ extension ParseSchema {
                        callbackQueue: DispatchQueue = .main,
                        completion: @escaping (Result<Self, ParseError>) -> Void) {
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         createCommand()
             .executeAsync(options: options,
@@ -317,7 +317,7 @@ extension ParseSchema {
      It should have the following argument signature: `(Result<Self, ParseError>)`.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
     */
@@ -331,7 +331,7 @@ extension ParseSchema {
             mutableSchema.indexes = nil
         }
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         mutableSchema.updateCommand()
             .executeAsync(options: options,
@@ -370,7 +370,7 @@ extension ParseSchema {
      - warning: This will delete all objects for this `ParseSchema` and cannot be reversed.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
     */
@@ -380,7 +380,7 @@ extension ParseSchema {
         completion: @escaping (Result<Void, ParseError>) -> Void
     ) {
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         purgeCommand().executeAsync(options: options,
                                         callbackQueue: callbackQueue) { result in
@@ -408,7 +408,7 @@ extension ParseSchema {
      currently contains objects, run `purge()` first.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
     */
@@ -418,7 +418,7 @@ extension ParseSchema {
         completion: @escaping (Result<Void, ParseError>) -> Void
     ) {
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         deleteCommand().executeAsync(options: options,
                                          callbackQueue: callbackQueue) { result in

--- a/Sources/ParseSwift/Types/Query+async.swift
+++ b/Sources/ParseSwift/Types/Query+async.swift
@@ -178,7 +178,7 @@ public extension Query {
 
     /**
      Executes an aggregate query *asynchronously*.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
      - parameter pipeline: A pipeline of stages to process query.
@@ -197,7 +197,7 @@ public extension Query {
 
     /**
      Query plan information for executing an aggregate query *asynchronously*.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
      - note: An explain query will have many different underlying types. Since Swift is a strongly
@@ -226,7 +226,7 @@ public extension Query {
 
     /**
      Executes a distinct query *asynchronously* and returns unique values when complete.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
      - parameter key: A field to find distinct values.
@@ -245,7 +245,7 @@ public extension Query {
 
     /**
      Query plan information for executing a distinct query *asynchronously* and returns unique values when complete.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
      - note: An explain query will have many different underlying types. Since Swift is a strongly

--- a/Sources/ParseSwift/Types/Query+combine.swift
+++ b/Sources/ParseSwift/Types/Query+combine.swift
@@ -172,7 +172,7 @@ public extension Query {
 
     /**
      Executes an aggregate query *asynchronously* and publishes when complete.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
      - parameter pipeline: A pipeline of stages to process query.
@@ -190,7 +190,7 @@ public extension Query {
 
     /**
      Query plan information for executing an aggregate query *asynchronously* and publishes when complete.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
      - note: An explain query will have many different underlying types. Since Swift is a strongly
@@ -218,7 +218,7 @@ public extension Query {
 
     /**
      Executes a distinct query *asynchronously* and publishes unique values when complete.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
      - parameter key: A field to find distinct values.
@@ -236,7 +236,7 @@ public extension Query {
 
     /**
      Query plan information for executing a distinct query *asynchronously* and publishes unique values when complete.
-     - requires: `.useMasterKey` has to be available. It is recommended to only
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
      use the master key in server-side applications where the key is kept secure and not
      exposed to the public.
      - note: An explain query will have many different underlying types. Since Swift is a strongly

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -1038,7 +1038,7 @@ extension Query: Queryable {
 
     /**
      Executes an aggregate query *synchronously*.
-      - requires: `.useMasterKey` has to be available. It is recommended to only
+      - requires: `.usePrimaryKey` has to be available. It is recommended to only
         use the master key in server-side applications where the key is kept secure and not
         exposed to the public.
       - parameter pipeline: A pipeline of stages to process query.
@@ -1053,7 +1053,7 @@ extension Query: Queryable {
             return [ResultType]()
         }
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
 
         var updatedPipeline = [[String: AnyCodable]]()
         pipeline.forEach { updatedPipeline = $0.map { [$0.key: AnyCodable($0.value)] } }
@@ -1080,7 +1080,7 @@ extension Query: Queryable {
 
     /**
       Executes an aggregate query *asynchronously*.
-        - requires: `.useMasterKey` has to be available. It is recommended to only
+        - requires: `.usePrimaryKey` has to be available. It is recommended to only
         use the master key in server-side applications where the key is kept secure and not
         exposed to the public.
         - parameter pipeline: A pipeline of stages to process query.
@@ -1101,7 +1101,7 @@ extension Query: Queryable {
             return
         }
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
 
         var updatedPipeline = [[String: AnyCodable]]()
         pipeline.forEach { updatedPipeline = $0.map { [$0.key: AnyCodable($0.value)] } }
@@ -1143,7 +1143,7 @@ extension Query: Queryable {
 
     /**
      Query plan information for  executing an aggregate query *synchronously*.
-      - requires: `.useMasterKey` has to be available. It is recommended to only
+      - requires: `.usePrimaryKey` has to be available. It is recommended to only
       use the master key in server-side applications where the key is kept secure and not
       exposed to the public.
       - note: An explain query will have many different underlying types. Since Swift is a strongly
@@ -1166,7 +1166,7 @@ extension Query: Queryable {
             return [U]()
         }
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
 
         var updatedPipeline = [[String: AnyCodable]]()
         pipeline.forEach { updatedPipeline = $0.map { [$0.key: AnyCodable($0.value)] } }
@@ -1197,7 +1197,7 @@ extension Query: Queryable {
 
     /**
      Query plan information for executing an aggregate query *asynchronously*.
-        - requires: `.useMasterKey` has to be available. It is recommended to only
+        - requires: `.usePrimaryKey` has to be available. It is recommended to only
         use the master key in server-side applications where the key is kept secure and not
         exposed to the public.
         - note: An explain query will have many different underlying types. Since Swift is a strongly
@@ -1226,7 +1226,7 @@ extension Query: Queryable {
             return
         }
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
 
         var updatedPipeline = [[String: AnyCodable]]()
         pipeline.forEach { updatedPipeline = $0.map { [$0.key: AnyCodable($0.value)] } }
@@ -1282,7 +1282,7 @@ extension Query: Queryable {
 
     /**
      Executes an aggregate query *synchronously* and calls the given.
-      - requires: `.useMasterKey` has to be available. It is recommended to only
+      - requires: `.usePrimaryKey` has to be available. It is recommended to only
       use the master key in server-side applications where the key is kept secure and not
       exposed to the public.
       - parameter key: A field to find distinct values.
@@ -1297,14 +1297,14 @@ extension Query: Queryable {
             return [ResultType]()
         }
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         return try distinctCommand(key: key)
             .execute(options: options)
     }
 
     /**
      Executes a distinct query *asynchronously* and returns unique values.
-        - requires: `.useMasterKey` has to be available. It is recommended to only
+        - requires: `.usePrimaryKey` has to be available. It is recommended to only
         use the master key in server-side applications where the key is kept secure and not
         exposed to the public.
         - parameter key: A field to find distinct values.
@@ -1325,7 +1325,7 @@ extension Query: Queryable {
             return
         }
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         do {
             try distinctCommand(key: key)
                 .executeAsync(options: options,
@@ -1343,7 +1343,7 @@ extension Query: Queryable {
 
     /**
      Query plan information for executing an aggregate query *synchronously* and calls the given.
-      - requires: `.useMasterKey` has to be available. It is recommended to only
+      - requires: `.usePrimaryKey` has to be available. It is recommended to only
       use the master key in server-side applications where the key is kept secure and not
       exposed to the public.
       - note: An explain query will have many different underlying types. Since Swift is a strongly
@@ -1367,7 +1367,7 @@ extension Query: Queryable {
             return [U]()
         }
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         if !usingMongoDB {
             return try distinctExplainCommand(key: key)
                 .execute(options: options)
@@ -1379,7 +1379,7 @@ extension Query: Queryable {
 
     /**
      Query plan information for executing a distinct query *asynchronously* and returns unique values.
-        - requires: `.useMasterKey` has to be available. It is recommended to only
+        - requires: `.usePrimaryKey` has to be available. It is recommended to only
         use the master key in server-side applications where the key is kept secure and not
         exposed to the public.
         - note: An explain query will have many different underlying types. Since Swift is a strongly
@@ -1408,7 +1408,7 @@ extension Query: Queryable {
             return
         }
         var options = options
-        options.insert(.useMasterKey)
+        options.insert(.usePrimaryKey)
         if !usingMongoDB {
             do {
                 try distinctExplainCommand(key: key)

--- a/Tests/ParseSwiftTests/APICommandTests.swift
+++ b/Tests/ParseSwiftTests/APICommandTests.swift
@@ -368,6 +368,8 @@ class APICommandTests: XCTestCase {
         case .success(let request):
             XCTAssertEqual(request.allHTTPHeaderFields?["X-Parse-Master-Key"],
                            primaryKey)
+            XCTAssertEqual(ParseSwift.configuration.masterKey,
+                           primaryKey)
         case .failure(let error):
             XCTFail(error.localizedDescription)
         }

--- a/Tests/ParseSwiftTests/APICommandTests.swift
+++ b/Tests/ParseSwiftTests/APICommandTests.swift
@@ -34,7 +34,7 @@ class APICommandTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }
@@ -124,11 +124,11 @@ class APICommandTests: XCTestCase {
     func testOptionCacheHasher() throws {
         var options = API.Options()
         options.insert(.cachePolicy(.returnCacheDataDontLoad))
-        XCTAssertFalse(options.contains(.useMasterKey))
+        XCTAssertFalse(options.contains(.usePrimaryKey))
         XCTAssertTrue(options.contains(.cachePolicy(.returnCacheDataDontLoad)))
         XCTAssertTrue(options.contains(.cachePolicy(.reloadRevalidatingCacheData)))
-        options.insert(.useMasterKey)
-        XCTAssertTrue(options.contains(.useMasterKey))
+        options.insert(.usePrimaryKey)
+        XCTAssertTrue(options.contains(.usePrimaryKey))
     }
 
     func testExecuteCorrectly() {
@@ -352,7 +352,7 @@ class APICommandTests: XCTestCase {
     }
 
     func testPrimaryKeyHeader() throws {
-        guard let primaryKey = ParseSwift.configuration.masterKey else {
+        guard let primaryKey = ParseSwift.configuration.primaryKey else {
             throw ParseError(code: .unknownError, message: "Parse configuration should contain key")
         }
 
@@ -363,7 +363,7 @@ class APICommandTests: XCTestCase {
             return nil
         }
 
-        switch post.prepareURLRequest(options: [.useMasterKey]) {
+        switch post.prepareURLRequest(options: [.usePrimaryKey]) {
 
         case .success(let request):
             XCTAssertEqual(request.allHTTPHeaderFields?["X-Parse-Master-Key"],

--- a/Tests/ParseSwiftTests/ExtensionsTests.swift
+++ b/Tests/ParseSwiftTests/ExtensionsTests.swift
@@ -19,7 +19,7 @@ class ExtensionsTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: false)
     }

--- a/Tests/ParseSwiftTests/IOS13Tests.swift
+++ b/Tests/ParseSwiftTests/IOS13Tests.swift
@@ -63,7 +63,7 @@ class IOS13Tests: XCTestCase { // swiftlint:disable:this type_body_length
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -43,6 +43,7 @@ class InitializeSDKTests: XCTestCase {
             return
         }
         Parse.configuration = .init(applicationId: "applicationId",
+                                    primaryKey: "primaryKey",
                                     serverURL: url)
         Parse.configuration.isTestingSDK = true
     }
@@ -63,10 +64,9 @@ class InitializeSDKTests: XCTestCase {
             XCTFail("Should create valid URL")
             return
         }
-
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              masterKey: "primaryKey",
                               serverURL: url,
                               allowingCustomObjectIds: false) { (_, credential) in
             credential(.performDefaultHandling, nil)
@@ -77,7 +77,7 @@ class InitializeSDKTests: XCTestCase {
 
         let configuration = ParseConfiguration(applicationId: "applicationId",
                                                clientKey: "clientKey",
-                                               masterKey: "masterKey",
+                                               masterKey: "primaryKey",
                                                serverURL: url,
                                                allowingCustomObjectIds: false) { (_, credential) in
             credential(.performDefaultHandling, nil)
@@ -88,10 +88,10 @@ class InitializeSDKTests: XCTestCase {
         XCTAssertNil(Parse.sessionDelegate.authentication)
 
         let configuration2 = ParseConfiguration(applicationId: "applicationId",
-                                               clientKey: "clientKey",
-                                               masterKey: "masterKey",
-                                               serverURL: url,
-                                               migratingFromObjcSDK: false) { (_, credential) in
+                                                clientKey: "clientKey",
+                                                masterKey: "primaryKey",
+                                                serverURL: url,
+                                                migratingFromObjcSDK: false) { (_, credential) in
             credential(.performDefaultHandling, nil)
         }
         ParseSwift.initialize(configuration: configuration2)
@@ -199,7 +199,7 @@ class InitializeSDKTests: XCTestCase {
 
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true) { (_, credential) in
             credential(.performDefaultHandling, nil)
@@ -266,7 +266,7 @@ class InitializeSDKTests: XCTestCase {
 
             ParseSwift.initialize(applicationId: "applicationId",
                                   clientKey: "clientKey",
-                                  masterKey: "masterKey",
+                                  primaryKey: "primaryKey",
                                   serverURL: url,
                                   primitiveStore: memory,
                                   testing: true)
@@ -311,7 +311,7 @@ class InitializeSDKTests: XCTestCase {
 
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true) { (_, credential) in
             credential(.performDefaultHandling, nil)
@@ -339,7 +339,7 @@ class InitializeSDKTests: XCTestCase {
 
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               primitiveStore: memory,
                               testing: true)
@@ -375,7 +375,7 @@ class InitializeSDKTests: XCTestCase {
 
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               primitiveStore: memory,
                               testing: true)
@@ -411,7 +411,7 @@ class InitializeSDKTests: XCTestCase {
 
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               primitiveStore: memory,
                               testing: true)
@@ -448,7 +448,7 @@ class InitializeSDKTests: XCTestCase {
 
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               primitiveStore: memory,
                               testing: true)
@@ -484,7 +484,7 @@ class InitializeSDKTests: XCTestCase {
 
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               primitiveStore: memory,
                               testing: true)
@@ -502,7 +502,7 @@ class InitializeSDKTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               migratingFromObjcSDK: true,
                               testing: true)
@@ -553,7 +553,7 @@ class InitializeSDKTests: XCTestCase {
             }
             ParseSwift.initialize(applicationId: "applicationId",
                                   clientKey: "clientKey",
-                                  masterKey: "masterKey",
+                                  primaryKey: "primaryKey",
                                   serverURL: url,
                                   testing: true)
             XCTAssertEqual(ParseVersion.current, ParseConstants.version)
@@ -584,7 +584,7 @@ class InitializeSDKTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               migratingFromObjcSDK: true,
                               testing: true)
@@ -613,7 +613,7 @@ class InitializeSDKTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              masterKey: "primaryKey",
                               serverURL: url,
                               migratingFromObjcSDK: true,
                               parseFileTransfer: nil)
@@ -633,7 +633,7 @@ class InitializeSDKTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url)
         guard Installation.current != nil else {
             XCTFail("Should have installation")
@@ -668,7 +668,7 @@ class InitializeSDKTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }
@@ -689,7 +689,7 @@ class InitializeSDKTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               migratingFromObjcSDK: true,
                               testing: true)

--- a/Tests/ParseSwiftTests/KeychainStoreTests.swift
+++ b/Tests/ParseSwiftTests/KeychainStoreTests.swift
@@ -21,7 +21,7 @@ class KeychainStoreTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url, testing: true)
         testStore = KeychainStore(service: "test")
     }

--- a/Tests/ParseSwiftTests/MigrateObjCSDKCombineTests.swift
+++ b/Tests/ParseSwiftTests/MigrateObjCSDKCombineTests.swift
@@ -121,7 +121,7 @@ class MigrateObjCSDKCombineTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/MigrateObjCSDKTests.swift
+++ b/Tests/ParseSwiftTests/MigrateObjCSDKTests.swift
@@ -120,7 +120,7 @@ class MigrateObjCSDKTests: XCTestCase { // swiftlint:disable:this type_body_leng
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseACLTests.swift
+++ b/Tests/ParseSwiftTests/ParseACLTests.swift
@@ -20,7 +20,7 @@ class ParseACLTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url, testing: true)
     }
 

--- a/Tests/ParseSwiftTests/ParseAnalyticsAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnalyticsAsyncTests.swift
@@ -23,7 +23,7 @@ class ParseAnalyticsAsyncTests: XCTestCase { // swiftlint:disable:this type_body
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseAnalyticsCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnalyticsCombineTests.swift
@@ -23,7 +23,7 @@ class ParseAnalyticsCombineTests: XCTestCase { // swiftlint:disable:this type_bo
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseAnalyticsTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnalyticsTests.swift
@@ -20,7 +20,7 @@ class ParseAnalyticsTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseAnonymousAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousAsyncTests.swift
@@ -71,7 +71,7 @@ class ParseAnonymousAsyncTests: XCTestCase { // swiftlint:disable:this type_body
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseAnonymousCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousCombineTests.swift
@@ -71,7 +71,7 @@ class ParseAnonymousCombineTests: XCTestCase { // swiftlint:disable:this type_bo
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseAnonymousTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousTests.swift
@@ -74,7 +74,7 @@ class ParseAnonymousTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
 

--- a/Tests/ParseSwiftTests/ParseAppleAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleAsyncTests.swift
@@ -72,7 +72,7 @@ class ParseAppleAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseAppleCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleCombineTests.swift
@@ -72,7 +72,7 @@ class ParseAppleCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseAppleTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleTests.swift
@@ -68,7 +68,7 @@ class ParseAppleTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
 

--- a/Tests/ParseSwiftTests/ParseAuthenticationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationAsyncTests.swift
@@ -126,7 +126,7 @@ class ParseAuthenticationAsyncTests: XCTestCase { // swiftlint:disable:this type
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
 

--- a/Tests/ParseSwiftTests/ParseAuthenticationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationCombineTests.swift
@@ -126,7 +126,7 @@ class ParseAuthenticationCombineTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
 

--- a/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
@@ -126,7 +126,7 @@ class ParseAuthenticationTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
 

--- a/Tests/ParseSwiftTests/ParseBytesTests.swift
+++ b/Tests/ParseSwiftTests/ParseBytesTests.swift
@@ -18,7 +18,7 @@ class ParseBytesTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseCLPTests.swift
+++ b/Tests/ParseSwiftTests/ParseCLPTests.swift
@@ -58,7 +58,7 @@ class ParseCLPTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseCloudViewModelTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudViewModelTests.swift
@@ -31,7 +31,7 @@ class ParseCloudViewModelTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseCloudableAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudableAsyncTests.swift
@@ -34,7 +34,7 @@ class ParseCloudableAsyncTests: XCTestCase { // swiftlint:disable:this type_body
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseCloudableCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudableCombineTests.swift
@@ -34,7 +34,7 @@ class ParseCloudableCombineTests: XCTestCase { // swiftlint:disable:this type_bo
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseCloudableTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudableTests.swift
@@ -48,7 +48,7 @@ class ParseCloudableTests: XCTestCase { // swiftlint:disable:this type_body_leng
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseConfigAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigAsyncTests.swift
@@ -80,7 +80,7 @@ class ParseConfigAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseConfigCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigCombineTests.swift
@@ -80,7 +80,7 @@ class ParseConfigCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseConfigTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigTests.swift
@@ -77,7 +77,7 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseErrorTests.swift
+++ b/Tests/ParseSwiftTests/ParseErrorTests.swift
@@ -20,7 +20,7 @@ class ParseErrorTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseFacebookAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookAsyncTests.swift
@@ -72,7 +72,7 @@ class ParseFacebookAsyncTests: XCTestCase { // swiftlint:disable:this type_body_
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
@@ -72,7 +72,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseFacebookTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookTests.swift
@@ -68,7 +68,7 @@ class ParseFacebookTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
 

--- a/Tests/ParseSwiftTests/ParseFileAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileAsyncTests.swift
@@ -30,7 +30,7 @@ class ParseFileAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
         guard let fileManager = ParseFileManager() else {
@@ -284,7 +284,7 @@ class ParseFileAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        _ = try await parseFile.delete(options: [.useMasterKey])
+        _ = try await parseFile.delete(options: [.usePrimaryKey])
     }
 
     @MainActor
@@ -311,7 +311,7 @@ class ParseFileAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         }
 
         do {
-            _ = try await parseFile.delete(options: [.useMasterKey])
+            _ = try await parseFile.delete(options: [.usePrimaryKey])
             XCTFail("Should have thrown error")
         } catch {
 

--- a/Tests/ParseSwiftTests/ParseFileCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileCombineTests.swift
@@ -30,7 +30,7 @@ class ParseFileCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
         guard let fileManager = ParseFileManager() else {
@@ -273,7 +273,7 @@ class ParseFileCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        let publisher = parseFile.deletePublisher(options: [.useMasterKey])
+        let publisher = parseFile.deletePublisher(options: [.usePrimaryKey])
             .sink(receiveCompletion: { result in
 
                 if case let .failure(error) = result {

--- a/Tests/ParseSwiftTests/ParseFileManagerTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileManagerTests.swift
@@ -25,7 +25,7 @@ class ParseFileManagerTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
 

--- a/Tests/ParseSwiftTests/ParseFileTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileTests.swift
@@ -30,7 +30,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
 
@@ -1346,7 +1346,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         let expectation1 = XCTestExpectation(description: "ParseFile async")
-        parseFile.delete(options: [.useMasterKey]) { result in
+        parseFile.delete(options: [.usePrimaryKey]) { result in
 
             if case let .failure(error) = result {
                 XCTFail(error.localizedDescription)
@@ -1378,7 +1378,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         let expectation1 = XCTestExpectation(description: "ParseFile async")
-        parseFile.delete(options: [.useMasterKey]) { result in
+        parseFile.delete(options: [.usePrimaryKey]) { result in
 
             if case .success = result {
                 XCTFail("Should have failed with error")
@@ -1410,7 +1410,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
 
-        try parseFile.delete(options: [.useMasterKey])
+        try parseFile.delete(options: [.usePrimaryKey])
     }
 
     func testCloudFileProgress() throws {

--- a/Tests/ParseSwiftTests/ParseFileTransferableTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileTransferableTests.swift
@@ -96,7 +96,7 @@ class ParseFileTransferableTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
 
@@ -147,13 +147,13 @@ class ParseFileTransferableTests: XCTestCase {
         XCTAssertTrue(ParseSwift.configuration.parseFileTransfer !== fileTransferAdapter)
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               parseFileTransfer: fileTransferAdapter)
         XCTAssertTrue(ParseSwift.configuration.parseFileTransfer === fileTransferAdapter)
         ParseSwift.initialize(configuration: .init(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               parseFileTransfer: fileTransferAdapterOther))
         XCTAssertTrue(ParseSwift.configuration.parseFileTransfer === fileTransferAdapterOther)

--- a/Tests/ParseSwiftTests/ParseGeoPointTests.swift
+++ b/Tests/ParseSwiftTests/ParseGeoPointTests.swift
@@ -21,7 +21,7 @@ class ParseGeoPointTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseGitHubCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseGitHubCombineTests.swift
@@ -72,7 +72,7 @@ class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseGitHubTests.swift
+++ b/Tests/ParseSwiftTests/ParseGitHubTests.swift
@@ -71,7 +71,7 @@ class ParseGitHubTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseGoogleCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseGoogleCombineTests.swift
@@ -72,7 +72,7 @@ class ParseGoogleCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseGoogleTests.swift
+++ b/Tests/ParseSwiftTests/ParseGoogleTests.swift
@@ -71,7 +71,7 @@ class ParseGoogleTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseHealthAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseHealthAsyncTests.swift
@@ -23,7 +23,7 @@ class ParseHealthAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseHealthCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseHealthCombineTests.swift
@@ -22,7 +22,7 @@ class ParseHealthCombineTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseHealthTests.swift
+++ b/Tests/ParseSwiftTests/ParseHealthTests.swift
@@ -20,7 +20,7 @@ class ParseHealthTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseHookFunctionCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionCombineTests.swift
@@ -27,7 +27,7 @@ class ParseHookFunctionCombineTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseHookFunctionRequestCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionRequestCombineTests.swift
@@ -57,7 +57,7 @@ class ParseHookFunctionRequestCombineTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }
@@ -90,13 +90,13 @@ class ParseHookFunctionRequestCombineTests: XCTestCase {
 
         let parameters = Parameters()
         let installationId = "cat"
-        let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
+        let functionRequest = ParseHookFunctionRequest<User, Parameters>(primaryKey: true,
                                                                          user: user,
                                                                          installationId: installationId,
                                                                          ipAddress: "1.1.1.1",
                                                                          headers: ["yolo": "me"],
                                                                          parameters: parameters)
-        let requestHydrated = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
+        let requestHydrated = ParseHookFunctionRequest<User, Parameters>(primaryKey: true,
                                                                          user: server,
                                                                          installationId: installationId,
                                                                          ipAddress: "1.1.1.1",
@@ -132,7 +132,7 @@ class ParseHookFunctionRequestCombineTests: XCTestCase {
 
         let parameters = Parameters()
         let installationId = "cat"
-        let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
+        let functionRequest = ParseHookFunctionRequest<User, Parameters>(primaryKey: true,
                                                                          user: user,
                                                                          installationId: installationId,
                                                                          ipAddress: "1.1.1.1",

--- a/Tests/ParseSwiftTests/ParseHookFunctionRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionRequestTests.swift
@@ -59,7 +59,7 @@ class ParseHookFunctionRequestTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }
@@ -75,7 +75,7 @@ class ParseHookFunctionRequestTests: XCTestCase {
 
     func testCoding() async throws {
         let parameters = Parameters()
-        let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
+        let functionRequest = ParseHookFunctionRequest<User, Parameters>(primaryKey: true,
                                                                          ipAddress: "1.1.1.1",
                                                                          headers: ["yolo": "me"],
                                                                          parameters: parameters)
@@ -86,7 +86,7 @@ class ParseHookFunctionRequestTests: XCTestCase {
 
     func testGetLog() async throws {
         let parameters = Parameters()
-        let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
+        let functionRequest = ParseHookFunctionRequest<User, Parameters>(primaryKey: true,
                                                                          ipAddress: "1.1.1.1",
                                                                          headers: ["yolo": "me"],
                                                                          parameters: parameters,
@@ -97,7 +97,7 @@ class ParseHookFunctionRequestTests: XCTestCase {
 
     func testGetLogError() async throws {
         let parameters = Parameters()
-        let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
+        let functionRequest = ParseHookFunctionRequest<User, Parameters>(primaryKey: true,
                                                                          ipAddress: "1.1.1.1",
                                                                          headers: ["yolo": "me"],
                                                                          parameters: parameters,
@@ -117,7 +117,7 @@ class ParseHookFunctionRequestTests: XCTestCase {
     func testGetContext() async throws {
         let parameters = Parameters()
         let context = ["peace": "out"]
-        let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
+        let functionRequest = ParseHookFunctionRequest<User, Parameters>(primaryKey: true,
                                                                          ipAddress: "1.1.1.1",
                                                                          headers: ["yolo": "me"],
                                                                          parameters: parameters,
@@ -129,7 +129,7 @@ class ParseHookFunctionRequestTests: XCTestCase {
     func testGetContextError() async throws {
         let parameters = Parameters()
         let context = ["peace": "out"]
-        let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
+        let functionRequest = ParseHookFunctionRequest<User, Parameters>(primaryKey: true,
                                                                          ipAddress: "1.1.1.1",
                                                                          headers: ["yolo": "me"],
                                                                          parameters: parameters,
@@ -151,16 +151,16 @@ class ParseHookFunctionRequestTests: XCTestCase {
         let sessionToken = "dog"
         let installationId = "cat"
         let user = User(sessionToken: sessionToken)
-        let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
+        let functionRequest = ParseHookFunctionRequest<User, Parameters>(primaryKey: true,
                                                                          user: user,
                                                                          installationId: installationId,
                                                                          ipAddress: "1.1.1.1",
                                                                          headers: ["yolo": "me"],
                                                                          parameters: parameters)
-        let options = API.Options([.useMasterKey])
+        let options = API.Options([.usePrimaryKey])
         let requestOptions = functionRequest.options()
         XCTAssertEqual(requestOptions, options)
-        let functionRequest2 = ParseHookFunctionRequest<User, Parameters>(masterKey: false,
+        let functionRequest2 = ParseHookFunctionRequest<User, Parameters>(primaryKey: false,
                                                                           user: user,
                                                                           installationId: installationId,
                                                                           ipAddress: "1.1.1.1",
@@ -170,7 +170,7 @@ class ParseHookFunctionRequestTests: XCTestCase {
             .installationId(installationId)])
         let requestOptions2 = functionRequest2.options()
         XCTAssertEqual(requestOptions2, options2)
-        let functionRequest3 = ParseHookFunctionRequest<User, Parameters>(masterKey: false,
+        let functionRequest3 = ParseHookFunctionRequest<User, Parameters>(primaryKey: false,
                                                                           user: user,
                                                                           ipAddress: "1.1.1.1",
                                                                           headers: ["yolo": "me"],
@@ -178,7 +178,7 @@ class ParseHookFunctionRequestTests: XCTestCase {
         let options3 = API.Options([.sessionToken(sessionToken)])
         let requestOptions3 = functionRequest3.options()
         XCTAssertEqual(requestOptions3, options3)
-        let functionRequest4 = ParseHookFunctionRequest<User, Parameters>(masterKey: false,
+        let functionRequest4 = ParseHookFunctionRequest<User, Parameters>(primaryKey: false,
                                                                           installationId: installationId,
                                                                           ipAddress: "1.1.1.1",
                                                                           headers: ["yolo": "me"],
@@ -186,7 +186,7 @@ class ParseHookFunctionRequestTests: XCTestCase {
         let options4 = API.Options([.installationId(installationId)])
         let requestOptions4 = functionRequest4.options()
         XCTAssertEqual(requestOptions4, options4)
-        let functionRequest5 = ParseHookFunctionRequest<User, Parameters>(masterKey: false,
+        let functionRequest5 = ParseHookFunctionRequest<User, Parameters>(primaryKey: false,
                                                                           ipAddress: "1.1.1.1",
                                                                           headers: ["yolo": "me"],
                                                                           parameters: parameters)
@@ -212,13 +212,13 @@ class ParseHookFunctionRequestTests: XCTestCase {
 
         let parameters = Parameters()
         let installationId = "cat"
-        let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
+        let functionRequest = ParseHookFunctionRequest<User, Parameters>(primaryKey: true,
                                                                          user: user,
                                                                          installationId: installationId,
                                                                          ipAddress: "1.1.1.1",
                                                                          headers: ["yolo": "me"],
                                                                          parameters: parameters)
-        let requestHydrated = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
+        let requestHydrated = ParseHookFunctionRequest<User, Parameters>(primaryKey: true,
                                                                          user: server,
                                                                          installationId: installationId,
                                                                          ipAddress: "1.1.1.1",
@@ -240,7 +240,7 @@ class ParseHookFunctionRequestTests: XCTestCase {
 
         let parameters = Parameters()
         let installationId = "cat"
-        let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
+        let functionRequest = ParseHookFunctionRequest<User, Parameters>(primaryKey: true,
                                                                          user: user,
                                                                          installationId: installationId,
                                                                          ipAddress: "1.1.1.1",
@@ -264,7 +264,7 @@ class ParseHookFunctionRequestTests: XCTestCase {
 
         let parameters = Parameters()
         let installationId = "cat"
-        let functionRequest = ParseHookFunctionRequest<User, Parameters>(masterKey: true,
+        let functionRequest = ParseHookFunctionRequest<User, Parameters>(primaryKey: true,
                                                                          installationId: installationId,
                                                                          ipAddress: "1.1.1.1",
                                                                          headers: ["yolo": "me"],

--- a/Tests/ParseSwiftTests/ParseHookFunctionRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionRequestTests.swift
@@ -82,6 +82,7 @@ class ParseHookFunctionRequestTests: XCTestCase {
         // swiftlint:disable:next line_length
         let expected = "{\"headers\":{\"yolo\":\"me\"},\"ip\":\"1.1.1.1\",\"master\":true,\"params\":{\"hello\":\"world\"}}"
         XCTAssertEqual(functionRequest.description, expected)
+        XCTAssertEqual(functionRequest.masterKey, functionRequest.primaryKey)
     }
 
     func testGetLog() async throws {

--- a/Tests/ParseSwiftTests/ParseHookFunctionTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionTests.swift
@@ -28,7 +28,7 @@ class ParseHookFunctionTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseHookResponseTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookResponseTests.swift
@@ -19,7 +19,7 @@ class ParseHookResponseTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseHookTriggerCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerCombineTests.swift
@@ -28,7 +28,7 @@ class ParseHookTriggerCombineTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseHookTriggerRequestCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerRequestCombineTests.swift
@@ -54,7 +54,7 @@ class ParseHookTriggerRequestCombineTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }
@@ -87,13 +87,13 @@ class ParseHookTriggerRequestCombineTests: XCTestCase {
 
         let object = User(objectId: "geez")
         let installationId = "cat"
-        let triggerRequest = ParseHookTriggerRequest<User, User>(masterKey: true,
+        let triggerRequest = ParseHookTriggerRequest<User, User>(primaryKey: true,
                                                                  user: user,
                                                                  installationId: installationId,
                                                                  ipAddress: "1.1.1.1",
                                                                  headers: ["yolo": "me"],
                                                                  object: object)
-        let requestHydrated = ParseHookTriggerRequest<User, User>(masterKey: true,
+        let requestHydrated = ParseHookTriggerRequest<User, User>(primaryKey: true,
                                                                   user: server,
                                                                   installationId: installationId,
                                                                   ipAddress: "1.1.1.1",
@@ -129,7 +129,7 @@ class ParseHookTriggerRequestCombineTests: XCTestCase {
 
         let object = User(objectId: "geez")
         let installationId = "cat"
-        let triggerRequest = ParseHookTriggerRequest<User, User>(masterKey: true,
+        let triggerRequest = ParseHookTriggerRequest<User, User>(primaryKey: true,
                                                                  user: user,
                                                                  installationId: installationId,
                                                                  ipAddress: "1.1.1.1",

--- a/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
@@ -83,6 +83,7 @@ class ParseHookTriggerRequestTests: XCTestCase {
                                                                   object: object)
         let expected2 = "{\"headers\":{\"yolo\":\"me\"},\"ip\":\"1.1.1.1\",\"object\":{\"objectId\":\"geez\"}}"
         XCTAssertEqual(triggerRequest2.description, expected2)
+        XCTAssertEqual(triggerRequest2.masterKey, triggerRequest2.primaryKey)
     }
 
     func testGetLog() async throws {

--- a/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
@@ -55,7 +55,7 @@ class ParseHookTriggerRequestTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }
@@ -71,7 +71,7 @@ class ParseHookTriggerRequestTests: XCTestCase {
 
     func testCoding() async throws {
         let object = User(objectId: "geez")
-        let triggerRequest = ParseHookTriggerRequest<User, User>(masterKey: true,
+        let triggerRequest = ParseHookTriggerRequest<User, User>(primaryKey: true,
                                                                  ipAddress: "1.1.1.1",
                                                                  headers: ["yolo": "me"],
                                                                  object: object)
@@ -87,7 +87,7 @@ class ParseHookTriggerRequestTests: XCTestCase {
 
     func testGetLog() async throws {
         let object = User(objectId: "geez")
-        let triggerRequest = ParseHookTriggerRequest<User, User>(masterKey: true,
+        let triggerRequest = ParseHookTriggerRequest<User, User>(primaryKey: true,
                                                                  ipAddress: "1.1.1.1",
                                                                  headers: ["yolo": "me"],
                                                                  object: object,
@@ -98,7 +98,7 @@ class ParseHookTriggerRequestTests: XCTestCase {
 
     func testGetLogError() async throws {
         let object = User(objectId: "geez")
-        let triggerRequest = ParseHookTriggerRequest<User, User>(masterKey: true,
+        let triggerRequest = ParseHookTriggerRequest<User, User>(primaryKey: true,
                                                                  ipAddress: "1.1.1.1",
                                                                  headers: ["yolo": "me"],
                                                                  object: object,
@@ -118,7 +118,7 @@ class ParseHookTriggerRequestTests: XCTestCase {
     func testGetContext() async throws {
         let object = User(objectId: "geez")
         let context = ["peace": "out"]
-        let triggerRequest = ParseHookTriggerRequest<User, User>(masterKey: true,
+        let triggerRequest = ParseHookTriggerRequest<User, User>(primaryKey: true,
                                                                  ipAddress: "1.1.1.1",
                                                                  headers: ["yolo": "me"],
                                                                  object: object,
@@ -130,7 +130,7 @@ class ParseHookTriggerRequestTests: XCTestCase {
     func testGetContextError() async throws {
         let object = User(objectId: "geez")
         let context = ["peace": "out"]
-        let triggerRequest = ParseHookTriggerRequest<User, User>(masterKey: true,
+        let triggerRequest = ParseHookTriggerRequest<User, User>(primaryKey: true,
                                                                  ipAddress: "1.1.1.1",
                                                                  headers: ["yolo": "me"],
                                                                  object: object,
@@ -152,16 +152,16 @@ class ParseHookTriggerRequestTests: XCTestCase {
         let sessionToken = "dog"
         let installationId = "cat"
         let user = User(sessionToken: sessionToken)
-        let triggerRequest = ParseHookTriggerRequest<User, User>(masterKey: true,
+        let triggerRequest = ParseHookTriggerRequest<User, User>(primaryKey: true,
                                                                  user: user,
                                                                  installationId: installationId,
                                                                  ipAddress: "1.1.1.1",
                                                                  headers: ["yolo": "me"],
                                                                  object: object)
-        let options = API.Options([.useMasterKey])
+        let options = API.Options([.usePrimaryKey])
         let requestOptions = triggerRequest.options()
         XCTAssertEqual(requestOptions, options)
-        let triggerRequest2 = ParseHookTriggerRequest<User, User>(masterKey: false,
+        let triggerRequest2 = ParseHookTriggerRequest<User, User>(primaryKey: false,
                                                                    user: user,
                                                                    installationId: installationId,
                                                                    ipAddress: "1.1.1.1",
@@ -171,7 +171,7 @@ class ParseHookTriggerRequestTests: XCTestCase {
             .installationId(installationId)])
         let requestOptions2 = triggerRequest2.options()
         XCTAssertEqual(requestOptions2, options2)
-        let triggerRequest3 = ParseHookTriggerRequest<User, User>(masterKey: false,
+        let triggerRequest3 = ParseHookTriggerRequest<User, User>(primaryKey: false,
                                                                   user: user,
                                                                   ipAddress: "1.1.1.1",
                                                                   headers: ["yolo": "me"],
@@ -179,7 +179,7 @@ class ParseHookTriggerRequestTests: XCTestCase {
         let options3 = API.Options([.sessionToken(sessionToken)])
         let requestOptions3 = triggerRequest3.options()
         XCTAssertEqual(requestOptions3, options3)
-        let triggerRequest4 = ParseHookTriggerRequest<User, User>(masterKey: false,
+        let triggerRequest4 = ParseHookTriggerRequest<User, User>(primaryKey: false,
                                                                   installationId: installationId,
                                                                   ipAddress: "1.1.1.1",
                                                                   headers: ["yolo": "me"],
@@ -187,7 +187,7 @@ class ParseHookTriggerRequestTests: XCTestCase {
         let options4 = API.Options([.installationId(installationId)])
         let requestOptions4 = triggerRequest4.options()
         XCTAssertEqual(requestOptions4, options4)
-        let triggerRequest5 = ParseHookTriggerRequest<User, User>(masterKey: false,
+        let triggerRequest5 = ParseHookTriggerRequest<User, User>(primaryKey: false,
                                                                   ipAddress: "1.1.1.1",
                                                                   headers: ["yolo": "me"],
                                                                   object: object)
@@ -213,13 +213,13 @@ class ParseHookTriggerRequestTests: XCTestCase {
 
         let object = User(objectId: "geez")
         let installationId = "cat"
-        let triggerRequest = ParseHookTriggerRequest<User, User>(masterKey: true,
+        let triggerRequest = ParseHookTriggerRequest<User, User>(primaryKey: true,
                                                                  user: user,
                                                                  installationId: installationId,
                                                                  ipAddress: "1.1.1.1",
                                                                  headers: ["yolo": "me"],
                                                                  object: object)
-        let requestHydrated = ParseHookTriggerRequest<User, User>(masterKey: true,
+        let requestHydrated = ParseHookTriggerRequest<User, User>(primaryKey: true,
                                                                   user: server,
                                                                   installationId: installationId,
                                                                   ipAddress: "1.1.1.1",
@@ -241,7 +241,7 @@ class ParseHookTriggerRequestTests: XCTestCase {
 
         let object = User(objectId: "geez")
         let installationId = "cat"
-        let triggerRequest = ParseHookTriggerRequest<User, User>(masterKey: true,
+        let triggerRequest = ParseHookTriggerRequest<User, User>(primaryKey: true,
                                                                  user: user,
                                                                  installationId: installationId,
                                                                  ipAddress: "1.1.1.1",

--- a/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
@@ -61,7 +61,7 @@ class ParseHookTriggerTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseInstagramAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstagramAsyncTests.swift
@@ -72,7 +72,7 @@ class ParseInstagramAsyncTests: XCTestCase { // swiftlint:disable:this type_body
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseInstagramCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstagramCombineTests.swift
@@ -72,7 +72,7 @@ class ParseInstagramCombineTests: XCTestCase { // swiftlint:disable:this type_bo
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseInstagramTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstagramTests.swift
@@ -71,7 +71,7 @@ class ParseInstagramTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
 

--- a/Tests/ParseSwiftTests/ParseInstallationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationAsyncTests.swift
@@ -150,7 +150,7 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
         login()

--- a/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
@@ -100,7 +100,7 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
         login()

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -124,7 +124,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
         try userLogin()
@@ -1041,7 +1041,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         }
 
         do {
-            try installation.delete(options: [.useMasterKey])
+            try installation.delete(options: [.usePrimaryKey])
         } catch {
             XCTFail(error.localizedDescription)
         }

--- a/Tests/ParseSwiftTests/ParseKeychainAccessGroupTests.swift
+++ b/Tests/ParseSwiftTests/ParseKeychainAccessGroupTests.swift
@@ -117,7 +117,7 @@ class ParseKeychainAccessGroupTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseLDAPAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPAsyncTests.swift
@@ -72,7 +72,7 @@ class ParseLDAPAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseLDAPCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPCombineTests.swift
@@ -72,7 +72,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseLDAPTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPTests.swift
@@ -68,7 +68,7 @@ class ParseLDAPTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
 

--- a/Tests/ParseSwiftTests/ParseLinkedInCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLinkedInCombineTests.swift
@@ -72,7 +72,7 @@ class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_bod
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseLinkedInTests.swift
+++ b/Tests/ParseSwiftTests/ParseLinkedInTests.swift
@@ -71,7 +71,7 @@ class ParseLinkedInTests: XCTestCase { // swiftlint:disable:this type_body_lengt
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseLiveQueryAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryAsyncTests.swift
@@ -23,7 +23,7 @@ class ParseLiveQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
         ParseLiveQuery.defaultClient = try ParseLiveQuery(isDefault: true)

--- a/Tests/ParseSwiftTests/ParseLiveQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryCombineTests.swift
@@ -24,7 +24,7 @@ class ParseLiveQueryCombineTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
         ParseLiveQuery.defaultClient = try ParseLiveQuery(isDefault: true)

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -57,7 +57,7 @@ class ParseLiveQueryTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
         ParseLiveQuery.setDefault(try ParseLiveQuery(isDefault: true))
@@ -196,7 +196,7 @@ class ParseLiveQueryTests: XCTestCase {
             return
         }
         // swiftlint:disable:next line_length
-        let expected = "{\"applicationId\":\"applicationId\",\"clientKey\":\"clientKey\",\"installationId\":\"\(installationId)\",\"masterKey\":\"masterKey\",\"op\":\"connect\"}"
+        let expected = "{\"applicationId\":\"applicationId\",\"clientKey\":\"clientKey\",\"installationId\":\"\(installationId)\",\"masterKey\":\"primaryKey\",\"op\":\"connect\"}"
         let message = StandardMessage(operation: .connect, additionalProperties: true)
         let encoded = try ParseCoding.jsonEncoder()
             .encode(message)

--- a/Tests/ParseSwiftTests/ParseObjectAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectAsyncTests.swift
@@ -330,7 +330,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
@@ -59,7 +59,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }
@@ -507,7 +507,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
 
         do {
             let saved = try [score, score2].saveAll(transaction: true,
-                                                    options: [.useMasterKey])
+                                                    options: [.usePrimaryKey])
 
             XCTAssertEqual(saved.count, 2)
             XCTAssertThrowsError(try saved[0].get())
@@ -638,7 +638,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
 
         do {
             let saved = try [score, score2].saveAll(transaction: true,
-                                                    options: [.useMasterKey])
+                                                    options: [.usePrimaryKey])
             XCTAssertEqual(saved.count, 2)
 
             switch saved[0] {
@@ -716,7 +716,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
 
         do {
             let saved = try [score, score2].saveAll(transaction: true,
-                                                    options: [.useMasterKey])
+                                                    options: [.usePrimaryKey])
 
             XCTAssertEqual(saved.count, 2)
             XCTAssertThrowsError(try saved[0].get())
@@ -801,7 +801,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
 
         do {
             let saved = try [score, score2].saveAll(transaction: true,
-                                                    options: [.useMasterKey])
+                                                    options: [.usePrimaryKey])
             XCTAssertEqual(saved.count, 2)
             switch saved[0] {
 
@@ -897,7 +897,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
 
         let expectation2 = XCTestExpectation(description: "Save object2")
         scores.saveAll(transaction: true,
-                       options: [.useMasterKey],
+                       options: [.usePrimaryKey],
                        callbackQueue: callbackQueue) { result in
 
             switch result {
@@ -1002,7 +1002,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
 
         let expectation2 = XCTestExpectation(description: "Save object2")
         scores.saveAll(transaction: true,
-                       options: [.useMasterKey],
+                       options: [.usePrimaryKey],
                        callbackQueue: callbackQueue) { result in
 
             switch result {
@@ -1306,7 +1306,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
 
         let expectation2 = XCTestExpectation(description: "Update object2")
         scores.saveAll(transaction: true,
-                       options: [.useMasterKey],
+                       options: [.usePrimaryKey],
                        callbackQueue: callbackQueue) { result in
 
             switch result {

--- a/Tests/ParseSwiftTests/ParseObjectCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCombineTests.swift
@@ -50,7 +50,7 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
@@ -125,7 +125,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               requiringCustomObjectIds: true,
                               testing: true)
@@ -694,7 +694,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         let expectation2 = XCTestExpectation(description: "Save object2")
         score.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
-                   options: [.useMasterKey],
+                   options: [.usePrimaryKey],
                    callbackQueue: callbackQueue) { result in
 
             switch result {
@@ -799,7 +799,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         let expectation2 = XCTestExpectation(description: "Update object2")
         score.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
-                   options: [.useMasterKey],
+                   options: [.usePrimaryKey],
                    callbackQueue: callbackQueue) { result in
 
             switch result {
@@ -1771,7 +1771,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
         let expectation2 = XCTestExpectation(description: "Update object2")
         installation.save(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig,
-                          options: [.useMasterKey],
+                          options: [.usePrimaryKey],
                           callbackQueue: callbackQueue) { result in
 
             switch result {

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -325,7 +325,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }
@@ -681,7 +681,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         do {
-            let fetched = try score.fetch(options: [.useMasterKey])
+            let fetched = try score.fetch(options: [.usePrimaryKey])
             XCTAssert(fetched.hasSameObjectId(as: scoreOnServer))
             guard let fetchedCreatedAt = fetched.createdAt,
                 let fetchedUpdatedAt = fetched.updatedAt else {
@@ -778,7 +778,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         let expectation2 = XCTestExpectation(description: "Fetch object2")
-        score.fetch(options: [.useMasterKey], callbackQueue: callbackQueue) { result in
+        score.fetch(options: [.usePrimaryKey], callbackQueue: callbackQueue) { result in
 
             switch result {
             case .success(let fetched):
@@ -1027,7 +1027,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         do {
-            let saved = try score.save(options: [.useMasterKey])
+            let saved = try score.save(options: [.usePrimaryKey])
             XCTAssert(saved.hasSameObjectId(as: scoreOnServer))
             guard let savedCreatedAt = saved.createdAt,
                 let savedUpdatedAt = saved.updatedAt else {
@@ -1129,7 +1129,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         do {
-            let saved = try score.save(options: [.useMasterKey])
+            let saved = try score.save(options: [.usePrimaryKey])
             guard let savedUpdatedAt = saved.updatedAt else {
                 XCTFail("Should unwrap dates")
                 return
@@ -1214,7 +1214,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         let expectation2 = XCTestExpectation(description: "Save object2")
-        score.save(options: [.useMasterKey], callbackQueue: callbackQueue) { result in
+        score.save(options: [.usePrimaryKey], callbackQueue: callbackQueue) { result in
 
             switch result {
 
@@ -1315,7 +1315,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         let expectation2 = XCTestExpectation(description: "Update object2")
-        score.save(options: [.useMasterKey], callbackQueue: callbackQueue) { result in
+        score.save(options: [.usePrimaryKey], callbackQueue: callbackQueue) { result in
 
             switch result {
 
@@ -1436,7 +1436,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         do {
-            try score.delete(options: [.useMasterKey])
+            try score.delete(options: [.usePrimaryKey])
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -1472,7 +1472,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         do {
-            try score.delete(options: [.useMasterKey])
+            try score.delete(options: [.usePrimaryKey])
             XCTFail("Should have thrown ParseError")
         } catch {
             if let error = error as? ParseError {
@@ -1495,7 +1495,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         let expectation2 = XCTestExpectation(description: "Delete object2")
-        score.delete(options: [.useMasterKey], callbackQueue: callbackQueue) { result in
+        score.delete(options: [.usePrimaryKey], callbackQueue: callbackQueue) { result in
 
             if case let .failure(error) = result {
                 XCTFail(error.localizedDescription)
@@ -1575,7 +1575,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         let expectation2 = XCTestExpectation(description: "Delete object2")
-        score.delete(options: [.useMasterKey], callbackQueue: callbackQueue) { result in
+        score.delete(options: [.usePrimaryKey], callbackQueue: callbackQueue) { result in
 
             if case let .failure(error) = result {
                 XCTAssertEqual(error.code, parseError.code)

--- a/Tests/ParseSwiftTests/ParseOperationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationAsyncTests.swift
@@ -50,7 +50,7 @@ class ParseOperationAsyncTests: XCTestCase { // swiftlint:disable:this type_body
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseOperationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationCombineTests.swift
@@ -50,7 +50,7 @@ class ParseOperationCombineTests: XCTestCase { // swiftlint:disable:this type_bo
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseOperationTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationTests.swift
@@ -96,7 +96,7 @@ class ParseOperationTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParsePointerAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerAsyncTests.swift
@@ -45,7 +45,7 @@ class ParsePointerAsyncTests: XCTestCase { // swiftlint:disable:this type_body_l
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParsePointerCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerCombineTests.swift
@@ -42,7 +42,7 @@ class ParsePointerCombineTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParsePointerTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerTests.swift
@@ -42,7 +42,7 @@ class ParsePointerTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }
@@ -192,7 +192,7 @@ class ParsePointerTests: XCTestCase {
         }
 
         do {
-            let fetched = try pointer.fetch(options: [.useMasterKey])
+            let fetched = try pointer.fetch(options: [.usePrimaryKey])
             XCTAssert(fetched.hasSameObjectId(as: scoreOnServer))
             guard let fetchedCreatedAt = fetched.createdAt,
                 let fetchedUpdatedAt = fetched.updatedAt else {
@@ -243,7 +243,7 @@ class ParsePointerTests: XCTestCase {
         }
 
         let expectation2 = XCTestExpectation(description: "Fetch object2")
-        score.fetch(options: [.useMasterKey], callbackQueue: callbackQueue) { result in
+        score.fetch(options: [.usePrimaryKey], callbackQueue: callbackQueue) { result in
 
             switch result {
             case .success(let fetched):

--- a/Tests/ParseSwiftTests/ParsePolygonTests.swift
+++ b/Tests/ParseSwiftTests/ParsePolygonTests.swift
@@ -24,7 +24,7 @@ class ParsePolygonTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
         points = [

--- a/Tests/ParseSwiftTests/ParsePushAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParsePushAsyncTests.swift
@@ -53,7 +53,7 @@ class ParsePushAsyncTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParsePushCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParsePushCombineTests.swift
@@ -52,7 +52,7 @@ class ParsePushCombineTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParsePushPayloadAnyTests.swift
+++ b/Tests/ParseSwiftTests/ParsePushPayloadAnyTests.swift
@@ -22,7 +22,7 @@ class ParsePushPayloadAnyTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParsePushPayloadAppleTests.swift
+++ b/Tests/ParseSwiftTests/ParsePushPayloadAppleTests.swift
@@ -22,7 +22,7 @@ class ParsePushPayloadAppleTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParsePushPayloadFirebaseTests.swift
+++ b/Tests/ParseSwiftTests/ParsePushPayloadFirebaseTests.swift
@@ -22,7 +22,7 @@ class ParsePushPayloadFirebaseTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParsePushTests.swift
+++ b/Tests/ParseSwiftTests/ParsePushTests.swift
@@ -133,7 +133,7 @@ class ParsePushTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseQueryAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryAsyncTests.swift
@@ -57,7 +57,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               usingPostForQuery: true,
                               testing: true)

--- a/Tests/ParseSwiftTests/ParseQueryCacheTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryCacheTests.swift
@@ -63,7 +63,7 @@ class ParseQueryCacheTests: XCTestCase { // swiftlint:disable:this type_body_len
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               usingEqualQueryConstraint: false,
                               usingPostForQuery: false,

--- a/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
@@ -55,7 +55,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               usingPostForQuery: true,
                               testing: true)

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -61,7 +61,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               usingEqualQueryConstraint: false,
                               usingPostForQuery: true,

--- a/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
@@ -42,7 +42,7 @@ class ParseQueryViewModelTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               usingPostForQuery: true,
                               testing: true)

--- a/Tests/ParseSwiftTests/ParseRelationTests.swift
+++ b/Tests/ParseSwiftTests/ParseRelationTests.swift
@@ -85,7 +85,7 @@ class ParseRelationTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -97,7 +97,7 @@ class ParseRoleTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseSchemaAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseSchemaAsyncTests.swift
@@ -45,7 +45,7 @@ class ParseSchemaAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseSchemaCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseSchemaCombineTests.swift
@@ -44,7 +44,7 @@ class ParseSchemaCombineTests: XCTestCase { // swiftlint:disable:this type_body_
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseSchemaTests.swift
+++ b/Tests/ParseSwiftTests/ParseSchemaTests.swift
@@ -61,7 +61,7 @@ class ParseSchemaTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseSessionTests.swift
+++ b/Tests/ParseSwiftTests/ParseSessionTests.swift
@@ -63,7 +63,7 @@ class ParseSessionTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: false) // Set to false for codecov
 
@@ -134,7 +134,7 @@ class ParseSessionTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               // swiftlint:disable:next line_length
                               testing: false) {(_: URLAuthenticationChallenge, completion: (_: URLSession.AuthChallengeDisposition, _: URLCredential?) -> Void) in

--- a/Tests/ParseSwiftTests/ParseSpotifyAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseSpotifyAsyncTests.swift
@@ -72,7 +72,7 @@ class ParseSpotifyAsyncTests: XCTestCase { // swiftlint:disable:this type_body_l
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseSpotifyCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseSpotifyCombineTests.swift
@@ -72,7 +72,7 @@ class ParseSpotifyCombineTests: XCTestCase { // swiftlint:disable:this type_body
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseSpotifyTests.swift
+++ b/Tests/ParseSwiftTests/ParseSpotifyTests.swift
@@ -68,7 +68,7 @@ class ParseSpotifyTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
 

--- a/Tests/ParseSwiftTests/ParseTwitterAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterAsyncTests.swift
@@ -72,7 +72,7 @@ class ParseTwitterAsyncTests: XCTestCase { // swiftlint:disable:this type_body_l
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseTwitterCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterCombineTests.swift
@@ -72,7 +72,7 @@ class ParseTwitterCombineTests: XCTestCase { // swiftlint:disable:this type_body
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseTwitterTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterTests.swift
@@ -68,7 +68,7 @@ class ParseTwitterTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
 

--- a/Tests/ParseSwiftTests/ParseUserAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserAsyncTests.swift
@@ -126,7 +126,7 @@ class ParseUserAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseUserCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserCombineTests.swift
@@ -78,7 +78,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -116,7 +116,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }
@@ -325,7 +325,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         do {
-            let fetched = try user.fetch(options: [.useMasterKey])
+            let fetched = try user.fetch(options: [.usePrimaryKey])
             XCTAssert(fetched.hasSameObjectId(as: userOnServer))
             guard let fetchedCreatedAt = fetched.createdAt,
                 let fetchedUpdatedAt = fetched.updatedAt else {
@@ -374,7 +374,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         do {
-            let fetched = try user.fetch(options: [.useMasterKey])
+            let fetched = try user.fetch(options: [.usePrimaryKey])
             XCTAssert(fetched.hasSameObjectId(as: userOnServer))
             guard let fetchedCreatedAt = fetched.createdAt,
                 let fetchedUpdatedAt = fetched.updatedAt else {
@@ -781,7 +781,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         do {
-            let saved = try user.save(options: [.useMasterKey])
+            let saved = try user.save(options: [.usePrimaryKey])
             XCTAssert(saved.hasSameObjectId(as: userOnServer))
             XCTAssertEqual(saved.email, user.email)
             guard let savedCreatedAt = saved.createdAt,
@@ -842,7 +842,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         do {
-            let saved = try user.save(options: [.useMasterKey])
+            let saved = try user.save(options: [.usePrimaryKey])
             XCTAssert(saved.hasSameObjectId(as: userOnServer))
             XCTAssertEqual(saved.email, user.email)
             guard let savedCreatedAt = saved.createdAt,
@@ -1114,7 +1114,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         do {
-            let saved = try user.save(options: [.useMasterKey])
+            let saved = try user.save(options: [.usePrimaryKey])
             guard let savedUpdatedAt = saved.updatedAt else {
                 XCTFail("Should unwrap dates")
                 return
@@ -1158,7 +1158,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         do {
-            let saved = try user.save(options: [.useMasterKey])
+            let saved = try user.save(options: [.usePrimaryKey])
             XCTAssert(saved.hasSameObjectId(as: userOnServer))
             guard let savedCreatedAt = saved.createdAt,
                 let savedUpdatedAt = saved.updatedAt else {
@@ -1250,7 +1250,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         let expectation2 = XCTestExpectation(description: "Update user2")
-        user.save(options: [.useMasterKey], callbackQueue: callbackQueue) { result in
+        user.save(options: [.usePrimaryKey], callbackQueue: callbackQueue) { result in
 
             switch result {
 
@@ -2097,7 +2097,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
 
         do {
-            try user.delete(options: [.useMasterKey])
+            try user.delete(options: [.usePrimaryKey])
         } catch {
             XCTFail(error.localizedDescription)
         }

--- a/Tests/ParseSwiftTests/ParseVersionTests.swift
+++ b/Tests/ParseSwiftTests/ParseVersionTests.swift
@@ -19,7 +19,7 @@ class ParseVersionTests: XCTestCase {
         }
         ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
-                              masterKey: "masterKey",
+                              primaryKey: "primaryKey",
                               serverURL: url,
                               testing: true)
     }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
The parse-platform doesn't use inclusive language. Though a change has been requested for 2+ years a number of times:
 - https://github.com/parse-community/parse-server/issues/7584
 - https://github.com/parse-community/parse-server/issues/7584#issuecomment-923490677
 - https://github.com/parse-community/parse-server/issues/7584#issuecomment-923838865
 - https://github.com/parse-community/parse-server/issues/8218)
 - https://community.parseplatform.org/t/terminology-and-depictions-across-parse-platform/2009

changes have still not been made.

### Approach
<!-- Add a description of the approach in this PR. -->
Change `masterKey` to `primaryKey` to reflect inclusive language discussed in https://github.com/dialpad/inclusive-language#motivation

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Verify tests still build
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
