### PR TITLE
refactor: Switch mounting point for Playgrounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ __New features__
 * The max connection attempts for LiveQuery can now be changed when initializing the SDK ([#43](https://github.com/netreconlab/Parse-Swift/pull/43)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Fixes__
+* Refactored playground mount to be "/parse" instead "/1". Also do not require url when decoding a ParseFile ([#52](https://github.com/netreconlab/Parse-Swift/pull/52)), thanks to [Corey Baker](https://github.com/cbaker6).
 * Fixed issues that can cause cache misses when querying ([#46](https://github.com/netreconlab/Parse-Swift/pull/46)), thanks to [Corey Baker](https://github.com/cbaker6).
 * Fixed a threading issue with .current objects that can cause apps to crash 
 ([#45](https://github.com/netreconlab/Parse-Swift/pull/45)), thanks 

--- a/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
@@ -12,7 +12,7 @@ PlaygroundPage.current.needsIndefiniteExecution = true
 
 /*:
  Start your parse-server with:
- npm start -- --appId applicationId --clientKey clientKey --masterKey primaryKey --mountPath /1
+ npm start -- --appId applicationId --clientKey clientKey --masterKey primaryKey --mountPath /parse
 */
 
 do {

--- a/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/15 - Custom ObjectId.xcplaygroundpage/Contents.swift
@@ -14,7 +14,7 @@ PlaygroundPage.current.needsIndefiniteExecution = true
 
 /*:
  Start parse-server with:
- npm start -- --appId applicationId --clientKey clientKey --masterKey primaryKey --mountPath /1
+ npm start -- --appId applicationId --clientKey clientKey --masterKey primaryKey --mountPath /parse
 */
 
 do {

--- a/ParseSwift.playground/Pages/3 - User - Sign Up.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/3 - User - Sign Up.xcplaygroundpage/Contents.swift
@@ -54,7 +54,7 @@ struct User: ParseUser {
     queue and returns to specified callbackQueue.
     If no callbackQueue is specified it returns to main queue.
 */
-User.signup(username: "hello", password: "world") { results in
+User.signup(username: "hello", password: "TestMePass123^") { results in
 
     switch results {
     case .success(let user):
@@ -77,7 +77,7 @@ User.signup(username: "hello", password: "world") { results in
 
 //: You can verify the password of the user.
 //: Note that usingPost should be set to **true** on newer servers.
-User.verifyPassword(password: "world", usingPost: false) { results in
+User.verifyPassword(password: "TestMePass123^", usingPost: false) { results in
 
     switch results {
     case .success(let user):

--- a/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/4 - User - Continued.xcplaygroundpage/Contents.swift
@@ -124,7 +124,7 @@ do {
  queue and returns to specified callbackQueue.
  If no callbackQueue is specified it returns to main queue.
 */
-User.login(username: "hello", password: "world") { result in
+User.login(username: "hello", password: "TestMePass123^") { result in
 
     switch result {
     case .success(let user):
@@ -258,7 +258,7 @@ User.anonymous.login { result in
 //: Convert the anonymous user to a real new user.
 var currentUser2 = User.current
 currentUser2?.username = "bye"
-currentUser2?.password = "world"
+currentUser2?.password = "HelloMePass123^"
 currentUser2?.signup { result in
     switch result {
 

--- a/ParseSwift.playground/Sources/Common.swift
+++ b/ParseSwift.playground/Sources/Common.swift
@@ -5,7 +5,7 @@ public func initializeParse(customObjectId: Bool = false) throws {
     try ParseSwift.initialize(applicationId: "applicationId",
                               clientKey: "clientKey",
                               primaryKey: "primaryKey",
-                              serverURL: URL(string: "http://localhost:1337/1")!,
+                              serverURL: URL(string: "http://localhost:1337/parse")!,
                               requiringCustomObjectIds: customObjectId,
                               usingEqualQueryConstraint: false,
                               usingDataProtectionKeychain: false)

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.0.0-beta.4"
+    static let version = "5.0.0-beta.5"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Types/ParseFile.swift
+++ b/Sources/ParseSwift/Types/ParseFile.swift
@@ -206,7 +206,7 @@ extension ParseFile {
 extension ParseFile {
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
-        url = try values.decode(URL.self, forKey: .url)
+        url = try values.decodeIfPresent(URL.self, forKey: .url)
         name = try values.decode(String.self, forKey: .name)
         id = UUID()
     }

--- a/Sources/ParseSwift/Types/ParseHookFunctionRequest.swift
+++ b/Sources/ParseSwift/Types/ParseHookFunctionRequest.swift
@@ -21,6 +21,8 @@ public struct ParseHookFunctionRequest<U: ParseCloudUser, P: ParseHookParametabl
     public var installationId: String?
     public var ipAddress: String?
     public var headers: [String: String]?
+    /// The name of Parse Hook Function.
+    public var functionName: String?
     /**
      The `ParseHookParametable` object containing the parameters passed
      to the function.
@@ -33,7 +35,7 @@ public struct ParseHookFunctionRequest<U: ParseCloudUser, P: ParseHookParametabl
         case primaryKey = "master"
         case parameters = "params"
         case ipAddress = "ip"
-        case user, installationId,
+        case user, installationId, functionName,
              headers, log, context
     }
 }

--- a/Sources/ParseSwift/Types/ParseHookTriggerRequest.swift
+++ b/Sources/ParseSwift/Types/ParseHookTriggerRequest.swift
@@ -22,7 +22,7 @@ public struct ParseHookTriggerRequest<U: ParseCloudUser, T: ParseObject>: ParseH
     public var ipAddress: String?
     public var headers: [String: String]?
     /// The types of Parse Hook Trigger.
-    public var triggerName: ParseHookTriggerType?
+    public var triggerName: String?
     /// An object from the hook call.
     public var object: T?
     /// The results the query yielded..

--- a/Sources/ParseSwift/Types/ParseHookTriggerRequest.swift
+++ b/Sources/ParseSwift/Types/ParseHookTriggerRequest.swift
@@ -21,6 +21,8 @@ public struct ParseHookTriggerRequest<U: ParseCloudUser, T: ParseObject>: ParseH
     public var installationId: String?
     public var ipAddress: String?
     public var headers: [String: String]?
+    /// The types of Parse Hook Trigger.
+    public var triggerName: ParseHookTriggerType?
     /// An object from the hook call.
     public var object: T?
     /// The results the query yielded..
@@ -58,7 +60,7 @@ public struct ParseHookTriggerRequest<U: ParseCloudUser, T: ParseObject>: ParseH
              log, context, object, objects,
              original, query, file, fileSize,
              isGet, contentLength, clients,
-             subscriptions, sendEvent
+             subscriptions, sendEvent, triggerName
     }
 }
 

--- a/Tests/ParseSwiftTests/APICommandMultipleAttemptsTests.swift
+++ b/Tests/ParseSwiftTests/APICommandMultipleAttemptsTests.swift
@@ -34,7 +34,7 @@ class APICommandMultipleAttemptsTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/APICommandTests.swift
+++ b/Tests/ParseSwiftTests/APICommandTests.swift
@@ -30,7 +30,7 @@ class APICommandTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -126,7 +126,7 @@ class APICommandTests: XCTestCase {
     func testSetServerURLOption() throws {
         let serverURL1 = API.serverURL(options: [])
         XCTAssertEqual(Parse.configuration.serverURL, serverURL1)
-        let newServerURLString = "http://parse:1337/1"
+        let newServerURLString = "http://parse:1337/parse"
         let serverURL2 = API.serverURL(options: [.serverURL(newServerURLString)])
         XCTAssertNotEqual(Parse.configuration.serverURL, serverURL2)
         XCTAssertEqual(serverURL2, URL(string: newServerURLString))

--- a/Tests/ParseSwiftTests/ExtensionsTests.swift
+++ b/Tests/ParseSwiftTests/ExtensionsTests.swift
@@ -13,7 +13,7 @@ import XCTest
 class ExtensionsTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/IOS13Tests.swift
+++ b/Tests/ParseSwiftTests/IOS13Tests.swift
@@ -57,7 +57,7 @@ class IOS13Tests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -40,7 +40,7 @@ class InitializeSDKTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -153,7 +153,7 @@ class InitializeSDKTests: XCTestCase {
     #endif
 
     func testCreateParseInstallationOnInit() throws {
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -219,7 +219,7 @@ class InitializeSDKTests: XCTestCase {
         let expectation1 = XCTestExpectation(description: "Wait")
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
 
-            guard let url = URL(string: "http://localhost:1337/1") else {
+            guard let url = URL(string: "http://localhost:1337/parse") else {
                 XCTFail("Should create valid URL")
                 expectation1.fulfill()
                 return
@@ -265,7 +265,7 @@ class InitializeSDKTests: XCTestCase {
     #endif
 
     func testUpdateAuthChallenge() throws {
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -284,7 +284,7 @@ class InitializeSDKTests: XCTestCase {
 
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testDontOverwriteMigratedInstallation() throws {
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -313,7 +313,7 @@ class InitializeSDKTests: XCTestCase {
     }
 
     func testDontOverwriteOldInstallationBecauseVersionLess() throws {
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -349,7 +349,7 @@ class InitializeSDKTests: XCTestCase {
     }
 
     func testDontOverwriteOldInstallationBecauseVersionEqual() throws {
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -385,7 +385,7 @@ class InitializeSDKTests: XCTestCase {
     }
 
     func testDontOverwriteOldInstallationBecauseVersionGreater() throws {
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -423,7 +423,7 @@ class InitializeSDKTests: XCTestCase {
     #endif
 
     func testOverwriteOldInstallation() throws {
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -457,7 +457,7 @@ class InitializeSDKTests: XCTestCase {
     }
 
     func testMigrateObjcKeychainMissing() throws {
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -507,7 +507,7 @@ class InitializeSDKTests: XCTestCase {
         try? KeychainStore.old.set(aclContainer, for: ParseStorage.Keys.defaultACL)
         let expectation1 = XCTestExpectation(description: "Wait")
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            guard let url = URL(string: "http://localhost:1337/1") else {
+            guard let url = URL(string: "http://localhost:1337/parse") else {
                 XCTFail("Should create valid URL")
                 expectation1.fulfill()
                 return
@@ -539,7 +539,7 @@ class InitializeSDKTests: XCTestCase {
         let objcInstallationId = "helloWorld"
         _ = objcParseKeychain.setObjectiveC(object: objcInstallationId, forKey: "installationId")
 
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -560,7 +560,7 @@ class InitializeSDKTests: XCTestCase {
     #if !os(macOS)
     func testInitializeSDKNoTest() throws {
 
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -595,7 +595,7 @@ class InitializeSDKTests: XCTestCase {
         XCTAssertNil(retrievedInstallationId2)
 
         // This is needed for tear down
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -616,7 +616,7 @@ class InitializeSDKTests: XCTestCase {
         let objcInstallationId = "helloWorld"
         _ = objcParseKeychain.setObjectiveC(object: objcInstallationId, forKey: "anotherPlace")
 
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/KeychainStoreTests.swift
+++ b/Tests/ParseSwiftTests/KeychainStoreTests.swift
@@ -15,7 +15,7 @@ class KeychainStoreTests: XCTestCase {
     var testStore: KeychainStore!
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/MigrateObjCSDKCombineTests.swift
+++ b/Tests/ParseSwiftTests/MigrateObjCSDKCombineTests.swift
@@ -117,7 +117,7 @@ class MigrateObjCSDKCombineTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/MigrateObjCSDKTests.swift
+++ b/Tests/ParseSwiftTests/MigrateObjCSDKTests.swift
@@ -114,7 +114,7 @@ class MigrateObjCSDKTests: XCTestCase { // swiftlint:disable:this type_body_leng
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseACLTests.swift
+++ b/Tests/ParseSwiftTests/ParseACLTests.swift
@@ -16,7 +16,7 @@ class ParseACLTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseAnalyticsAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnalyticsAsyncTests.swift
@@ -17,7 +17,7 @@ import XCTest
 class ParseAnalyticsAsyncTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseAnalyticsCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnalyticsCombineTests.swift
@@ -17,7 +17,7 @@ class ParseAnalyticsCombineTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseAnalyticsTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnalyticsTests.swift
@@ -16,7 +16,7 @@ class ParseAnalyticsTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseAnonymousAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousAsyncTests.swift
@@ -65,7 +65,7 @@ class ParseAnonymousAsyncTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseAnonymousCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousCombineTests.swift
@@ -65,7 +65,7 @@ class ParseAnonymousCombineTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseAnonymousTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousTests.swift
@@ -70,7 +70,7 @@ class ParseAnonymousTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseAppleAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleAsyncTests.swift
@@ -66,7 +66,7 @@ class ParseAppleAsyncTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseAppleCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleCombineTests.swift
@@ -66,7 +66,7 @@ class ParseAppleCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseAppleTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleTests.swift
@@ -64,7 +64,7 @@ class ParseAppleTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseAuthenticationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationAsyncTests.swift
@@ -120,7 +120,7 @@ class ParseAuthenticationAsyncTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseAuthenticationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationCombineTests.swift
@@ -120,7 +120,7 @@ class ParseAuthenticationCombineTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
@@ -120,7 +120,7 @@ class ParseAuthenticationTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseBytesTests.swift
+++ b/Tests/ParseSwiftTests/ParseBytesTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class ParseBytesTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseCLPTests.swift
+++ b/Tests/ParseSwiftTests/ParseCLPTests.swift
@@ -49,7 +49,7 @@ class ParseCLPTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseCloudViewModelTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudViewModelTests.swift
@@ -25,7 +25,7 @@ class ParseCloudViewModelTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseCloudableAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudableAsyncTests.swift
@@ -28,7 +28,7 @@ class ParseCloudableAsyncTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseCloudableCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudableCombineTests.swift
@@ -28,7 +28,7 @@ class ParseCloudableCombineTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseCloudableTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudableTests.swift
@@ -42,7 +42,7 @@ class ParseCloudableTests: XCTestCase { // swiftlint:disable:this type_body_leng
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseConfigAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigAsyncTests.swift
@@ -74,7 +74,7 @@ class ParseConfigAsyncTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseConfigCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigCombineTests.swift
@@ -74,7 +74,7 @@ class ParseConfigCombineTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseConfigTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigTests.swift
@@ -71,7 +71,7 @@ class ParseConfigTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseErrorTests.swift
+++ b/Tests/ParseSwiftTests/ParseErrorTests.swift
@@ -14,7 +14,7 @@ class ParseErrorTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseFacebookAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookAsyncTests.swift
@@ -66,7 +66,7 @@ class ParseFacebookAsyncTests: XCTestCase { // swiftlint:disable:this type_body_
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookCombineTests.swift
@@ -66,7 +66,7 @@ class ParseFacebookCombineTests: XCTestCase { // swiftlint:disable:this type_bod
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseFacebookTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookTests.swift
@@ -64,7 +64,7 @@ class ParseFacebookTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseFileAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileAsyncTests.swift
@@ -24,7 +24,7 @@ class ParseFileAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -74,7 +74,7 @@ class ParseFileAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
     func testFetch() async throws {
 
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -109,7 +109,7 @@ class ParseFileAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
     func testFetchLoadFromRemote() async throws {
 
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -144,7 +144,7 @@ class ParseFileAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
     func testFetchLoadFromCacheNoCache() async throws {
 
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -167,7 +167,7 @@ class ParseFileAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
     func testFetchFileProgress() async throws {
 
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -206,7 +206,7 @@ class ParseFileAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         let parseFile = ParseFile(name: "sampleData.txt", data: sampleData)
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
             XCTFail("Should create URL")
             return
         }
@@ -236,7 +236,7 @@ class ParseFileAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
         let parseFile = ParseFile(name: "sampleData.txt", data: sampleData)
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
             XCTFail("Should create URL")
             return
         }
@@ -264,7 +264,7 @@ class ParseFileAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
     func testDelete() async throws {
 
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -290,7 +290,7 @@ class ParseFileAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
     @MainActor
     func testDeleteError () async throws {
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -326,7 +326,7 @@ class ParseFileAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
     @MainActor
     func testParseURLSessionDelegates() async throws {
         // swiftlint:disable:next line_length
-        let downloadTask = URLSession.shared.downloadTask(with: .init(fileURLWithPath: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg"))
+        let downloadTask = URLSession.shared.downloadTask(with: .init(fileURLWithPath: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg"))
         let task = downloadTask as URLSessionTask
         // swiftlint:disable:next line_length
         let uploadCompletion: ((URLSessionTask, Int64, Int64, Int64) -> Void) = { (_: URLSessionTask, _: Int64, _: Int64, _: Int64) -> Void in }
@@ -363,7 +363,7 @@ class ParseFileAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
     #if !os(iOS)
     func testParseURLSessionDelegateUpload() async throws {
         // swiftlint:disable:next line_length
-        let downloadTask = URLSession.shared.downloadTask(with: .init(fileURLWithPath: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg"))
+        let downloadTask = URLSession.shared.downloadTask(with: .init(fileURLWithPath: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg"))
         let task = downloadTask as URLSessionTask
         let queue = DispatchQueue.global(qos: .utility)
 
@@ -410,7 +410,7 @@ class ParseFileAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
 
     func testParseURLSessionDelegateDownload() async throws {
         // swiftlint:disable:next line_length
-        let downloadTask = URLSession.shared.downloadTask(with: .init(fileURLWithPath: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg"))
+        let downloadTask = URLSession.shared.downloadTask(with: .init(fileURLWithPath: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg"))
         let task = downloadTask as URLSessionTask
         let queue = DispatchQueue.global(qos: .utility)
         guard let fileManager = ParseFileManager(),
@@ -462,7 +462,7 @@ class ParseFileAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
 
     func testParseURLSessionDelegateStream() async throws {
         // swiftlint:disable:next line_length
-        let downloadTask = URLSession.shared.downloadTask(with: .init(fileURLWithPath: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg"))
+        let downloadTask = URLSession.shared.downloadTask(with: .init(fileURLWithPath: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg"))
         let task = downloadTask as URLSessionTask
         let queue = DispatchQueue.global(qos: .utility)
 

--- a/Tests/ParseSwiftTests/ParseFileCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileCombineTests.swift
@@ -24,7 +24,7 @@ class ParseFileCombineTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -73,7 +73,7 @@ class ParseFileCombineTests: XCTestCase {
         let expectation1 = XCTestExpectation(description: "Fetch")
 
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -117,7 +117,7 @@ class ParseFileCombineTests: XCTestCase {
         let expectation1 = XCTestExpectation(description: "Fetch")
 
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -168,7 +168,7 @@ class ParseFileCombineTests: XCTestCase {
         let parseFile = ParseFile(name: "sampleData.txt", data: sampleData)
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
             XCTFail("Should create URL")
             return
         }
@@ -212,7 +212,7 @@ class ParseFileCombineTests: XCTestCase {
         let parseFile = ParseFile(name: "sampleData.txt", data: sampleData)
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
             XCTFail("Should create URL")
             return
         }
@@ -253,7 +253,7 @@ class ParseFileCombineTests: XCTestCase {
         let expectation1 = XCTestExpectation(description: "Fetch")
 
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
             XCTFail("Should create URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseFileManagerTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileManagerTests.swift
@@ -19,7 +19,7 @@ class ParseFileManagerTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseFileTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileTests.swift
@@ -24,7 +24,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -229,7 +229,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
                                   tags: ["Hey": "now"])
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
             XCTFail("Should create URL")
             return
         }
@@ -257,7 +257,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         let parseFile = ParseFile(data: sampleData, mimeType: "application/txt")
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_file") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_file") else {
             XCTFail("Should create URL")
             return
         }
@@ -288,7 +288,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         let parseFile = ParseFile(name: "sampleData.txt", localURL: tempFilePath)
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
             XCTFail("Should create URL")
             return
         }
@@ -320,7 +320,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         let parseFile = ParseFile(name: "sampleData.data", localURL: tempFilePath)
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
             XCTFail("Should create URL")
             return
         }
@@ -352,7 +352,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         let parseFile = ParseFile(name: "sampleData.data", localURL: tempFilePath)
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
             XCTFail("Should create URL")
             return
         }
@@ -388,7 +388,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         let parseFile = ParseFile(name: "sampleData.data", localURL: tempFilePath)
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
             XCTFail("Should create URL")
             return
         }
@@ -439,7 +439,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         let parseFile = ParseFile(name: "sampleData.data", localURL: tempFilePath)
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
             XCTFail("Should create URL")
             return
         }
@@ -469,7 +469,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         let parseFile = ParseFile(name: "sampleData.txt", data: sampleData)
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
             XCTFail("Should create URL")
             return
         }
@@ -508,7 +508,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         let parseFile = ParseFile(name: "sampleData.txt", data: sampleData)
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
             XCTFail("Should create URL")
             return
         }
@@ -550,7 +550,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         let parseFile = ParseFile(name: "sampleData.txt", data: sampleData)
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
             XCTFail("Should create URL")
             return
         }
@@ -595,7 +595,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         let parseFile = ParseFile(data: sampleData, mimeType: "application/txt")
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_file") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_file") else {
             XCTFail("Should create URL")
             return
         }
@@ -638,7 +638,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         let parseFile = ParseFile(name: "sampleData.txt", localURL: tempFilePath)
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
             XCTFail("Should create URL")
             return
         }
@@ -695,7 +695,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
     #if compiler(<5.5.2)
     func testParseURLSessionDelegates() throws {
         // swiftlint:disable:next line_length
-        let dowloadTask = URLSession.shared.downloadTask(with: .init(fileURLWithPath: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg"))
+        let dowloadTask = URLSession.shared.downloadTask(with: .init(fileURLWithPath: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg"))
         let task = dowloadTask as URLSessionTask
         // swiftlint:disable:next line_length
         let uploadCompletion: ((URLSessionTask, Int64, Int64, Int64) -> Void) = { (_: URLSessionTask, _: Int64, _: Int64, _: Int64) -> Void in }
@@ -725,7 +725,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testParseURLSessionDelegateUpload() throws {
         // swiftlint:disable:next line_length
-        let downloadTask = URLSession.shared.downloadTask(with: .init(fileURLWithPath: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg"))
+        let downloadTask = URLSession.shared.downloadTask(with: .init(fileURLWithPath: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg"))
         let task = downloadTask as URLSessionTask
         let queue = DispatchQueue.global(qos: .utility)
 
@@ -765,7 +765,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testParseURLSessionDelegateDownload() throws {
         // swiftlint:disable:next line_length
-        let downloadTask = URLSession.shared.downloadTask(with: .init(fileURLWithPath: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg"))
+        let downloadTask = URLSession.shared.downloadTask(with: .init(fileURLWithPath: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg"))
         let task = downloadTask as URLSessionTask
         let queue = DispatchQueue.global(qos: .utility)
         guard let fileManager = ParseFileManager(),
@@ -812,7 +812,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testParseURLSessionDelegateStream() throws {
         // swiftlint:disable:next line_length
-        let downloadTask = URLSession.shared.downloadTask(with: .init(fileURLWithPath: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg"))
+        let downloadTask = URLSession.shared.downloadTask(with: .init(fileURLWithPath: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg"))
         let task = downloadTask as URLSessionTask
         let queue = DispatchQueue.global(qos: .utility)
 
@@ -849,7 +849,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
     // URL Mocker is not able to mock this in linux and tests fail, so do not run.
     func testFetchFileCancelAsync() throws {
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/7793939a2e59b98138c1bbf2412a060c_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/7793939a2e59b98138c1bbf2412a060c_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -894,7 +894,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
     func testFetchFileAysnc() throws {
 
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/7793939a2e59b98138c1bbf2412a060c_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/7793939a2e59b98138c1bbf2412a060c_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -933,7 +933,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testFetchFileProgressAsync() throws {
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/6f9988ab5faa28f7247664c6ffd9fd85_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/6f9988ab5faa28f7247664c6ffd9fd85_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -983,7 +983,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         let parseFile = ParseFile(name: "logo.svg", cloudURL: tempFilePath)
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_logo.svg") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -1029,7 +1029,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         let parseFile = ParseFile(name: "logo.svg", cloudURL: tempFilePath)
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_logo.svg") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -1071,7 +1071,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         let parseFile = ParseFile(name: "logo.svg", cloudURL: tempFilePath)
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_logo.svg") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -1096,7 +1096,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testFetchFile() throws {
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -1129,7 +1129,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testFetchFileLoadFromRemote() throws {
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -1162,7 +1162,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testFetchFileLoadFromCacheNoCache() throws {
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -1183,7 +1183,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testFetchFileWithDirectoryInName() throws {
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -1220,7 +1220,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testFetchFileProgress() throws {
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -1260,7 +1260,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testFetchFileProgressLoadFromRemote() throws {
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -1300,7 +1300,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testFetchFileProgressFromCacheNoCache() throws {
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -1325,7 +1325,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testDeleteFileAysnc() throws {
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/1b0683d529463e173cbf8046d7d9a613_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/1b0683d529463e173cbf8046d7d9a613_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -1358,7 +1358,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testDeleteFileAysncError() throws {
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/1b0683d529463e173cbf8046d7d9a613_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/1b0683d529463e173cbf8046d7d9a613_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -1390,7 +1390,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testDeleteFile() throws {
         // swiftlint:disable:next line_length
-        guard let parseFileURL = URL(string: "http://localhost:1337/1/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
+        guard let parseFileURL = URL(string: "http://localhost:1337/parse/files/applicationId/d3a37aed0672a024595b766f97133615_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -1422,7 +1422,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         let parseFile = ParseFile(name: "logo.svg", cloudURL: tempFilePath)
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_logo.svg") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_logo.svg") else {
             XCTFail("Should create URL")
             return
         }
@@ -1457,7 +1457,7 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         let parseFile = ParseFile(name: "logo.svg", cloudURL: tempFilePath)
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_logo.svg") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_logo.svg") else {
             XCTFail("Should create URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseFileTransferableTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileTransferableTests.swift
@@ -92,7 +92,7 @@ class ParseFileTransferableTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -139,7 +139,7 @@ class ParseFileTransferableTests: XCTestCase {
     }
 
     func testSDKInitializers() throws {
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -162,7 +162,7 @@ class ParseFileTransferableTests: XCTestCase {
     }
 
     func testMakeSuccessfulUploadResponse() throws {
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -192,7 +192,7 @@ class ParseFileTransferableTests: XCTestCase {
                                   tags: ["Hey": "now"])
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
             XCTFail("Should create URL")
             return
         }
@@ -222,7 +222,7 @@ class ParseFileTransferableTests: XCTestCase {
         let fileName = "sampleData.txt"
         let parseFile = ParseFile(name: fileName, localURL: tempFilePath)
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
             XCTFail("Should create URL")
             return
         }
@@ -254,7 +254,7 @@ class ParseFileTransferableTests: XCTestCase {
                                   tags: ["Hey": "now"])
 
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
             XCTFail("Should create URL")
             return
         }
@@ -283,7 +283,7 @@ class ParseFileTransferableTests: XCTestCase {
         let fileName = "sampleData.txt"
         let parseFile = ParseFile(name: fileName, localURL: tempFilePath)
         // swiftlint:disable:next line_length
-        guard let url = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
+        guard let url = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_sampleData.txt") else {
             XCTFail("Should create URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseGeoPointTests.swift
+++ b/Tests/ParseSwiftTests/ParseGeoPointTests.swift
@@ -15,7 +15,7 @@ import CoreLocation
 class ParseGeoPointTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseGitHubCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseGitHubCombineTests.swift
@@ -66,7 +66,7 @@ class ParseGitHubCombineTests: XCTestCase { // swiftlint:disable:this type_body_
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseGitHubTests.swift
+++ b/Tests/ParseSwiftTests/ParseGitHubTests.swift
@@ -65,7 +65,7 @@ class ParseGitHubTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseGoogleCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseGoogleCombineTests.swift
@@ -66,7 +66,7 @@ class ParseGoogleCombineTests: XCTestCase { // swiftlint:disable:this type_body_
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseGoogleTests.swift
+++ b/Tests/ParseSwiftTests/ParseGoogleTests.swift
@@ -65,7 +65,7 @@ class ParseGoogleTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseHealthAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseHealthAsyncTests.swift
@@ -17,7 +17,7 @@ import XCTest
 class ParseHealthAsyncTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseHealthCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseHealthCombineTests.swift
@@ -16,7 +16,7 @@ import Combine
 class ParseHealthCombineTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseHealthTests.swift
+++ b/Tests/ParseSwiftTests/ParseHealthTests.swift
@@ -14,7 +14,7 @@ class ParseHealthTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseHookFunctionCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionCombineTests.swift
@@ -21,7 +21,7 @@ class ParseHookFunctionCombineTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseHookFunctionRequestCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionRequestCombineTests.swift
@@ -55,7 +55,7 @@ class ParseHookFunctionRequestCombineTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseHookFunctionRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionRequestTests.swift
@@ -57,7 +57,7 @@ class ParseHookFunctionRequestTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseHookFunctionRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionRequestTests.swift
@@ -82,9 +82,10 @@ class ParseHookFunctionRequestTests: XCTestCase {
         let functionRequest = ParseHookFunctionRequest<User, Parameters>(primaryKey: true,
                                                                          ipAddress: "1.1.1.1",
                                                                          headers: ["yolo": "me"],
+                                                                         functionName: "wow",
                                                                          parameters: parameters)
         // swiftlint:disable:next line_length
-        let expected = "{\"headers\":{\"yolo\":\"me\"},\"ip\":\"1.1.1.1\",\"master\":true,\"params\":{\"hello\":\"world\"}}"
+        let expected = "{\"functionName\":\"wow\",\"headers\":{\"yolo\":\"me\"},\"ip\":\"1.1.1.1\",\"master\":true,\"params\":{\"hello\":\"world\"}}"
         XCTAssertEqual(functionRequest.description, expected)
     }
 

--- a/Tests/ParseSwiftTests/ParseHookFunctionTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionTests.swift
@@ -22,7 +22,7 @@ class ParseHookFunctionTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseHookResponseTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookResponseTests.swift
@@ -13,7 +13,7 @@ import XCTest
 class ParseHookResponseTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseHookTriggerCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerCombineTests.swift
@@ -24,7 +24,7 @@ class ParseHookTriggerCombineTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseHookTriggerRequestCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerRequestCombineTests.swift
@@ -52,7 +52,7 @@ class ParseHookTriggerRequestCombineTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
@@ -78,7 +78,7 @@ class ParseHookTriggerRequestTests: XCTestCase {
         let triggerRequest = ParseHookTriggerRequest<User, User>(primaryKey: true,
                                                                  ipAddress: "1.1.1.1",
                                                                  headers: ["yolo": "me"],
-                                                                 triggerName: .beforeDelete,
+                                                                 triggerName: "beforeDelete",
                                                                  object: object)
         // swiftlint:disable:next line_length
         let expected = "{\"headers\":{\"yolo\":\"me\"},\"ip\":\"1.1.1.1\",\"master\":true,\"object\":{\"objectId\":\"geez\"},\"triggerName\":\"beforeDelete\"}"

--- a/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
@@ -53,7 +53,7 @@ class ParseHookTriggerRequestTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
@@ -78,9 +78,10 @@ class ParseHookTriggerRequestTests: XCTestCase {
         let triggerRequest = ParseHookTriggerRequest<User, User>(primaryKey: true,
                                                                  ipAddress: "1.1.1.1",
                                                                  headers: ["yolo": "me"],
+                                                                 triggerName: .beforeDelete,
                                                                  object: object)
         // swiftlint:disable:next line_length
-        let expected = "{\"headers\":{\"yolo\":\"me\"},\"ip\":\"1.1.1.1\",\"master\":true,\"object\":{\"objectId\":\"geez\"}}"
+        let expected = "{\"headers\":{\"yolo\":\"me\"},\"ip\":\"1.1.1.1\",\"master\":true,\"object\":{\"objectId\":\"geez\"},\"triggerName\":\"beforeDelete\"}"
         XCTAssertEqual(triggerRequest.description, expected)
         let triggerRequest2 = ParseHookTriggerRequest<User, User>(ipAddress: "1.1.1.1",
                                                                   headers: ["yolo": "me"],

--- a/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
@@ -54,7 +54,7 @@ class ParseHookTriggerTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseInstagramAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstagramAsyncTests.swift
@@ -66,7 +66,7 @@ class ParseInstagramAsyncTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseInstagramCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstagramCombineTests.swift
@@ -66,7 +66,7 @@ class ParseInstagramCombineTests: XCTestCase { // swiftlint:disable:this type_bo
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseInstagramTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstagramTests.swift
@@ -67,7 +67,7 @@ class ParseInstagramTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseInstallationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationAsyncTests.swift
@@ -146,7 +146,7 @@ class ParseInstallationAsyncTests: XCTestCase { // swiftlint:disable:this type_b
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationCombineTests.swift
@@ -96,7 +96,7 @@ class ParseInstallationCombineTests: XCTestCase { // swiftlint:disable:this type
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -120,7 +120,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseKeychainAccessGroupTests.swift
+++ b/Tests/ParseSwiftTests/ParseKeychainAccessGroupTests.swift
@@ -113,7 +113,7 @@ class ParseKeychainAccessGroupTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseLDAPAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPAsyncTests.swift
@@ -66,7 +66,7 @@ class ParseLDAPAsyncTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseLDAPCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPCombineTests.swift
@@ -66,7 +66,7 @@ class ParseLDAPCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseLDAPTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPTests.swift
@@ -64,7 +64,7 @@ class ParseLDAPTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseLinkedInCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLinkedInCombineTests.swift
@@ -66,7 +66,7 @@ class ParseLinkedInCombineTests: XCTestCase { // swiftlint:disable:this type_bod
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseLinkedInTests.swift
+++ b/Tests/ParseSwiftTests/ParseLinkedInTests.swift
@@ -65,7 +65,7 @@ class ParseLinkedInTests: XCTestCase { // swiftlint:disable:this type_body_lengt
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseLiveQueryAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryAsyncTests.swift
@@ -17,7 +17,7 @@ import XCTest
 class ParseLiveQueryAsyncTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseLiveQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryCombineTests.swift
@@ -18,7 +18,7 @@ class ParseLiveQueryCombineTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -49,7 +49,7 @@ class ParseLiveQueryTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -74,7 +74,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testWebsocketURL() throws {
-        guard let originalURL = URL(string: "http://localhost:1337/1"),
+        guard let originalURL = URL(string: "http://localhost:1337/parse"),
             var components = URLComponents(url: originalURL,
                                              resolvingAgainstBaseURL: false) else {
             XCTFail("Should have retrieved URL components")
@@ -101,7 +101,7 @@ class ParseLiveQueryTests: XCTestCase {
     }
 
     func testInitializeWithNewURL() throws {
-        guard let originalURL = URL(string: "http://parse:1337/1"),
+        guard let originalURL = URL(string: "http://parse:1337/parse"),
             var components = URLComponents(url: originalURL,
                                              resolvingAgainstBaseURL: false) else {
             XCTFail("Should have retrieved URL components")

--- a/Tests/ParseSwiftTests/ParseObjectAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectAsyncTests.swift
@@ -324,7 +324,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -1762,7 +1762,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
         guard let cloudPath = URL(string: "https://parseplatform.org/img/logo.svg"),
               // swiftlint:disable:next line_length
-              let parseURL = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_logo.svg") else {
+              let parseURL = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_logo.svg") else {
             XCTFail("Should create URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
@@ -84,7 +84,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         let batch = API.Command<GameScore, GameScore>
             .batch(commands: [command], transaction: false)
         // swiftlint:disable:next line_length
-        let expected = "{\"body\":{\"requests\":[{\"body\":{\"other\":{\"__type\":\"Pointer\",\"className\":\"Game2\",\"objectId\":\"brave\"},\"points\":10},\"method\":\"PUT\",\"path\":\"\\/1\\/classes\\/GameScore\\/yolo\"}],\"transaction\":false},\"method\":\"POST\",\"path\":\"\\/batch\"}"
+        let expected = "{\"body\":{\"requests\":[{\"body\":{\"other\":{\"__type\":\"Pointer\",\"className\":\"Game2\",\"objectId\":\"brave\"},\"points\":10},\"method\":\"PUT\",\"path\":\"\\/parse\\/classes\\/GameScore\\/yolo\"}],\"transaction\":false},\"method\":\"POST\",\"path\":\"\\/batch\"}"
         let encoded = try ParseCoding.parseEncoder().encode(batch,
                                                             batching: true)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -105,7 +105,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         let batch = API.Command<GameScore, GameScore>
             .batch(commands: [command, command], transaction: false)
         // swiftlint:disable:next line_length
-        let expected = "{\"body\":{\"requests\":[{\"body\":{\"other\":{\"__type\":\"Pointer\",\"className\":\"Game2\",\"objectId\":\"brave\"},\"points\":10},\"method\":\"PUT\",\"path\":\"\\/1\\/classes\\/GameScore\\/yolo\"},{\"body\":{\"other\":{\"__type\":\"Pointer\",\"className\":\"Game2\",\"objectId\":\"brave\"},\"points\":10},\"method\":\"PUT\",\"path\":\"\\/1\\/classes\\/GameScore\\/yolo\"}],\"transaction\":false},\"method\":\"POST\",\"path\":\"\\/batch\"}"
+        let expected = "{\"body\":{\"requests\":[{\"body\":{\"other\":{\"__type\":\"Pointer\",\"className\":\"Game2\",\"objectId\":\"brave\"},\"points\":10},\"method\":\"PUT\",\"path\":\"\\/parse\\/classes\\/GameScore\\/yolo\"},{\"body\":{\"other\":{\"__type\":\"Pointer\",\"className\":\"Game2\",\"objectId\":\"brave\"},\"points\":10},\"method\":\"PUT\",\"path\":\"\\/parse\\/classes\\/GameScore\\/yolo\"}],\"transaction\":false},\"method\":\"POST\",\"path\":\"\\/batch\"}"
         let encoded = try ParseCoding.parseEncoder().encode(batch,
                                                             batching: true)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
@@ -539,7 +539,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
         }
         let body = BatchCommand(requests: commands, transaction: false)
         // swiftlint:disable:next line_length
-        let expected = "{\"requests\":[{\"body\":{\"points\":10},\"method\":\"PUT\",\"path\":\"\\/1\\/classes\\/GameScore\\/yarr\"},{\"body\":{\"points\":20},\"method\":\"PUT\",\"path\":\"\\/1\\/classes\\/GameScore\\/yolo\"}],\"transaction\":false}"
+        let expected = "{\"requests\":[{\"body\":{\"points\":10},\"method\":\"PUT\",\"path\":\"\\/parse\\/classes\\/GameScore\\/yarr\"},{\"body\":{\"points\":20},\"method\":\"PUT\",\"path\":\"\\/parse\\/classes\\/GameScore\\/yolo\"}],\"transaction\":false}"
 
         let encoded = try ParseCoding.parseEncoder()
             .encode(body,

--- a/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
@@ -50,7 +50,7 @@ class ParseObjectBatchTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseObjectCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCombineTests.swift
@@ -46,7 +46,7 @@ class ParseObjectCombineTests: XCTestCase { // swiftlint:disable:this type_body_
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
@@ -119,7 +119,7 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -317,7 +317,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -1995,7 +1995,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
 
         guard let cloudPath = URL(string: "https://parseplatform.org/img/logo.svg"),
               // swiftlint:disable:next line_length
-              let parseURL = URL(string: "http://localhost:1337/1/files/applicationId/89d74fcfa4faa5561799e5076593f67c_logo.svg") else {
+              let parseURL = URL(string: "http://localhost:1337/parse/files/applicationId/89d74fcfa4faa5561799e5076593f67c_logo.svg") else {
             XCTFail("Should create URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseOperationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationAsyncTests.swift
@@ -44,7 +44,7 @@ class ParseOperationAsyncTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseOperationCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationCombineTests.swift
@@ -44,7 +44,7 @@ class ParseOperationCombineTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseOperationTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationTests.swift
@@ -63,7 +63,7 @@ class ParseOperationTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParsePointerAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerAsyncTests.swift
@@ -40,7 +40,7 @@ class ParsePointerAsyncTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             throw ParseError(code: .otherCause, message: "Should create valid URL")
         }
         try ParseSwift.initialize(applicationId: "applicationId",

--- a/Tests/ParseSwiftTests/ParsePointerCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerCombineTests.swift
@@ -37,7 +37,7 @@ class ParsePointerCombineTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             throw ParseError(code: .otherCause, message: "Should create valid URL")
         }
         try ParseSwift.initialize(applicationId: "applicationId",

--- a/Tests/ParseSwiftTests/ParsePointerTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerTests.swift
@@ -39,7 +39,7 @@ class ParsePointerTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             throw ParseError(code: .otherCause, message: "Should create valid URL")
         }
         try ParseSwift.initialize(applicationId: "applicationId",

--- a/Tests/ParseSwiftTests/ParsePolygonTests.swift
+++ b/Tests/ParseSwiftTests/ParsePolygonTests.swift
@@ -18,7 +18,7 @@ class ParsePolygonTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParsePushAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParsePushAsyncTests.swift
@@ -49,7 +49,7 @@ class ParsePushAsyncTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParsePushCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParsePushCombineTests.swift
@@ -48,7 +48,7 @@ class ParsePushCombineTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParsePushPayloadAnyTests.swift
+++ b/Tests/ParseSwiftTests/ParsePushPayloadAnyTests.swift
@@ -16,7 +16,7 @@ class ParsePushPayloadAnyTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParsePushPayloadAppleTests.swift
+++ b/Tests/ParseSwiftTests/ParsePushPayloadAppleTests.swift
@@ -16,7 +16,7 @@ class ParsePushPayloadAppleTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParsePushPayloadFirebaseTests.swift
+++ b/Tests/ParseSwiftTests/ParsePushPayloadFirebaseTests.swift
@@ -16,7 +16,7 @@ class ParsePushPayloadFirebaseTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParsePushTests.swift
+++ b/Tests/ParseSwiftTests/ParsePushTests.swift
@@ -127,7 +127,7 @@ class ParsePushTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseQueryAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryAsyncTests.swift
@@ -51,7 +51,7 @@ class ParseQueryAsyncTests: XCTestCase { // swiftlint:disable:this type_body_len
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseQueryCacheTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryCacheTests.swift
@@ -57,7 +57,7 @@ class ParseQueryCacheTests: XCTestCase { // swiftlint:disable:this type_body_len
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryCombineTests.swift
@@ -49,7 +49,7 @@ class ParseQueryCombineTests: XCTestCase { // swiftlint:disable:this type_body_l
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -55,7 +55,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
@@ -35,7 +35,7 @@ class ParseQueryViewModelTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseRelationTests.swift
+++ b/Tests/ParseSwiftTests/ParseRelationTests.swift
@@ -81,7 +81,7 @@ class ParseRelationTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -105,7 +105,7 @@ class ParseRoleTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseSchemaAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseSchemaAsyncTests.swift
@@ -39,7 +39,7 @@ class ParseSchemaAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseSchemaCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseSchemaCombineTests.swift
@@ -38,7 +38,7 @@ class ParseSchemaCombineTests: XCTestCase { // swiftlint:disable:this type_body_
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseSchemaTests.swift
+++ b/Tests/ParseSwiftTests/ParseSchemaTests.swift
@@ -59,7 +59,7 @@ class ParseSchemaTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseSessionTests.swift
+++ b/Tests/ParseSwiftTests/ParseSessionTests.swift
@@ -57,7 +57,7 @@ class ParseSessionTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }
@@ -128,7 +128,7 @@ class ParseSessionTests: XCTestCase {
     }
 
     func testParseURLSessionCustomCertificatePinning() throws {
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseSpotifyAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseSpotifyAsyncTests.swift
@@ -66,7 +66,7 @@ class ParseSpotifyAsyncTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseSpotifyCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseSpotifyCombineTests.swift
@@ -66,7 +66,7 @@ class ParseSpotifyCombineTests: XCTestCase { // swiftlint:disable:this type_body
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseSpotifyTests.swift
+++ b/Tests/ParseSwiftTests/ParseSpotifyTests.swift
@@ -64,7 +64,7 @@ class ParseSpotifyTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseTwitterAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterAsyncTests.swift
@@ -66,7 +66,7 @@ class ParseTwitterAsyncTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseTwitterCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterCombineTests.swift
@@ -66,7 +66,7 @@ class ParseTwitterCombineTests: XCTestCase { // swiftlint:disable:this type_body
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseTwitterTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterTests.swift
@@ -64,7 +64,7 @@ class ParseTwitterTests: XCTestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseUserAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserAsyncTests.swift
@@ -122,7 +122,7 @@ class ParseUserAsyncTests: XCTestCase { // swiftlint:disable:this type_body_leng
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseUserCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserCombineTests.swift
@@ -74,7 +74,7 @@ class ParseUserCombineTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -110,7 +110,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }

--- a/Tests/ParseSwiftTests/ParseVersionTests.swift
+++ b/Tests/ParseSwiftTests/ParseVersionTests.swift
@@ -13,7 +13,7 @@ import XCTest
 class ParseVersionTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
-        guard let url = URL(string: "http://localhost:1337/1") else {
+        guard let url = URL(string: "http://localhost:1337/parse") else {
             XCTFail("Should create valid URL")
             return
         }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
The mounting point for playgrounds works more consistently when it's a String instead of an Int.

### Approach
<!-- Add a description of the approach in this PR. -->
- [x] Change the Playground mount from `/1` to `/parse`
- [x] Sometimes a `ParseFile` doesn't sent `url`. Make decoding `url` optional
- [x] Decode the functionName and triggerName when receiving Parse Hook requests.  

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
