### PR TITLE
feat: Add user login related attempts to ParseCloudUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ deprecation warnings when building your app in Xcode before upgrading
 to [Corey Baker](https://github.com/cbaker6).
 
 __New features__
+* Add user login related attempts to ParseCloudUser. This allows developers to decode login related information when using Parse-Swift for Cloud Code ([#51](https://github.com/netreconlab/Parse-Swift/pull/51)), thanks to [Corey Baker](https://github.com/cbaker6).
 * Add option to set the serverURL for a particular call. This is useful when using the Swift SDK for Cloud Code in a multi-server environment ([#50](https://github.com/netreconlab/Parse-Swift/pull/50)), thanks to [Corey Baker](https://github.com/cbaker6).
 * ParseVersion now supports pre-release versions of the SDK ([#49](https://github.com/netreconlab/Parse-Swift/pull/49)), thanks to [Corey Baker](https://github.com/cbaker6).
 * Adds the the ability to watch particular keys with LiveQueries. Requires Parse-Server 6.0.0 ([#48](https://github.com/netreconlab/Parse-Swift/pull/48)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 
 ---
 
+[![Documentation](http://img.shields.io/badge/read_the-docs-2196f3.svg)](https://swiftpackageindex.com/netreconlab/Parse-Swift/documentation)
+[![Playgrounds](http://img.shields.io/badge/read_the-playgrounds-2196f3.svg)](https://github.com/netreconlab/Parse-Swift/tree/main/ParseSwift.playground/Pages)
+[![Tuturiol](http://img.shields.io/badge/read_the-tuturials-2196f3.svg)](https://netreconlab.github.io/Parse-Swift/release/tutorials/parseswift/)
 [![Build Status CI](https://github.com/netreconlab/Parse-Swift/workflows/ci/badge.svg?branch=main)](https://github.com/netreconlab/Parse-Swift/actions?query=workflow%3Aci+branch%3Amain)
 [![Build Status Release](https://github.com/netreconlab/Parse-Swift/workflows/release/badge.svg)](https://github.com/netreconlab/Parse-Swift/actions?query=workflow%3Arelease)
 [![Coverage](https://codecov.io/gh/netreconlab/Parse-Swift/branch/main/graph/badge.svg)](https://codecov.io/gh/netreconlab/Parse-Swift/branches)

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 ---
 
-[![Documentation](http://img.shields.io/badge/read_the-docs-2196f3.svg)](https://swiftpackageindex.com/netreconlab/Parse-Swift/documentation)
 [![Playgrounds](http://img.shields.io/badge/swift-playgrounds-2196f3.svg)](https://github.com/netreconlab/Parse-Swift/tree/main/ParseSwift.playground/Pages)
-[![Tuturiol](http://img.shields.io/badge/read_the-tuturials-2196f3.svg)](https://netreconlab.github.io/Parse-Swift/release/tutorials/parseswift/)
+[![Documentation](http://img.shields.io/badge/read_-docs-2196f3.svg)](https://swiftpackageindex.com/netreconlab/Parse-Swift/documentation)
+[![Tuturiol](http://img.shields.io/badge/read_-tuturials-2196f3.svg)](https://netreconlab.github.io/Parse-Swift/release/tutorials/parseswift/)
 [![Build Status CI](https://github.com/netreconlab/Parse-Swift/workflows/ci/badge.svg?branch=main)](https://github.com/netreconlab/Parse-Swift/actions?query=workflow%3Aci+branch%3Amain)
 [![Build Status Release](https://github.com/netreconlab/Parse-Swift/workflows/release/badge.svg)](https://github.com/netreconlab/Parse-Swift/actions?query=workflow%3Arelease)
 [![Coverage](https://codecov.io/gh/netreconlab/Parse-Swift/branch/main/graph/badge.svg)](https://codecov.io/gh/netreconlab/Parse-Swift/branches)

--- a/README.md
+++ b/README.md
@@ -6,15 +6,13 @@
 ---
 
 [![Documentation](http://img.shields.io/badge/read_the-docs-2196f3.svg)](https://swiftpackageindex.com/netreconlab/Parse-Swift/documentation)
-[![Playgrounds](http://img.shields.io/badge/read_the-playgrounds-2196f3.svg)](https://github.com/netreconlab/Parse-Swift/tree/main/ParseSwift.playground/Pages)
+[![Playgrounds](http://img.shields.io/badge/swift-playgrounds-2196f3.svg)](https://github.com/netreconlab/Parse-Swift/tree/main/ParseSwift.playground/Pages)
 [![Tuturiol](http://img.shields.io/badge/read_the-tuturials-2196f3.svg)](https://netreconlab.github.io/Parse-Swift/release/tutorials/parseswift/)
 [![Build Status CI](https://github.com/netreconlab/Parse-Swift/workflows/ci/badge.svg?branch=main)](https://github.com/netreconlab/Parse-Swift/actions?query=workflow%3Aci+branch%3Amain)
 [![Build Status Release](https://github.com/netreconlab/Parse-Swift/workflows/release/badge.svg)](https://github.com/netreconlab/Parse-Swift/actions?query=workflow%3Arelease)
 [![Coverage](https://codecov.io/gh/netreconlab/Parse-Swift/branch/main/graph/badge.svg)](https://codecov.io/gh/netreconlab/Parse-Swift/branches)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/403b74d0f2514e288b0a1b2e52b6d841)](https://www.codacy.com/gh/netreconlab/Parse-Swift/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=netreconlab/Parse-Swift&amp;utm_campaign=Badge_Grade)
-[![Carthage](https://img.shields.io/badge/carthage-compatible-4BC51D.svg?style=flat)](https://github.com/carthage/carthage)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)][license-link]
-
 [![Swift Versions](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fnetreconlab%2FParse-Swift%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/netreconlab/Parse-Swift)
 [![Platforms](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fnetreconlab%2FParse-Swift%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/netreconlab/Parse-Swift)
 

--- a/Sources/ParseSwift/Objects/ParseCloudUser.swift
+++ b/Sources/ParseSwift/Objects/ParseCloudUser.swift
@@ -15,4 +15,9 @@ import Foundation
 public protocol ParseCloudUser: ParseUser {
     /// The session token of the `ParseUser`.
     var sessionToken: String? { get set }
+    /// The number of unsuccessful login attempts.
+    var _failed_login_count: Int? { get }
+    /// The date the lockout expires. After this date, the `ParseUser`
+    /// can attempt to login again.
+    var _account_lockout_expires_at: Date? { get }
 }

--- a/Tests/ParseSwiftTests/ParseHookFunctionRequestCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionRequestCombineTests.swift
@@ -33,8 +33,12 @@ class ParseHookFunctionRequestCombineTests: XCTestCase {
         var emailVerified: Bool?
         var password: String?
         var authData: [String: [String: String]?]?
+        
+        // These are required by ParseCloudUser
         var sessionToken: String?
-
+        var _failed_login_count: Int?
+        var _account_lockout_expires_at: Date?
+        
         // Your custom keys
         var customKey: String?
 

--- a/Tests/ParseSwiftTests/ParseHookFunctionRequestCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionRequestCombineTests.swift
@@ -33,12 +33,12 @@ class ParseHookFunctionRequestCombineTests: XCTestCase {
         var emailVerified: Bool?
         var password: String?
         var authData: [String: [String: String]?]?
-        
+
         // These are required by ParseCloudUser
         var sessionToken: String?
         var _failed_login_count: Int?
         var _account_lockout_expires_at: Date?
-        
+
         // Your custom keys
         var customKey: String?
 

--- a/Tests/ParseSwiftTests/ParseHookFunctionRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionRequestTests.swift
@@ -35,7 +35,11 @@ class ParseHookFunctionRequestTests: XCTestCase {
         var emailVerified: Bool?
         var password: String?
         var authData: [String: [String: String]?]?
+        
+        // These are required by ParseCloudUser
         var sessionToken: String?
+        var _failed_login_count: Int?
+        var _account_lockout_expires_at: Date?
 
         // Your custom keys
         var customKey: String?

--- a/Tests/ParseSwiftTests/ParseHookFunctionRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionRequestTests.swift
@@ -35,7 +35,7 @@ class ParseHookFunctionRequestTests: XCTestCase {
         var emailVerified: Bool?
         var password: String?
         var authData: [String: [String: String]?]?
-        
+
         // These are required by ParseCloudUser
         var sessionToken: String?
         var _failed_login_count: Int?

--- a/Tests/ParseSwiftTests/ParseHookTriggerRequestCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerRequestCombineTests.swift
@@ -30,7 +30,7 @@ class ParseHookTriggerRequestCombineTests: XCTestCase {
         var emailVerified: Bool?
         var password: String?
         var authData: [String: [String: String]?]?
-        
+
         // These are required by ParseCloudUser
         var sessionToken: String?
         var _failed_login_count: Int?

--- a/Tests/ParseSwiftTests/ParseHookTriggerRequestCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerRequestCombineTests.swift
@@ -30,7 +30,11 @@ class ParseHookTriggerRequestCombineTests: XCTestCase {
         var emailVerified: Bool?
         var password: String?
         var authData: [String: [String: String]?]?
+        
+        // These are required by ParseCloudUser
         var sessionToken: String?
+        var _failed_login_count: Int?
+        var _account_lockout_expires_at: Date?
 
         // Your custom keys
         var customKey: String?

--- a/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
@@ -31,7 +31,11 @@ class ParseHookTriggerRequestTests: XCTestCase {
         var emailVerified: Bool?
         var password: String?
         var authData: [String: [String: String]?]?
+        
+        // These are required by ParseCloudUser
         var sessionToken: String?
+        var _failed_login_count: Int?
+        var _account_lockout_expires_at: Date?
 
         // Your custom keys
         var customKey: String?

--- a/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
@@ -31,7 +31,7 @@ class ParseHookTriggerRequestTests: XCTestCase {
         var emailVerified: Bool?
         var password: String?
         var authData: [String: [String: String]?]?
-        
+
         // These are required by ParseCloudUser
         var sessionToken: String?
         var _failed_login_count: Int?


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
`ParseCloudUser` is missing properties: `_failed_login_count` and `_account_lockout_expires_at`. These these can be added to a conforming type directly by the developer, adding them to the `ParseCloudUser` can ensure they are used correctly.

### Approach
<!-- Add a description of the approach in this PR. -->
Add `_failed_login_count` and `_account_lockout_expires_at` to `ParseCloudUser` as getters only, preventing them from being set from Cloud Code. The Parse Server has routes and checks to increment/delete these properties at the necessary time. In Cloud Code, the developer may need to read these values to make a decision.

Though these properties are not written in a Swifty way (they are not lowerCamelCase) they are left as-is to prevent writing encoding keys for `ParseCloudUser` as this is how they look on the Parse Server.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
