### PR TITLE
feat: add isDirtyForKey method for ParseObjects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,15 @@ on:
     branches: [ main ]
   pull_request:
     branches: '*'
+
 env:
   CI_XCODE_OLDEST: '/Applications/Xcode_12.5.1.app/Contents/Developer'
   CI_XCODE_13: '/Applications/Xcode_13.4.1.app/Contents/Developer'
   CI_XCODE_LATEST: '/Applications/Xcode_14.0.1.app/Contents/Developer'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   xcode-test-ios:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   xcode-test-ios:
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
     - name: Use multiple cores
@@ -43,7 +43,7 @@ jobs:
           DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
 
   xcode-test-macos:
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
     - name: Create and set the default keychain
@@ -76,7 +76,7 @@ jobs:
           DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
 
   xcode-test-tvos:
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
     - name: Use multiple cores
@@ -103,7 +103,7 @@ jobs:
           DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
 
   xcode-build-watchos:
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
     - name: Use multiple cores
@@ -120,7 +120,7 @@ jobs:
           DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
 
   spm-test:
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v3
     - name: Create and set the default keychain
@@ -154,7 +154,7 @@ jobs:
 
   xcode-test-ios-5_3:
     needs: xcode-build-watchos
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
     - uses: actions/checkout@v3
     - name: Build-Test
@@ -231,7 +231,7 @@ jobs:
   
   docs:
     needs: xcode-build-watchos
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - name: Use multiple cores
@@ -243,7 +243,7 @@ jobs:
 
   carthage:
    needs: xcode-build-watchos
-   runs-on: macos-12
+   runs-on: macos-latest
    steps:
      - uses: actions/checkout@v3
      - name: Use multiple cores

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   docs:
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
       - name: Get release version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/4.15.2...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+__New features__
+- Added the ability to check if a `ParseObject` key is dirty ([#9](https://github.com/netreconlab/Parse-Swift/pull/9)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 4.15.2
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/4.15.1...4.15.2), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/4.15.2/documentation/parseswift)
 

--- a/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
@@ -128,10 +128,10 @@ score.save { result in
 
         /*:
          To modify, you need to make it a var as the value type
-         was initialized as immutable. Using `mergeable`
+         was initialized as immutable. Using `.mergeable`
          allows you to only send the updated keys to the
          parse server as opposed to the whole object. Make sure
-         to call `mergeable` before you begin
+         to call `.mergeable` before you begin
          your first mutation of your `ParseObject`.
         */
         var changedScore = savedScore.mergeable
@@ -221,10 +221,10 @@ assert(savedScore?.points == 10)
 
 /*:
  To modify, you need to make a mutable copy of `savedScore`.
- Instead of using `mergeable` this time, we will use the `set()`
+ Instead of using `.mergeable` this time, we will use the `set()`
  method which allows us to accomplish the same thing
- as `mergeable`. You can choose to use `set()` or
- `mergeable` as long as you use either before you begin
+ as `.mergeable`. You can choose to use `.set()` or
+ `.mergeable` as long as you use either before you begin
  your first mutation of your `ParseObject`.
 */
 guard var changedScore = savedScore else {

--- a/ParseSwift.playground/Pages/10 - Cloud Code.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/10 - Cloud Code.xcplaygroundpage/Contents.swift
@@ -165,10 +165,6 @@ extension GameScore {
     init(points: Int) {
         self.points = points
     }
-
-    init(objectId: String?) {
-        self.objectId = objectId
-    }
 }
 
 //: Define a GameScore.

--- a/ParseSwift.playground/Pages/12 - Roles and Relations.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/12 - Roles and Relations.xcplaygroundpage/Contents.swift
@@ -105,10 +105,6 @@ extension GameScore {
     init(points: Int) {
         self.points = points
     }
-
-    init(objectId: String?) {
-        self.objectId = objectId
-    }
 }
 
 //: Roles can provide additional access/security to your apps.

--- a/ParseSwift.playground/Pages/13 - Operations.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/13 - Operations.xcplaygroundpage/Contents.swift
@@ -50,10 +50,6 @@ extension GameScore {
     init(points: Int) {
         self.points = points
     }
-
-    init(objectId: String?) {
-        self.objectId = objectId
-    }
 }
 
 //: You can have the server do operations on your `ParseObject`'s for you.

--- a/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
@@ -56,10 +56,6 @@ extension GameScore {
         self.objectId = objectId
         self.points = points
     }
-
-    init(objectId: String) {
-        self.objectId = objectId
-    }
 }
 
 //: Define initial GameScore this time with custom `objectId`.

--- a/ParseSwift.playground/Pages/20 - Cloud Schemas.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/20 - Cloud Schemas.xcplaygroundpage/Contents.swift
@@ -92,21 +92,6 @@ struct GameScore2: ParseObject {
     }
 }
 
