### PR TITLE
fix: restore name after updating ParseRole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 __New features__
 - Added the ability to check if a `ParseObject` key is dirty ([#9](https://github.com/netreconlab/Parse-Swift/pull/9)), thanks to [Corey Baker](https://github.com/cbaker6).
 
+__Fixes__
+- Fixed an issue where the name propery of a ParseRole may not be restored after updating a ParseRole on the server ([#10](https://github.com/netreconlab/Parse-Swift/pull/10)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 4.15.2
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/4.15.1...4.15.2), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/4.15.2/documentation/parseswift)
 

--- a/ParseSwift.playground/Pages/12 - Roles and Relations.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/12 - Roles and Relations.xcplaygroundpage/Contents.swift
@@ -58,15 +58,18 @@ struct Role<RoleUser: ParseUser>: ParseRole {
     //: Provided by Role.
     var name: String?
 
+    //: Custom properties.
+    var subtitle: String
+
     /*:
      Optional - implement your own version of merge
      for faster decoding after updating your `ParseObject`.
      */
     func merge(with object: Self) throws -> Self {
         var updated = try mergeParse(with: object)
-        if updated.shouldRestoreKey(\.name,
+        if updated.shouldRestoreKey(\.subtitle,
                                      original: object) {
-            updated.name = object.name
+            updated.subtitle = object.subtitle
         }
         return updated
     }
@@ -124,7 +127,8 @@ acl.setWriteAccess(user: currentUser, value: true)
 
 do {
     //: Create the actual Role with a name and ACL.
-    let adminRole = try Role<User>(name: "Administrator", acl: acl)
+    var adminRole = try Role<User>(name: "Administrator", acl: acl)
+    adminRole.subtitle = "staff"
     adminRole.save { result in
         switch result {
         case .success(let saved):
@@ -166,7 +170,10 @@ do {
     print("Error: \(error)")
 }
 
-//: To retrieve the users who are all Administrators, we need to query the relation.
+/*:
+ To retrieve the users who are all Administrators,
+ we need to query the relation.
+ */
 do {
     let query: Query<User>? = try savedRole!.users?.query()
     query?.find { result in
@@ -201,8 +208,10 @@ do {
     print(error)
 }
 
-//: Additional roles can be created and tied to already created roles. Lets create a "Member" role.
-
+/*:
+ Additional roles can be created and tied to already created roles.
+ Lets create a "Member" role.
+*/
 //: This variable will store the saved role.
 var savedRoleModerator: Role<User>?
 
@@ -233,8 +242,12 @@ if savedRoleModerator != nil {
 
 //: Roles can be added to our previously saved Role.
 do {
-    //: `ParseRoles` have `ParseRelations` that relate them either `ParseUser` and `ParseRole` objects.
-    //: The `ParseUser` relations can be accessed using `users`. We can then add `ParseUser`'s to the relation.
+    /*:
+     `ParseRoles` have `ParseRelations` that relate them either
+     `ParseUser` and `ParseRole` objects. The `ParseUser`
+     relations can be accessed using `users`. We can then add
+     `ParseUser`'s to the relation.
+     */
     try savedRole!.roles?.add([savedRoleModerator!]).save { result in
         switch result {
         case .success(let saved):
@@ -249,8 +262,11 @@ do {
     print("Error: \(error)")
 }
 
-//: To retrieve the users who are all Administrators, we need to query the relation.
-//: This time we will use a helper query from `ParseRole`.
+/*:
+ To retrieve the users who are all Administrators,
+ we need to query the relation. This time we will
+ use a helper query from `ParseRole`.
+ */
 do {
     try savedRole!.queryRoles().find { result in
         switch result {
@@ -284,10 +300,12 @@ do {
     print(error)
 }
 
-//: Using this relation, you can create one-to-many relationships with other `ParseObjecs`,
-//: similar to `users` and `roles`.
-//: All `ParseObject`s have a `ParseRelation` attribute that be used on instances.
-//: For example, the User has:
+/*:
+ Using this relation, you can create one-to-many relationships
+ with other `ParseObjecs`, similar to `users` and `roles`. All
+ `ParseObject`s have a `ParseRelation` attribute that be used on
+ instances. For example, the User has:
+ */
 var relation = User.current!.relation
 let score1 = GameScore(points: 53)
 let score2 = GameScore(points: 57)

--- a/ParseSwift.playground/Pages/5 - ACL.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/5 - ACL.xcplaygroundpage/Contents.swift
@@ -60,9 +60,10 @@ extension GameScore {
 //: Define initial GameScores.
 var score = GameScore(points: 40)
 
-/*: Save asynchronously (preferred way) - Performs work on background
-    queue and returns to specified callbackQueue.
-    If no callbackQueue is specified it returns to main queue.
+/*:
+ Save asynchronously (preferred way) - Performs work on background
+ queue and returns to specified callbackQueue. If no callbackQueue
+ is specified it returns to main queue.
 */
 score.save { result in
     switch result {

--- a/Sources/ParseSwift/Objects/ParseRole.swift
+++ b/Sources/ParseSwift/Objects/ParseRole.swift
@@ -101,6 +101,31 @@ public extension ParseRole {
         let name = self.name ?? self.objectId
         hasher.combine(name)
     }
+
+    func mergeParse(with object: Self) throws -> Self {
+        guard hasSameObjectId(as: object) else {
+            throw ParseError(code: .unknownError,
+                             message: "objectId's of objects do not match")
+        }
+        var updatedUser = self
+        if shouldRestoreKey(\.ACL,
+                             original: object) {
+            updatedUser.ACL = object.ACL
+        }
+        if shouldRestoreKey(\.name,
+                             original: object) {
+            updatedUser.name = object.name
+        }
+        return updatedUser
+    }
+
+    func merge(with object: Self) throws -> Self {
+        do {
+            return try mergeAutomatically(object)
+        } catch {
+            return try mergeParse(with: object)
+        }
+    }
 }
 
 // MARK: Convenience

--- a/Sources/ParseSwift/Objects/ParseRole.swift
+++ b/Sources/ParseSwift/Objects/ParseRole.swift
@@ -107,16 +107,16 @@ public extension ParseRole {
             throw ParseError(code: .unknownError,
                              message: "objectId's of objects do not match")
         }
-        var updatedUser = self
+        var updatedRole = self
         if shouldRestoreKey(\.ACL,
                              original: object) {
-            updatedUser.ACL = object.ACL
+            updatedRole.ACL = object.ACL
         }
         if shouldRestoreKey(\.name,
                              original: object) {
-            updatedUser.name = object.name
+            updatedRole.name = object.name
         }
-        return updatedUser
+        return updatedRole
     }
 
     func merge(with object: Self) throws -> Self {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
When a developer implements their own `merge()` function for a `ParseRole`, they currently have to add the `name` key into their method for it to be restored properly.

### Approach
<!-- Add a description of the approach in this PR. -->
Add the `name` property into the `mergeParse()` check so the developer doesn't have to add it.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
