### PR TITLE
fix: Query count and withCount always returning 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ __New features__
 * The max connection attempts for LiveQuery can now be changed when initializing the SDK ([#43](https://github.com/netreconlab/Parse-Swift/pull/43)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Fixes__
+* Fixed query count and withCount returning 0 when the SDK is configured to use GET for queries ([#61](https://github.com/netreconlab/Parse-Swift/pull/61)), thanks to [Corey Baker](https://github.com/cbaker6).
 * Fixed ambiguous ParseAnalytics trackAppOpenned ([#55](https://github.com/netreconlab/Parse-Swift/pull/55)), thanks to [Corey Baker](https://github.com/cbaker6).
 * Refactored playground mount to be "/parse" instead "/1". Also do not require url when decoding a ParseFile ([#52](https://github.com/netreconlab/Parse-Swift/pull/52)), thanks to [Corey Baker](https://github.com/cbaker6).
 * Fixed issues that can cause cache misses when querying ([#46](https://github.com/netreconlab/Parse-Swift/pull/46)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/2 - Finding Objects.xcplaygroundpage/Contents.swift
@@ -130,6 +130,20 @@ query.first { results in
 //: Query first asynchronously (preferred way) - Performs work on background
 //: queue and returns to specified callbackQueue.
 //: If no callbackQueue is specified it returns to main queue.
+query.count { results in
+    switch results {
+    case .success(let count):
+        print("Found total scores: \(count)")
+
+    case .failure(let error):
+        if error.containedIn([.objectNotFound, .invalidQuery]) {
+            assertionFailure("The query is invalid or the object is not found.")
+        } else {
+            assertionFailure("Error querying: \(error)")
+        }
+    }
+}
+
 query.withCount { results in
     switch results {
     case .success(let (score, count)):

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.0.0-beta.7"
+    static let version = "5.0.0-beta.8"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -1462,7 +1462,7 @@ extension Query {
         if !Parse.configuration.isUsingPostForQuery {
             return API.NonParseBodyCommand(method: .GET,
                                            path: query.endpoint,
-                                           params: try getQueryParameters()) {
+                                           params: try query.getQueryParameters()) {
                 if let decoded = try ParseCoding.jsonDecoder().decode(QueryResponse<T>.self, from: $0).results.first {
                     return decoded
                 }
@@ -1482,12 +1482,12 @@ extension Query {
 
     func countCommand() throws -> API.NonParseBodyCommand<Query<ResultType>, Int> {
         var query = self
-        query.limit = 1
+        query.limit = 0
         query.isCount = true
         if !Parse.configuration.isUsingPostForQuery {
             return API.NonParseBodyCommand(method: .GET,
                                            path: query.endpoint,
-                                           params: try getQueryParameters()) {
+                                           params: try query.getQueryParameters()) {
                 try ParseCoding.jsonDecoder().decode(QueryResponse<T>.self, from: $0).count ?? 0
             }
         } else {
@@ -1505,7 +1505,7 @@ extension Query {
         if !Parse.configuration.isUsingPostForQuery {
             return API.NonParseBodyCommand(method: .GET,
                                            path: query.endpoint,
-                                           params: try getQueryParameters()) {
+                                           params: try query.getQueryParameters()) {
                 let decoded = try ParseCoding.jsonDecoder().decode(QueryResponse<T>.self, from: $0)
                 return (decoded.results, decoded.count ?? 0)
             }

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -1018,7 +1018,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         let query = GameScore.query()
         let command = try query.countCommand()
         // swiftlint:disable:next line_length
-        let expected = "{\"body\":{\"_method\":\"GET\",\"count\":true,\"limit\":1,\"skip\":0,\"where\":{}},\"method\":\"POST\",\"path\":\"\\/classes\\/GameScore\"}"
+        let expected = "{\"body\":{\"_method\":\"GET\",\"count\":true,\"limit\":0,\"skip\":0,\"where\":{}},\"method\":\"POST\",\"path\":\"\\/classes\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()
             .encode(command)
         let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Query `count` and `withCount` always returns zero instead of the correct count when the SDK is configured to use `GET` instead of `POST` for queries.

A similar issue occurs when using the `first` query.

The workaround for older versions of ParseSwift is to configure the SDK to `usingPostForQuery: true`. The side-effect of the workaround is you can't cache future queries.

### Approach
<!-- Add a description of the approach in this PR. -->
Always use the mutated query for getting parameters instead of the original query.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