-/*:
- It's recommended to place custom initializers in an extension
- to preserve the memberwise initializer.
- */
-extension GameScore2 {
-
-    init(points: Int) {
-        self.points = points
-    }
-
-    init(objectId: String?) {
-        self.objectId = objectId
-    }
-}
-
 //: First lets create a new CLP for the new schema.
 let clp = ParseCLP(requiresAuthentication: true, publicAccess: false)
     .setAccessPublic(true, on: .get)

--- a/ParseSwift.playground/Pages/23 - Cloud Hook Triggers.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/23 - Cloud Hook Triggers.xcplaygroundpage/Contents.swift
@@ -39,19 +39,6 @@ struct GameScore: ParseObject {
     }
 }
 
-//: It's recommended to place custom initializers in an extension
-//: to preserve the memberwise initializer.
-extension GameScore {
-
-    init(points: Int) {
-        self.points = points
-    }
-
-    init(objectId: String?) {
-        self.objectId = objectId
-    }
-}
-
 /*:
  Parse Hook Triggers can be created by conforming to
  `ParseHookFunctionable`.

--- a/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
@@ -104,10 +104,6 @@ extension GameScore {
     init(points: Int) {
         self.points = points
     }
-
-    init(objectId: String?) {
-        self.objectId = objectId
-    }
 }
 
 //: Logging out - synchronously

--- a/ParseSwift.playground/Pages/9 - Files.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/9 - Files.xcplaygroundpage/Contents.swift
@@ -61,10 +61,6 @@ extension GameScore {
     init(points: Int) {
         self.points = points
     }
-
-    init(objectId: String?) {
-        self.objectId = objectId
-    }
 }
 
 struct GamePhoto: ParseObject {

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -49,7 +49,7 @@ public protocol ParseObject: ParseTypeable,
 
     /**
      A JSON encoded version of this `ParseObject` before `.set()` or
-     `mergeable` was called and properties were changed.
+     `.mergeable` was called and properties were changed.
      - warning: This property is not intended to be set or modified by the developer.
     */
     var originalData: Data? { get set }

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -17,7 +17,7 @@ import Foundation
  The Swift SDK is designed for your `ParseObject`s to be **value types (structures)**.
  Since you are using value types the compiler will assist you with conforming to the `ParseObject` protocol.
  After a `ParseObject`is saved/created to a Parse Server. It is recommended to conduct any updates on a
- `mergeable` copy of your `ParseObject`. This can be accomplished by calling the `mergeable` property
+ `mergeable` copy of your `ParseObject`. This can be accomplished by calling the `.mergeable` property
  of your `ParseObject` or by calling the `set()` method on your `ParseObject`. This allows a subset
  of the fields to be updated (PATCH) of an object as oppose to replacing all of the fields of an object (PUT).
  This reduces the amount of data sent between client and server when using `save`, `saveAll`, `update`,
