### PR TITLE
fix: update requestId for Idempotency when resending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ __New features__
 * The max connection attempts for LiveQuery can now be changed when initializing the SDK ([#43](https://github.com/netreconlab/Parse-Swift/pull/43)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Fixes__
+* Fixed "Duplicate request" error when resending requests related to ipempotency ([#63](https://github.com/netreconlab/Parse-Swift/pull/63)), thanks to [Corey Baker](https://github.com/cbaker6).
 * Fixed query count and withCount returning 0 when the SDK is configured to use GET for queries ([#61](https://github.com/netreconlab/Parse-Swift/pull/61)), thanks to [Corey Baker](https://github.com/cbaker6).
 * Fixed ambiguous ParseAnalytics trackAppOpenned ([#55](https://github.com/netreconlab/Parse-Swift/pull/55)), thanks to [Corey Baker](https://github.com/cbaker6).
 * Refactored playground mount to be "/parse" instead "/1". Also do not require url when decoding a ParseFile ([#52](https://github.com/netreconlab/Parse-Swift/pull/52)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/Sources/ParseSwift/API/API.swift
+++ b/Sources/ParseSwift/API/API.swift
@@ -219,7 +219,7 @@ public struct API {
         }
 
         headers["X-Parse-Client-Version"] = clientVersion()
-        headers["X-Parse-Request-Id"] = UUID().uuidString.lowercased()
+        headers["X-Parse-Request-Id"] = Self.createUniqueRequestId()
 
         options.forEach { (option) in
             switch option {
@@ -255,6 +255,10 @@ public struct API {
         }
 
         return headers
+    }
+
+    internal static func createUniqueRequestId() -> String {
+        UUID().uuidString.lowercased()
     }
 
     internal static func clientVersion() -> String {

--- a/Sources/ParseSwift/Extensions/URLSession.swift
+++ b/Sources/ParseSwift/Extensions/URLSession.swift
@@ -213,6 +213,11 @@ internal extension URLSession {
                 }
 
                 callbackQueue.asyncAfter(deadline: .now() + delayInterval) {
+                    // Update requestId in header for Idempotency
+                    var request = request
+                    if request.allHTTPHeaderFields?["X-Parse-Request-Id"] != nil {
+                        request.allHTTPHeaderFields?["X-Parse-Request-Id"] = API.createUniqueRequestId()
+                    }
                     self.dataTask(with: request,
                                   callbackQueue: callbackQueue,
                                   attempts: attempts,

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.0.0-beta.8"
+    static let version = "5.0.0-beta.9"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
When resending requests after an error is thrown from the server, the same requestId is currently used. This can result in the parse-server throwing `Duplicate Request` when Idempotency is enabled on the server-side.

### Approach
<!-- Add a description of the approach in this PR. -->
When resending a request, update the requestId if a request currently contains a requestId since the original request was already handled by the server.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
