### PR TITLE
ci: bump windows swift toolchain

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 <!--
     Please check the following boxes [x] before submitting your issue.
     Click the "Preview" tab for better readability.
-    Thanks for contributing to Parse Platform!
+    Thanks for contributing to Parse-Swift!
 -->
 
 - [ ] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
@@ -10,8 +10,6 @@
 
 ### Issue Description
 <!-- Add a brief description of the issue this PR solves. -->
-
-Related issue: #`FILL_THIS_OUT`
 
 ### Approach
 <!-- Add a description of the approach in this PR. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
           tag: 5.7.1-RELEASE
       - name: Build
         run: |
-          swift test --enable-test-discovery --enable-code-coverage -v
+          swift build -v
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,11 +219,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: compnerd/gha-setup-swift@v0.0.1
         with:
-          branch: swift-5.6.3-release
-          tag: 5.6.3-RELEASE
+          branch: swift-5.7.1-release
+          tag: 5.7.1-RELEASE
       - name: Build
         run: |
-          swift build -v
+          swift test --enable-test-discovery --enable-code-coverage -v
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse Platform!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Windows toolchain in CI is outdated

### Approach
<!-- Add a description of the approach in this PR. -->
Bump windows toolchain for windows

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] All tests pass