@@ -48,8 +48,8 @@ public protocol ParseObject: ParseTypeable,
                              Hashable {
 
     /**
-     A JSON encoded version of this `ParseObject` before `mergeable` was called and
-     properties were changed.
+     A JSON encoded version of this `ParseObject` before `.set()` or
+     `mergeable` was called and properties were changed.
      - warning: This property is not intended to be set or modified by the developer.
     */
     var originalData: Data? { get set }
@@ -58,7 +58,7 @@ public protocol ParseObject: ParseTypeable,
      An empty copy of the respective object that allows you to update a
      a subset of the fields (PATCH) of an object as oppose to replacing an object (PUT).
      - note: It is recommended to use this to create a mergeable copy of your `ParseObject`.
-     - warning: `mergeable` should only be used on `ParseObject`'s that have already
+     - warning: `.mergeable` should only be used on `ParseObject`'s that have already
      been saved at least once to a Parse Server and have a valid `objectId`. In addition,
      the developer should have implemented added all of their properties to `merge`.
     */
@@ -66,6 +66,7 @@ public protocol ParseObject: ParseTypeable,
 
     /**
      The default initializer to ensure all `ParseObject`'s can be encoded/decoded properly.
+     All properties of this instance are **nil** resulting in an empty object.
      - important: The compiler will give you this initialzer for free
      ([memberwise initializer](https://docs.swift.org/swift-book/LanguageGuide/Initialization.html))
      as long as you declare all properties as **optional** (see **Warning** section) and you declare all other initializers in
@@ -84,11 +85,11 @@ public protocol ParseObject: ParseTypeable,
     /**
      Determines if a `KeyPath` of the current `ParseObject` should be restored
      by comparing it to another `ParseObject`.
-     - parameter key: The `KeyPath` to check.
+     - parameter keyPath: The `KeyPath` to check.
      - parameter original: The original `ParseObject`.
      - returns: Returns a **true** if the keyPath should be restored  or **false** otherwise.
     */
-    func shouldRestoreKey<W>(_ key: KeyPath<Self, W?>,
+    func shouldRestoreKey<W>(_ keyPath: KeyPath<Self, W?>,
                              original: Self) -> Bool where W: Equatable
 
     /**
@@ -147,6 +148,20 @@ public protocol ParseObject: ParseTypeable,
 // MARK: Default Implementations
 public extension ParseObject {
 
+    /**
+     Creates a `ParseObject` with a specified `objectId`. Can be used to create references or associations
+     between `ParseObject`'s.
+     - warning: It is required that all added properties be optional properties so they can eventually be used as
+     Parse `Pointer`'s. If a developer really wants to have a required key, they should require it on the server-side or
+     create methods to check the respective properties on the client-side before saving objects. See
+     [here](https://github.com/parse-community/Parse-Swift/pull/315#issuecomment-1014701003)
+     for more information.
+     */
+    init(objectId: String) {
+        self.init()
+        self.objectId = objectId
+    }
+
     func hash(into hasher: inout Hasher) {
         hasher.combine(self.id)
     }
@@ -189,9 +204,9 @@ public extension ParseObject {
         return try Pointer(self)
     }
 
-    func shouldRestoreKey<W>(_ key: KeyPath<Self, W?>,
+    func shouldRestoreKey<W>(_ keyPath: KeyPath<Self, W?>,
                              original: Self) -> Bool where W: Equatable {
-        self[keyPath: key] == nil && original[keyPath: key] != self[keyPath: key]
+        self[keyPath: keyPath] == nil && original[keyPath: keyPath] != self[keyPath: keyPath]
     }
 
     func mergeParse(with object: Self) throws -> Self {
@@ -218,9 +233,9 @@ public extension ParseObject {
 
 // MARK: Default Implementations (Internal)
 extension ParseObject {
-    func shouldRevertKey<W>(_ key: KeyPath<Self, W?>,
+    func shouldRevertKey<W>(_ keyPath: KeyPath<Self, W?>,
                             original: Self) -> Bool where W: Equatable {
-        original[keyPath: key] != self[keyPath: key]
+        original[keyPath: keyPath] != self[keyPath: keyPath]
     }
 }
 
@@ -231,7 +246,7 @@ public extension ParseObject {
      before mutations began.
      - throws: An error of type `ParseError`.
      - important: This reverts to the contents in `originalData`. This means `originalData` should have
-     been populated by calling `mergeable` or the `set` method.
+     been populated by calling `.mergeable` or the `.set` method.
     */
     @available(*, deprecated, renamed: "revert")
     func revertKeyPath<W>(_ keyPath: WritableKeyPath<Self, W?>) throws -> Self where W: Equatable {
@@ -242,7 +257,7 @@ public extension ParseObject {
      Reverts the `ParseObject` back to the original object before mutations began.
      - throws: An error of type `ParseError`.
      - important: This reverts to the contents in `originalData`. This means `originalData` should have
-     been populated by calling `mergeable` or the `set` method.
+     been populated by calling `.mergeable` or the `.set()` method.
     */
     @available(*, deprecated, renamed: "revert")
     func revertObject() throws -> Self {
@@ -254,7 +269,7 @@ public extension ParseObject {
      before mutations began.
      - throws: An error of type `ParseError`.
      - important: This reverts to the contents in `originalData`. This means `originalData` should have
-     been populated by calling `mergeable` or the `set` method.
+     been populated by calling `.mergeable` or the `.set()` method.
     */
     func revert<W>(_ keyPath: WritableKeyPath<Self, W?>) throws -> Self where W: Equatable {
         guard let originalData = originalData else {
@@ -279,7 +294,7 @@ public extension ParseObject {
      Reverts the `ParseObject` back to the original object before mutations began.
      - throws: An error of type `ParseError`.
      - important: This reverts to the contents in `originalData`. This means `originalData` should have
-     been populated by calling `mergeable` or the `set` method.
+     been populated by calling `.mergeable` or the `.set()` method.
     */
     func revert() throws -> Self {
         guard let originalData = originalData else {
@@ -297,7 +312,7 @@ public extension ParseObject {
 
     /**
      Get the unwrapped property value.
-     - parameter key: The `KeyPath` of the value to get.
+     - parameter keyPath: The `KeyPath` of the value to get.
      - throws: An error of type `ParseError` when the value is **nil**.
      - returns: The unwrapped value.
      */
@@ -311,7 +326,7 @@ public extension ParseObject {
 
     /**
      Set the value of a specific `KeyPath` on a `ParseObject`.
-     - parameter key: The `KeyPath` of the value to set.
+     - parameter keyPath: The `KeyPath` of the value to set.
      - parameter value: The value to set the `KeyPath` to.
      - returns: The updated `ParseObject`.
      - important: This method should be used when updating a `ParseObject` that has already been saved to
@@ -328,6 +343,26 @@ public extension ParseObject {
         var updated = self.mergeable
         updated[keyPath: keyPath] = value
         return updated
+    }
+
+    /**
+     Get whether a value associated with a `KeyPath` has been added/updated on the client, but has
+     not been updated on a Parse Server.
+     - parameter keyPath: The `KeyPath` of the value to check.
+     - throws: An error of type `ParseError`.
+     - returns: **true** if the `KeyPath` is dirty, **false** otherwise.
+     - important: In order for a `KeyPath` to be considered dirty, the respective `ParseObject` needs to
+     first be saved to a Parse Server and fetched locally.
+     - note: This method should only be used after updating a `ParseObject` using `.set()` or
+     `.mergeable` otherwide it will always return **false**.
+     */
+    func isDirtyForKey<W>(_ keyPath: KeyPath<Self, W?>) throws -> Bool where W: Equatable {
+        guard let originalData = originalData else {
+            return false
+        }
+        let original = try ParseCoding.jsonDecoder().decode(Self.self,
+                                                            from: originalData)
+        return self[keyPath: keyPath] != original[keyPath: keyPath]
     }
 }
 

--- a/Tests/ParseSwiftTests/ParseACLTests.swift
+++ b/Tests/ParseSwiftTests/ParseACLTests.swift
@@ -353,9 +353,3 @@ class ParseACLTests: XCTestCase {
         }
     }
 }
-
-extension ParseACLTests.User {
-    init(objectId: String) {
-        self.objectId = objectId
-    }
-}

--- a/Tests/ParseSwiftTests/ParseCLPTests.swift
+++ b/Tests/ParseSwiftTests/ParseCLPTests.swift
@@ -32,9 +32,6 @@ class ParseCLPTests: XCTestCase { // swiftlint:disable:this type_body_length
         var customKey: String?
 
         init() { }
-        init(objectId: String) {
-            self.objectId = objectId
-        }
     }
 
     struct Role<RoleUser: ParseUser>: ParseRole {

--- a/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
@@ -35,9 +35,6 @@ class ParseHookTriggerTests: XCTestCase {
         //: custom initializers
         init() {}
 
-        init(objectId: String?) {
-            self.objectId = objectId
-        }
         init(points: Int) {
             self.points = points
         }

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -28,10 +28,6 @@ class ParseLiveQueryTests: XCTestCase {
         init(points: Int) {
             self.points = points
         }
-
-        init(objectId: String?) {
-            self.objectId = objectId
-        }
     }
 
     class TestDelegate: ParseLiveQueryDelegate {

--- a/Tests/ParseSwiftTests/ParseObjectAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectAsyncTests.swift
@@ -94,13 +94,11 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
         //: custom initializers
         init() {}
 
-        init(objectId: String?) {
-            self.objectId = objectId
-        }
         init(points: Int) {
             self.points = points
             self.player = "Jen"
         }
+
         init(points: Int, name: String) {
             self.points = points
             self.player = name

--- a/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
@@ -25,16 +25,13 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         var other: Game2?
         var otherArray: [Game2]?
 
-        //custom initializers
+        // Custom initializers
         init() {
             self.points = 5
         }
+
         init(points: Int) {
             self.points = points
-        }
-
-        init(objectId: String?) {
-            self.objectId = objectId
         }
     }
 

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -47,13 +47,11 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         //: custom initializers
         init() {}
 
-        init(objectId: String?) {
-            self.objectId = objectId
-        }
         init(points: Int) {
             self.points = points
             self.player = "Jen"
         }
+
         init(points: Int, name: String) {
             self.points = points
             self.player = name
@@ -595,6 +593,20 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         }
     }
 
+    func testIsDirtyForKey() throws {
+        var score = GameScore(objectId: "hello")
+        score.objectId = "world"
+        score.points = 15
+        XCTAssertFalse(try score.isDirtyForKey(\.points))
+        score = score.set(\.points, to: 20)
+        XCTAssertTrue(try score.isDirtyForKey(\.points))
+        score = score.set(\.points, to: 15)
+        XCTAssertFalse(try score.isDirtyForKey(\.points))
+        XCTAssertFalse(try score.isDirtyForKey(\.player))
+        score = score.set(\.player, to: "yolo")
+        XCTAssertTrue(try score.isDirtyForKey(\.player))
+    }
+
     func testFetchCommand() {
         var score = GameScore(points: 10)
         let className = score.className
@@ -724,7 +736,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
             return MockURLResponse(data: encoded, statusCode: 200, delay: 0.0)
         }
         do {
-            var fetched = GameScore(objectId: score.objectId)
+            var fetched = GameScore(objectId: objectId)
             fetched = try fetched.fetch(options: [])
             XCTAssert(fetched.hasSameObjectId(as: scoreOnServer))
             guard let fetchedCreatedAt = fetched.createdAt,

--- a/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
@@ -23,14 +23,11 @@ class ParseQueryViewModelTests: XCTestCase {
         //: Your own properties
         var points: Int = 0
 
-        //custom initializer
+        // Custom initializer
         init() {}
+
         init(points: Int) {
             self.points = points
-        }
-
-        init(objectId: String?) {
-            self.objectId = objectId
         }
     }
 

--- a/Tests/ParseSwiftTests/ParseSchemaTests.swift
+++ b/Tests/ParseSwiftTests/ParseSchemaTests.swift
@@ -42,11 +42,13 @@ class ParseSchemaTests: XCTestCase { // swiftlint:disable:this type_body_length
         //: Your own properties
         var points: Int?
 
-        //: a custom initializer
+        //: Custom initializers
         init() { }
+
         init(points: Int) {
             self.points = points
         }
+
         init(objectId: String, points: Int) {
             self.objectId = objectId
             self.points = points


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Currently a developer has to write extra code to determine if a `ParseObject` has a dirty key.

### Approach
<!-- Add a description of the approach in this PR. -->
Add the following extensions to check a dirty `KeyPath`:

```swift
public extension ParseObject {

      /**
      Get whether a value associated with a `KeyPath` has been added/updated on the client, but has
      not been updated on a Parse Server.
      - parameter keyPath: The `KeyPath` of the value to check.
      - throws: An error of type `ParseError`.
      - returns: **true** if the `KeyPath` is dirty, **false** otherwise.
      - important: In order for a `KeyPath` to be considered dirty, the respective `ParseObject` needs to
      first be saved to a Parse Server and fetched locally.
      - note: This method should only be used after updating a `ParseObject` using `.set()` or
      `.mergeable` otherwide it will always return **false**.
      */
     func isDirtyForKey<W>(_ keyPath: KeyPath<Self, W?>) throws -> Bool where W: Equatable {
         guard let originalData = originalData else {
             return false
         }
         let original = try ParseCoding.jsonDecoder().decode(Self.self,
                                                             from: originalData)
         return self[keyPath: keyPath] != original[keyPath: keyPath]
     }

     /**
      Creates a `ParseObject` with a specified `objectId`. Can be used to create references or associations
      between `ParseObject`'s.
      - warning: It is required that all added properties be optional properties so they can eventually be used as
      Parse `Pointer`'s. If a developer really wants to have a required key, they should require it on the server-side or
      create methods to check the respective properties on the client-side before saving objects. See
      [here](https://github.com/parse-community/Parse-Swift/pull/315#issuecomment-1014701003)
      for more information.
      */
     init(objectId: String) {
         self.init()
         self.objectId = objectId
     }
}
```

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
