### PR TITLE
fix: query findAll() throwing hang risk warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/4.16.0...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/4.16.1...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 4.16.0
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/4.16.0...4.16.1), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/4.16.1/documentation/parseswift)
+
+__Fixes__
+- Querying using findAll throws a hang risk warning in Xcode 14 ([#14](https://github.com/netreconlab/Parse-Swift/pull/10)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 4.16.0
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/4.15.2...4.16.0), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/4.16.0/documentation/parseswift)

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "4.16.0"
+    static let version = "4.16.1"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
`findAll` on older versions of Swift needed to run synchronously to fetch results. This causes newer versions of Xcode to throw warnings.

Close #13 

### Approach
<!-- Add a description of the approach in this PR. -->
Use async/await on newer versions of Swift for `findAll()`

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
