### PR TITLE
fix: ParseAnalytics trackAppOpened had ambiguous inits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ __New features__
 * The max connection attempts for LiveQuery can now be changed when initializing the SDK ([#43](https://github.com/netreconlab/Parse-Swift/pull/43)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Fixes__
+* Fixed ambiguous ParseAnalytics trackAppOpenned ([#55](https://github.com/netreconlab/Parse-Swift/pull/55)), thanks to [Corey Baker](https://github.com/cbaker6).
 * Refactored playground mount to be "/parse" instead "/1". Also do not require url when decoding a ParseFile ([#52](https://github.com/netreconlab/Parse-Swift/pull/52)), thanks to [Corey Baker](https://github.com/cbaker6).
 * Fixed issues that can cause cache misses when querying ([#46](https://github.com/netreconlab/Parse-Swift/pull/46)), thanks to [Corey Baker](https://github.com/cbaker6).
 * Fixed a threading issue with .current objects that can cause apps to crash 

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.0.0-beta.6"
+    static let version = "5.0.0-beta.7"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Types/ParseAnalytics+async.swift
+++ b/Sources/ParseSwift/Types/ParseAnalytics+async.swift
@@ -18,6 +18,7 @@ public extension ParseAnalytics {
     // MARK: Aysnc/Await
 
     #if os(iOS)
+
     /**
      Tracks *asynchronously* this application being launched. If this happened as the result of the
      user opening a push notification, this method sends along information to
@@ -34,6 +35,7 @@ public extension ParseAnalytics {
     static func trackAppOpened(launchOptions: [UIApplication.LaunchOptionsKey: Any],
                                at date: Date? = nil,
                                options: API.Options = []) async throws {
+
         let result = try await withCheckedThrowingContinuation { continuation in
             Self.trackAppOpened(launchOptions: launchOptions,
                                 at: date,
@@ -43,7 +45,9 @@ public extension ParseAnalytics {
         if case let .failure(error) = result {
             throw error
         }
+
     }
+
     #endif
 
     /**

--- a/Sources/ParseSwift/Types/ParseAnalytics+async.swift
+++ b/Sources/ParseSwift/Types/ParseAnalytics+async.swift
@@ -31,7 +31,7 @@ public extension ParseAnalytics {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - throws: An error of type `ParseError`.
     */
-    static func trackAppOpened(launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil,
+    static func trackAppOpened(launchOptions: [UIApplication.LaunchOptionsKey: Any],
                                at date: Date? = nil,
                                options: API.Options = []) async throws {
         let result = try await withCheckedThrowingContinuation { continuation in

--- a/Sources/ParseSwift/Types/ParseAnalytics+combine.swift
+++ b/Sources/ParseSwift/Types/ParseAnalytics+combine.swift
@@ -19,6 +19,7 @@ public extension ParseAnalytics {
     // MARK: Combine
 
     #if os(iOS)
+
     /**
      Tracks *asynchronously* this application being launched. If this happened as the result of the
      user opening a push notification, this method sends along information to
@@ -35,6 +36,7 @@ public extension ParseAnalytics {
     static func trackAppOpenedPublisher(launchOptions: [UIApplication.LaunchOptionsKey: Any],
                                         at date: Date? = nil,
                                         options: API.Options = []) -> Future<Void, ParseError> {
+
         Future { promise in
             Self.trackAppOpened(launchOptions: launchOptions,
                                 at: date,
@@ -42,6 +44,7 @@ public extension ParseAnalytics {
                                 completion: promise)
         }
     }
+
     #endif
 
     /**

--- a/Sources/ParseSwift/Types/ParseAnalytics+combine.swift
+++ b/Sources/ParseSwift/Types/ParseAnalytics+combine.swift
@@ -32,7 +32,7 @@ public extension ParseAnalytics {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
     */
-    static func trackAppOpenedPublisher(launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil,
+    static func trackAppOpenedPublisher(launchOptions: [UIApplication.LaunchOptionsKey: Any],
                                         at date: Date? = nil,
                                         options: API.Options = []) -> Future<Void, ParseError> {
         Future { promise in

--- a/Sources/ParseSwift/Types/ParseAnalytics.swift
+++ b/Sources/ParseSwift/Types/ParseAnalytics.swift
@@ -99,7 +99,7 @@ public struct ParseAnalytics: ParseTypeable, Hashable {
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    static public func trackAppOpened(launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil,
+    static public func trackAppOpened(launchOptions: [UIApplication.LaunchOptionsKey: Any],
                                       at date: Date? = nil,
                                       options: API.Options = [],
                                       callbackQueue: DispatchQueue = .main,
@@ -107,7 +107,7 @@ public struct ParseAnalytics: ParseTypeable, Hashable {
         var options = options
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
         var userInfo: [String: String]?
-        if let remoteOptions = launchOptions?[.remoteNotification] as? [String: String] {
+        if let remoteOptions = launchOptions[.remoteNotification] as? [String: String] {
             userInfo = remoteOptions
         }
         let appOppened = ParseAnalytics(name: "AppOpened",

--- a/Sources/ParseSwift/Types/ParseAnalytics.swift
+++ b/Sources/ParseSwift/Types/ParseAnalytics.swift
@@ -82,6 +82,7 @@ public struct ParseAnalytics: ParseTypeable, Hashable {
     // MARK: Intents
 
     #if os(iOS)
+
     /**
      Tracks *asynchronously* this application being launched. If this happened as the result of the
      user opening a push notification, this method sends along information to
@@ -104,11 +105,15 @@ public struct ParseAnalytics: ParseTypeable, Hashable {
                                       options: API.Options = [],
                                       callbackQueue: DispatchQueue = .main,
                                       completion: @escaping (Result<Void, ParseError>) -> Void) {
+
         var options = options
         options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
-        var userInfo: [String: String]?
-        if let remoteOptions = launchOptions[.remoteNotification] as? [String: String] {
-            userInfo = remoteOptions
+        var userInfo = [String: String]()
+        launchOptions.forEach { (key, value) in
+            guard let value = value as? String else {
+                return
+            }
+            userInfo[key.rawValue] = value
         }
         let appOppened = ParseAnalytics(name: "AppOpened",
                                         dimensions: userInfo,

--- a/Tests/ParseSwiftTests/ParseAnalyticsTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnalyticsTests.swift
@@ -152,6 +152,32 @@ class ParseAnalyticsTests: XCTestCase {
         }
 
         let expectation = XCTestExpectation(description: "Analytics save")
+        let options = [UIApplication.LaunchOptionsKey.remoteNotification: "stop"]
+        ParseAnalytics.trackAppOpened(launchOptions: options) { result in
+
+            if case .failure(let error) = result {
+                XCTFail(error.localizedDescription)
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 10.0)
+    }
+
+    func testTrackAppOpenedUIKitNotStringValue() {
+        let serverResponse = NoBody()
+        let encoded: Data!
+        do {
+            encoded = try ParseCoding.jsonEncoder().encode(serverResponse)
+        } catch {
+            XCTFail("Should encode/decode. Error \(error)")
+            return
+        }
+
+        MockURLProtocol.mockRequests { _ in
+            return MockURLResponse(data: encoded, statusCode: 200)
+        }
+
+        let expectation = XCTestExpectation(description: "Analytics save")
         let options = [UIApplication.LaunchOptionsKey.remoteNotification: ["stop": "drop"]]
         ParseAnalytics.trackAppOpened(launchOptions: options) { result in
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
The two static method signatures for `ParseAnalytics.trackAppOpened` can appear to be ambiguous when not passing any arguments to them in `iOS` only. This is because all of the variables have default values. 

In previous versions, you will need to pass a value to first variable, `ParseAnalytics.trackAppOpenedPublisher(launchOptions: nil)` to differentiate the signature.

In addition, it's possible for none of the `launchOptions` to not be tracked depending on the dictionary passed in.

### Approach
<!-- Add a description of the approach in this PR. -->
- [x] Change `launchOptions` to not have a default value of `nil`, differentiating the method call
- [x] Check all key/values of `launchOptions` and track them if they are `[String: String]` 

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add entry to changelog
