### PR TITLE
fix: ambiguous SDK initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,20 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/4.15.0...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/4.15.1...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 4.15.1
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/4.15.0...4.15.1), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/4.15.1/documentation/parseswift)
+
+__Fixes__
+- Fixed ambigous SDK initializer ([#6](https://github.com/netrecolab/Parse-Swift/pull/6)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 4.15.0
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/4.14.2...4.15.0), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/4.15.0/documentation/parseswift)
 
 __New features__
-- Addressed an issue that prevented updating ParseObjects with saveAll ([#2](https://github.com/netrecolab/Parse-Swift/pull/2)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Refactored masterKey->primaryKey due to insensitive language ([#2](https://github.com/netrecolab/Parse-Swift/pull/2)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 4.14.2
 [Full Changelog](https://github.com/parse-community/Parse-Swift/compare/4.14.1...4.14.2), [Documentation](https://swiftpackageindex.com/parse-community/Parse-Swift/4.14.2/documentation/parseswift)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ If you are not familiar with Pull Requests and want to know more about them, you
 
 Before you start to code, please open a [new issue](https://github.com/netreconlab/Parse-Swift/issues/new/choose) to describe your idea, or search for and continue the discussion in an [existing issue](https://github.com/netreconlab/Parse-Swift/issues).
 
-> ⚠️ Please do not post a security vulnerability on GitHub or in the Parse Community Forum. Instead, follow the [Parse Community Security Policy](https://github.com/netreconlab/parse-server/security/policy).
+> ⚠️ Please do not post a security vulnerability on GitHub. Instead, follow the [Security Policy](https://github.com/netreconlab/parse-server/security/policy).
 
 Please completely fill out any templates to provide essential information about your new feature or the bug you discovered.
 
@@ -27,7 +27,7 @@ Together we will plan out the best conceptual approach for your contribution, so
 
 When you are ready to code, you can find more information about opening a pull request in the [GitHub docs](https://help.github.com/articles/creating-a-pull-request/).
 
-Whether this is your first contribution or you are already an experienced contributor, the Parse Community has your back – do not hesitate to ask for help!
+Whether this is your first contribution or you are already an experienced contributor, do not hesitate to ask for help!
 
 ## Why Contributing?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,9 @@ If you are not familiar with Pull Requests and want to know more about them, you
 
 ## Contributing
 
-Before you start to code, please open a [new issue](https://github.com/parse-community/Parse-Swift/issues/new/choose) to describe your idea, or search for and continue the discussion in an [existing issue](https://github.com/parse-community/Parse-Swift/issues).
+Before you start to code, please open a [new issue](https://github.com/netreconlab/Parse-Swift/issues/new/choose) to describe your idea, or search for and continue the discussion in an [existing issue](https://github.com/netreconlab/Parse-Swift/issues).
 
-> ⚠️ Please do not post a security vulnerability on GitHub or in the Parse Community Forum. Instead, follow the [Parse Community Security Policy](https://github.com/parse-community/parse-server/security/policy).
+> ⚠️ Please do not post a security vulnerability on GitHub or in the Parse Community Forum. Instead, follow the [Parse Community Security Policy](https://github.com/netreconlab/parse-server/security/policy).
 
 Please completely fill out any templates to provide essential information about your new feature or the bug you discovered.
 
@@ -54,10 +54,10 @@ Most importantly, with every contribution you improve your skills so that future
 
 ### Setting up your local machine
 
-* [Fork](https://github.com/parse-community/Parse-Swift) this project and clone the fork on to your local machine:
+* [Fork](https://github.com/netreconlab/Parse-Swift) this project and clone the fork on to your local machine:
 
 ```sh
-$ git clone https://github.com/parse-community/Parse-Swift
+$ git clone https://github.com/netreconlab/Parse-Swift
 $ cd Parse-Swift # go into the clone directory
 ```
 
@@ -69,15 +69,15 @@ $ brew install swiftlint
 
 ### Swift Playgrounds
 
-Any feature additions should work with a real Parse Server. You can experiment with features in the ParseSwift SDK by modifying the [ParseSwift Playground files](https://github.com/parse-community/Parse-Swift/tree/main/ParseSwift.playground/Pages). It is recommended to make sure your ParseSwift workspace in Xcode is set to build for `ParseSwift (macOS)` framework when using Swift Playgrounds. To configure the playgounds, you can do one of the following:
+Any feature additions should work with a real Parse Server. You can experiment with features in the ParseSwift SDK by modifying the [ParseSwift Playground files](https://github.com/netreconlab/Parse-Swift/tree/main/ParseSwift.playground/Pages). It is recommended to make sure your ParseSwift workspace in Xcode is set to build for `ParseSwift (macOS)` framework when using Swift Playgrounds. To configure the playgounds, you can do one of the following:
 
 * Use the pre-configured parse-server in [this repo](https://github.com/netreconlab/parse-hipaa/tree/parse-swift) which comes with docker compose files (`docker-compose up` gives you a working server) configured to connect with the ParseSwift Playgrounds. The docker comes with [Parse Dashboard](https://github.com/parse-community/parse-dashboard) and can be used with MongoDB or PostgreSQL.
-* Configure the ParseSwift Playgrounds to work with your own Parse Server by editing the configuation in [Common.swift](https://github.com/parse-community/Parse-Swift/blob/e9ba846c399257100b285d25d2bd055628b13b4b/ParseSwift.playground/Sources/Common.swift#L4-L19).
+* Configure the ParseSwift Playgrounds to work with your own Parse Server by editing the configuation in [Common.swift](https://github.com/netreconlab/Parse-Swift/blob/e9ba846c399257100b285d25d2bd055628b13b4b/ParseSwift.playground/Sources/Common.swift#L4-L19).
 
 ### Please Do's
 
 * Take testing seriously! Aim to increase the test coverage with every pull request
-* Add/modify test files for the code you are working on in [ParseSwiftTests](https://github.com/parse-community/Parse-Swift/tree/main/Tests/ParseSwiftTests)
+* Add/modify test files for the code you are working on in [ParseSwiftTests](https://github.com/netreconlab/Parse-Swift/tree/main/Tests/ParseSwiftTests)
 * Run the tests for the file you are working on using Xcode
 * Run the tests for the whole project to make sure the code passes all tests. This can be done by running the tests in Xcode
 * Address all errors and warnings your fixes introduce as the ParseSwift SDK should have zero warnings
@@ -120,7 +120,3 @@ Currently, we are not making use of the commit _scope_, which would be written a
 ## Evolution
 
 The ParseSwift SDK is not a port of the [Parse-SDK-iOS-OSX SDK](https://github.com/parse-community/Parse-SDK-iOS-OSX) and though some of it may feel familiar, it is not backwards compatible and is designed using [protocol oriented programming (POP) and value types](https://www.pluralsight.com/guides/protocol-oriented-programming-in-swift) instead of OOP and reference types. You can learn more about POP by watching [this](https://developer.apple.com/videos/play/wwdc2015/408/) or [that](https://developer.apple.com/videos/play/wwdc2016/419/) videos from previous WWDC's. Please see [this thread](https://github.com/parse-community/Parse-Swift/issues/3) for a detailed discussion about the intended evolution of this SDK.
-
-## Code of Conduct
-
-This project adheres to the [Contributor Covenant Code of Conduct](https://github.com/parse-community/.github/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to honor this code.

--- a/ParseSwift-macOS/Info.plist
+++ b/ParseSwift-macOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2020 Parse Community. All rights reserved.</string>
+	<string>Copyright © 2022 Network Reconnaissance Lab. All rights reserved.</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -316,7 +316,7 @@ public func initialize(
 public func initialize(
     applicationId: String,
     clientKey: String? = nil,
-    masterKey: String? = nil,
+    masterKey: String,
     serverURL: URL,
     liveQueryServerURL: URL? = nil,
     requiringCustomObjectIds: Bool = false,
@@ -429,7 +429,7 @@ public func initialize(
 ) {
     initialize(applicationId: applicationId,
                clientKey: clientKey,
-               masterKey: masterKey,
+               primaryKey: masterKey,
                serverURL: serverURL,
                liveQueryServerURL: liveQueryServerURL,
                requiringCustomObjectIds: allowingCustomObjectIds,
@@ -523,7 +523,7 @@ public func initialize(
 ) {
     var configuration = ParseConfiguration(applicationId: applicationId,
                                            clientKey: clientKey,
-                                           masterKey: masterKey,
+                                           primaryKey: masterKey,
                                            serverURL: serverURL,
                                            liveQueryServerURL: liveQueryServerURL,
                                            requiringCustomObjectIds: allowingCustomObjectIds,

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "4.14.2"
+    static let version = "4.15.1"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Types/ParseConfiguration.swift
+++ b/Sources/ParseSwift/Types/ParseConfiguration.swift
@@ -262,7 +262,7 @@ public struct ParseConfiguration {
     @available(*, deprecated, message: "Change: masterKey->primaryKey.")
     public init(applicationId: String,
                 clientKey: String? = nil,
-                masterKey: String? = nil,
+                masterKey: String,
                 webhookKey: String? = nil,
                 serverURL: URL,
                 liveQueryServerURL: URL? = nil,
@@ -374,7 +374,7 @@ public struct ParseConfiguration {
                                    URLCredential?) -> Void) -> Void)? = nil) {
         self.init(applicationId: applicationId,
                   clientKey: clientKey,
-                  masterKey: masterKey,
+                  primaryKey: masterKey,
                   webhookKey: webhookKey,
                   serverURL: serverURL,
                   liveQueryServerURL: liveQueryServerURL,
@@ -467,7 +467,7 @@ public struct ParseConfiguration {
                                    URLCredential?) -> Void) -> Void)? = nil) {
         self.init(applicationId: applicationId,
                   clientKey: clientKey,
-                  masterKey: masterKey,
+                  primaryKey: masterKey,
                   webhookKey: webhookKey,
                   serverURL: serverURL,
                   liveQueryServerURL: liveQueryServerURL,

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -98,6 +98,27 @@ class InitializeSDKTests: XCTestCase {
         XCTAssertNotNil(Parse.sessionDelegate.authentication)
         ParseSwift.updateAuthentication(nil)
         XCTAssertNil(Parse.sessionDelegate.authentication)
+
+        let configuration3 = ParseConfiguration(applicationId: "applicationId",
+                                                clientKey: "clientKey",
+                                                masterKey: "primaryKey",
+                                                serverURL: url) { (_, credential) in
+            credential(.performDefaultHandling, nil)
+        }
+        ParseSwift.initialize(configuration: configuration3)
+        XCTAssertNotNil(Parse.sessionDelegate.authentication)
+        ParseSwift.updateAuthentication(nil)
+        XCTAssertNil(Parse.sessionDelegate.authentication)
+
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "primaryKey",
+                              serverURL: url) { (_, credential) in
+            credential(.performDefaultHandling, nil)
+        }
+        XCTAssertNotNil(Parse.sessionDelegate.authentication)
+        ParseSwift.updateAuthentication(nil)
+        XCTAssertNil(Parse.sessionDelegate.authentication)
     }
 
     #if !os(Linux) && !os(Android) && !os(Windows)

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -119,6 +119,17 @@ class InitializeSDKTests: XCTestCase {
         XCTAssertNotNil(Parse.sessionDelegate.authentication)
         ParseSwift.updateAuthentication(nil)
         XCTAssertNil(Parse.sessionDelegate.authentication)
+
+        ParseSwift.initialize(applicationId: "applicationId",
+                              clientKey: "clientKey",
+                              masterKey: "primaryKey",
+                              serverURL: url,
+                              migratingFromObjcSDK: false) { (_, credential) in
+            credential(.performDefaultHandling, nil)
+        }
+        XCTAssertNotNil(Parse.sessionDelegate.authentication)
+        ParseSwift.updateAuthentication(nil)
+        XCTAssertNil(Parse.sessionDelegate.authentication)
     }
 
     #if !os(Linux) && !os(Android) && !os(Windows)


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Ambiguous initializer can cause build issues.

### Approach
<!-- Add a description of the approach in this PR. -->
Updated signatures of SDK initializers.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
