### PR TITLE
feat: Improve ParseError reporting by propagating Swift.Error

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,7 +6,7 @@ coverage:
   status:
     patch:
       default:
-        target: 82
+        target: auto
     changes: false
     project:
       default:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ deprecation warnings when building your app in Xcode before upgrading
 to [Corey Baker](https://github.com/cbaker6).
 
 __New features__
+* ParseError now has a new property called "swift" which is of type Swift.Error. This property will not be nil when the ParseError is really an OS error. This is intented to help developers improve error handeling by propagating the complete error ([#64](https://github.com/netreconlab/Parse-Swift/pull/64)), thanks to [Corey Baker](https://github.com/cbaker6).
 * Add user login related attempts to ParseCloudUser. This allows developers to decode login related information when using Parse-Swift for Cloud Code ([#51](https://github.com/netreconlab/Parse-Swift/pull/51)), thanks to [Corey Baker](https://github.com/cbaker6).
 * Add option to set the serverURL for a particular call. This is useful when using the Swift SDK for Cloud Code in a multi-server environment ([#50](https://github.com/netreconlab/Parse-Swift/pull/50)), thanks to [Corey Baker](https://github.com/cbaker6).
 * ParseVersion now supports pre-release versions of the SDK ([#49](https://github.com/netreconlab/Parse-Swift/pull/49)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/Sources/ParseSwift/API/API+Command.swift
+++ b/Sources/ParseSwift/API/API+Command.swift
@@ -528,8 +528,7 @@ internal extension API.Command where T: ParseObject {
                             return .success(updatedObject)
                         } catch {
                             guard let parseError = error as? ParseError else {
-                                return .failure(ParseError(code: .otherCause,
-                                                           message: error.localizedDescription))
+                                return .failure(ParseError(swift: error))
                             }
                             return .failure(parseError)
                         }

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseApple/ParseApple.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseApple/ParseApple.swift
@@ -75,7 +75,7 @@ public extension ParseApple {
         guard let appleAuthData = try? AuthenticationKeys.id.makeDictionary(user: user, identityToken: identityToken) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .otherCause,
-                                          message: "Could not create authData.")))
+                                          message: "Could not create \"authData\".")))
             }
             return
         }
@@ -92,7 +92,7 @@ public extension ParseApple {
         guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .otherCause,
-                                          message: "Should have authData in consisting of keys \"id\" and \"token\".")))
+                                          message: "Should have \"authData\" in consisting of keys \"id\" and \"token\".")))
             }
             return
         }
@@ -123,7 +123,7 @@ public extension ParseApple {
         guard let appleAuthData = try? AuthenticationKeys.id.makeDictionary(user: user, identityToken: identityToken) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .otherCause,
-                                          message: "Could not create authData.")))
+                                          message: "Could not create \"authData\".")))
             }
             return
         }
@@ -139,7 +139,7 @@ public extension ParseApple {
               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
         guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
             let error = ParseError(code: .otherCause,
-                                   message: "Should have authData in consisting of keys \"id\" and \"token\".")
+                                   message: "Should have \"authData\" in consisting of keys \"id\" and \"token\".")
             callbackQueue.async {
                 completion(.failure(error))
             }

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook/ParseFacebook.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseFacebook/ParseFacebook.swift
@@ -137,7 +137,7 @@ public extension ParseFacebook {
         guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .otherCause,
-                                          message: "Should have authData in consisting of keys \"id\", \"expirationDate\" and \"authenticationToken\" or \"accessToken\".")))
+                                          message: "Should have \"authData\" in consisting of keys \"id\", \"expirationDate\" and \"authenticationToken\" or \"accessToken\".")))
             }
             return
         }
@@ -211,7 +211,7 @@ public extension ParseFacebook {
         guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .otherCause,
-                                          message: "Should have authData in consisting of keys \"id\", \"expirationDate\" and \"authenticationToken\" or \"accessToken\".")))
+                                          message: "Should have \"authData\" in consisting of keys \"id\", \"expirationDate\" and \"authenticationToken\" or \"accessToken\".")))
             }
             return
         }

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseGithub/ParseGitHub.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseGithub/ParseGitHub.swift
@@ -88,7 +88,7 @@ public extension ParseGitHub {
         guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .otherCause,
-                                          message: "Should have authData in consisting of keys \"id\" and \"accessToken\".")))
+                                          message: "Should have \"authData\" in consisting of keys \"id\" and \"accessToken\".")))
             }
             return
         }
@@ -132,7 +132,7 @@ public extension ParseGitHub {
         guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .otherCause,
-                                          message: "Should have authData in consisting of keys \"id\" and \"accessToken\".")))
+                                          message: "Should have \"authData\" in consisting of keys \"id\" and \"accessToken\".")))
             }
             return
         }

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseGoogle/ParseGoogle.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseGoogle/ParseGoogle.swift
@@ -100,7 +100,7 @@ public extension ParseGoogle {
         guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .otherCause,
-                                          message: "Should have authData in consisting of keys \"id\", \"idToken\" or \"accessToken\".")))
+                                          message: "Should have \"authData\" in consisting of keys \"id\", \"idToken\" or \"accessToken\".")))
             }
             return
         }
@@ -147,7 +147,7 @@ public extension ParseGoogle {
         guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .otherCause,
-                                          message: "Should have authData in consisting of keys \"id\", \"idToken\" or \"accessToken\".")))
+                                          message: "Should have \"authData\" in consisting of keys \"id\", \"idToken\" or \"accessToken\".")))
             }
             return
         }

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseInstagram/ParseInstagram.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseInstagram/ParseInstagram.swift
@@ -99,7 +99,7 @@ public extension ParseInstagram {
         guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .otherCause,
-                                          message: "Should have authData in consisting of keys \"id\", \"accessToken\", and \"isMobileSDK\".")))
+                                          message: "Should have \"authData\" in consisting of keys \"id\", \"accessToken\", and \"isMobileSDK\".")))
             }
             return
         }
@@ -146,7 +146,7 @@ public extension ParseInstagram {
         guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .otherCause,
-                                          message: "Should have authData in consisting of keys \"id\", \"accessToken\", and \"isMobileSDK\".")))
+                                          message: "Should have \"authData\" in consisting of keys \"id\", \"accessToken\", and \"isMobileSDK\".")))
             }
             return
         }

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseLDAP/ParseLDAP.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseLDAP/ParseLDAP.swift
@@ -79,7 +79,7 @@ public extension ParseLDAP {
         guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .otherCause,
-                                          message: "Should have authData in consisting of keys \"id\" and \"password\".")))
+                                          message: "Should have \"authData\" in consisting of keys \"id\" and \"password\".")))
             }
             return
         }
@@ -119,7 +119,7 @@ public extension ParseLDAP {
               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
         guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
             let error = ParseError(code: .otherCause,
-                                   message: "Should have authData in consisting of keys \"id\" and \"password\".")
+                                   message: "Should have \"authData\" in consisting of keys \"id\" and \"password\".")
             callbackQueue.async {
                 completion(.failure(error))
             }

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseLinkedIn/ParseLinkedIn.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseLinkedIn/ParseLinkedIn.swift
@@ -94,7 +94,7 @@ public extension ParseLinkedIn {
         guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .otherCause,
-                                          message: "Should have authData in consisting of keys \"id\", \"accessToken\", and \"isMobileSDK\".")))
+                                          message: "Should have \"authData\" in consisting of keys \"id\", \"accessToken\", and \"isMobileSDK\".")))
             }
             return
         }
@@ -140,7 +140,7 @@ public extension ParseLinkedIn {
         guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .otherCause,
-                                          message: "Should have authData in consisting of keys \"id\", \"accessToken\", and \"isMobileSDK\".")))
+                                          message: "Should have \"authData\" in consisting of keys \"id\", \"accessToken\", and \"isMobileSDK\".")))
             }
             return
         }

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseSpotify/ParseSpotify.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseSpotify/ParseSpotify.swift
@@ -109,7 +109,7 @@ public extension ParseSpotify {
         guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .otherCause,
-                                          message: "Should have authData in consisting of keys \"id\" and \"accessToken\".")))
+                                          message: "Should have \"authData\" in consisting of keys \"id\" and \"accessToken\".")))
             }
             return
         }
@@ -159,7 +159,7 @@ public extension ParseSpotify {
         guard AuthenticationKeys.id.verifyMandatoryKeys(authData: authData) else {
             callbackQueue.async {
                 completion(.failure(.init(code: .otherCause,
-                                          message: "Should have authData in consisting of keys \"id\" and \"accessToken\".")))
+                                          message: "Should have \"authData\" in consisting of keys \"id\" and \"accessToken\".")))
             }
             return
         }

--- a/Sources/ParseSwift/Authentication/3rd Party/ParseTwitter/ParseTwitter.swift
+++ b/Sources/ParseSwift/Authentication/3rd Party/ParseTwitter/ParseTwitter.swift
@@ -120,7 +120,7 @@ public extension ParseTwitter {
                 completion(.failure(.init(code: .otherCause,
                                           message:
                                            """
-                                           Should have authData consisting of keys \"id,\"
+                                           Should have \"authData\" consisting of keys \"id,\"
                                            \"screenName,\" \"consumerKey,\" \"consumerSecret,\"
                                            \"authToken,\" and \"authTokenSecret\".
                                            """)))
@@ -179,7 +179,7 @@ public extension ParseTwitter {
             let error = ParseError(code: .otherCause,
                                    message:
                                     """
-                                    Should have authData consisting of keys \"id,\"
+                                    Should have \"authData\" consisting of keys \"id,\"
                                     \"screenName,\" \"consumerKey,\" \"consumerSecret,\"
                                     \"authToken,\" and \"authTokenSecret\".
                                     """)

--- a/Sources/ParseSwift/Authentication/Internal/ParseAnonymous.swift
+++ b/Sources/ParseSwift/Authentication/Internal/ParseAnonymous.swift
@@ -88,7 +88,8 @@ public extension ParseAnonymous {
               callbackQueue: DispatchQueue = .main,
               completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
         callbackQueue.async {
-            completion(.failure(ParseError(code: .otherCause, message: "Not supported")))
+            completion(.failure(ParseError(code: .otherCause,
+                                           message: "Not supported")))
         }
     }
 }

--- a/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
+++ b/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
@@ -199,7 +199,8 @@ public extension ParseAuthentication {
                 completion: @escaping (Result<AuthenticatedUser, ParseError>) -> Void) {
         Task {
             guard let current = try? await AuthenticatedUser.current() else {
-                let error = ParseError(code: .invalidLinkedSession, message: "No current ParseUser.")
+                let error = ParseError(code: .invalidLinkedSession,
+                                       message: "No current ParseUser.")
                 callbackQueue.async {
                     completion(.failure(error))
                 }
@@ -261,9 +262,7 @@ public extension ParseUser {
                                  callbackQueue: callbackQueue,
                                  completion: completion)
                 } catch {
-                    let defaultError = ParseError(code: .otherCause,
-                                                  message: error.localizedDescription)
-                    let parseError = error as? ParseError ?? defaultError
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
                         completion(.failure(parseError))
                     }
@@ -316,7 +315,8 @@ public extension ParseUser {
         let immutableOptions = options
         if self.isLinked(with: type) {
             guard let authData = self.strip(type).authData else {
-                let error = ParseError(code: .otherCause, message: "Missing authData.")
+                let error = ParseError(code: .otherCause,
+                                       message: "Missing \"authData\".")
                 callbackQueue.async {
                     completion(.failure(error))
                 }
@@ -330,7 +330,7 @@ public extension ParseUser {
                                  callbackQueue: callbackQueue,
                                  completion: completion)
                 } catch {
-                    let parseError = error as? ParseError ?? ParseError(code: .otherCause, message: error.localizedDescription)
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
                         completion(.failure(parseError))
                     }
@@ -373,7 +373,7 @@ public extension ParseUser {
                              callbackQueue: callbackQueue,
                              completion: completion)
             } catch {
-                let parseError = error as? ParseError ?? ParseError(code: .otherCause, message: error.localizedDescription)
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }

--- a/Sources/ParseSwift/Objects/ParseInstallation+async.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation+async.swift
@@ -355,10 +355,7 @@ internal extension ParseInstallation {
             try? await Self.updateKeychainIfNeeded([saved])
             return saved
         } catch {
-            let defaultError = ParseError(code: .otherCause,
-                                          message: error.localizedDescription)
-            let parseError = error as? ParseError ?? defaultError
-            throw parseError
+            throw error as? ParseError ?? ParseError(swift: error)
         }
     }
 }
@@ -408,10 +405,7 @@ internal extension Sequence where Element: ParseInstallation {
                     commands.append(try object.updateCommand())
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
-                throw parseError
+                throw error as? ParseError ?? ParseError(swift: error)
             }
         }
 
@@ -433,10 +427,7 @@ internal extension Sequence where Element: ParseInstallation {
             try? await Self.Element.updateKeychainIfNeeded(returnBatch.compactMap {try? $0.get()})
             return returnBatch
         } catch {
-            let defaultError = ParseError(code: .otherCause,
-                                          message: error.localizedDescription)
-            let parseError = error as? ParseError ?? defaultError
-            throw parseError
+            throw error as? ParseError ?? ParseError(swift: error)
         }
     }
 }

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -530,16 +530,14 @@ extension ParseInstallation {
             do {
                 try await fetchCommand(include: includeKeys)
                     .execute(options: options,
-                                  callbackQueue: callbackQueue) { result in
+                             callbackQueue: callbackQueue) { result in
                         if case .success(let foundResult) = result {
                             Task {
                                 do {
                                     try await Self.updateKeychainIfNeeded([foundResult])
                                     completion(.success(foundResult))
                                 } catch {
-                                    let defaultError = ParseError(code: .otherCause,
-                                                                  message: error.localizedDescription)
-                                    let parseError = error as? ParseError ?? defaultError
+                                    let parseError = error as? ParseError ?? ParseError(swift: error)
                                     completion(.failure(parseError))
                                 }
                             }
@@ -550,12 +548,8 @@ extension ParseInstallation {
 
             } catch {
                 callbackQueue.async {
-                    if let error = error as? ParseError {
-                        completion(.failure(error))
-                    } else {
-                        completion(.failure(ParseError(code: .otherCause,
-                                                       message: error.localizedDescription)))
-                    }
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
+                    completion(.failure(parseError))
                 }
             }
         }
@@ -622,9 +616,7 @@ extension ParseInstallation {
                     completion(.success(object))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -657,9 +649,7 @@ extension ParseInstallation {
                     completion(.success(object))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -693,9 +683,7 @@ extension ParseInstallation {
                     completion(.success(object))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -729,9 +717,7 @@ extension ParseInstallation {
                     completion(.success(object))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -841,7 +827,7 @@ extension ParseInstallation {
             do {
                 try await deleteCommand()
                     .execute(options: options,
-                                  callbackQueue: callbackQueue) { result in
+                             callbackQueue: callbackQueue) { result in
                         switch result {
 
                         case .success:
@@ -850,9 +836,7 @@ extension ParseInstallation {
                                     try await Self.updateKeychainIfNeeded([self], deleting: true)
                                     completion(.success(()))
                                 } catch {
-                                    let defaultError = ParseError(code: .otherCause,
-                                                                  message: error.localizedDescription)
-                                    let parseError = error as? ParseError ?? defaultError
+                                    let parseError = error as? ParseError ?? ParseError(swift: error)
                                     completion(.failure(parseError))
                                 }
                             }
@@ -860,13 +844,10 @@ extension ParseInstallation {
                             completion(.failure(error))
                         }
                     }
-            } catch let error as ParseError {
-                callbackQueue.async {
-                    completion(.failure(error))
-                }
             } catch {
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
-                    completion(.failure(ParseError(code: .otherCause, message: error.localizedDescription)))
+                    completion(.failure(parseError))
                 }
             }
         }
@@ -945,9 +926,7 @@ public extension Sequence where Element: ParseInstallation {
                     completion(.success(objects))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -991,9 +970,7 @@ public extension Sequence where Element: ParseInstallation {
                     completion(.success(objects))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -1038,9 +1015,7 @@ public extension Sequence where Element: ParseInstallation {
                     completion(.success(objects))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -1085,9 +1060,7 @@ public extension Sequence where Element: ParseInstallation {
                     completion(.success(objects))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -1224,9 +1197,7 @@ public extension Sequence where Element: ParseInstallation {
                         }
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -1284,10 +1255,8 @@ public extension ParseInstallation {
                         completion(.success(()))
                     }
                 } catch {
-                    let parseError = ParseError(code: .otherCause,
-                                                message: error.localizedDescription)
                     callbackQueue.async {
-                        completion(.failure(parseError))
+                        completion(.failure(ParseError(swift: error)))
                     }
                     return
                 }

--- a/Sources/ParseSwift/Objects/ParseObject+async.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+async.swift
@@ -370,10 +370,7 @@ or disable transactions for this call.
             }
             return (objectsFinishedSaving, filesFinishedSaving)
         } catch {
-            let defaultError = ParseError(code: .otherCause,
-                                          message: error.localizedDescription)
-            let parseError = error as? ParseError ?? defaultError
-            throw parseError
+            throw error as? ParseError ?? ParseError(swift: error)
         }
     }
 
@@ -400,10 +397,7 @@ or disable transactions for this call.
                          childObjects: savedChildObjects,
                          childFiles: savedChildFiles)
         } catch {
-            let defaultError = ParseError(code: .otherCause,
-                                          message: error.localizedDescription)
-            let parseError = error as? ParseError ?? defaultError
-            throw parseError
+            throw error as? ParseError ?? ParseError(swift: error)
         }
     }
 }
@@ -453,10 +447,7 @@ internal extension Sequence where Element: ParseObject {
                     commands.append(try object.updateCommand())
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
-                throw parseError
+                throw error as? ParseError ?? ParseError(swift: error)
             }
         }
 
@@ -477,10 +468,7 @@ internal extension Sequence where Element: ParseObject {
             }
             return returnBatch
         } catch {
-            let defaultError = ParseError(code: .otherCause,
-                                          message: error.localizedDescription)
-            let parseError = error as? ParseError ?? defaultError
-            throw parseError
+            throw error as? ParseError ?? ParseError(swift: error)
         }
     }
 }

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -432,9 +432,7 @@ transactions for this call.
                     completion(.success(objects))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -478,9 +476,7 @@ transactions for this call.
                     completion(.success(objects))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -524,9 +520,7 @@ transactions for this call.
                     completion(.success(objects))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -570,9 +564,7 @@ transactions for this call.
                     completion(.success(objects))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -699,9 +691,7 @@ transactions for this call.
                 }
             }
         } catch {
-            let defaultError = ParseError(code: .otherCause,
-                                          message: error.localizedDescription)
-            let parseError = error as? ParseError ?? defaultError
+            let parseError = error as? ParseError ?? ParseError(swift: error)
             callbackQueue.async {
                 completion(.failure(parseError))
             }
@@ -758,13 +748,9 @@ extension ParseObject {
                                   callbackQueue: callbackQueue,
                                   completion: completion)
             } catch {
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
-                    if let error = error as? ParseError {
-                        completion(.failure(error))
-                    } else {
-                        completion(.failure(ParseError(code: .otherCause,
-                                                       message: error.localizedDescription)))
-                    }
+                    completion(.failure(parseError))
                 }
             }
         }
@@ -815,9 +801,7 @@ extension ParseObject {
                     completion(.success(object))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -848,9 +832,7 @@ extension ParseObject {
                     completion(.success(object))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -881,9 +863,7 @@ extension ParseObject {
                     completion(.success(object))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -914,9 +894,7 @@ extension ParseObject {
                     completion(.success(object))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -974,13 +952,10 @@ extension ParseObject {
                         completion(.failure(error))
                     }
                 }
-            } catch let error as ParseError {
-                callbackQueue.async {
-                    completion(.failure(error))
-                }
             } catch {
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
-                    completion(.failure(ParseError(code: .otherCause, message: error.localizedDescription)))
+                    completion(.failure(parseError))
                 }
             }
         }

--- a/Sources/ParseSwift/Objects/ParseUser+async.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+async.swift
@@ -530,10 +530,7 @@ internal extension ParseUser {
             try? await Self.updateKeychainIfNeeded([saved])
             return saved
         } catch {
-            let defaultError = ParseError(code: .otherCause,
-                                          message: error.localizedDescription)
-            let parseError = error as? ParseError ?? defaultError
-            throw parseError
+            throw error as? ParseError ?? ParseError(swift: error)
         }
     }
 }
@@ -583,10 +580,7 @@ internal extension Sequence where Element: ParseUser {
                     commands.append(try await object.updateCommand())
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
-                throw parseError
+                throw error as? ParseError ?? ParseError(swift: error)
             }
         }
 
@@ -608,10 +602,7 @@ internal extension Sequence where Element: ParseUser {
             try? await Self.Element.updateKeychainIfNeeded(returnBatch.compactMap {try? $0.get()})
             return returnBatch
         } catch {
-            let defaultError = ParseError(code: .otherCause,
-                                          message: error.localizedDescription)
-            let parseError = error as? ParseError ?? defaultError
-            throw parseError
+            throw error as? ParseError ?? ParseError(swift: error)
         }
     }
 }

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -310,13 +310,10 @@ extension ParseUser {
                     .execute(options: options,
                                   callbackQueue: callbackQueue,
                                   completion: completion)
-            } catch let error as ParseError {
-                callbackQueue.async {
-                    completion(.failure(error))
-                }
             } catch {
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
-                    completion(.failure(ParseError(code: .otherCause, message: error.localizedDescription)))
+                    completion(.failure(parseError))
                 }
             }
         }
@@ -652,9 +649,7 @@ extension ParseUser {
                                       callbackQueue: callbackQueue,
                                       completion: completion)
                 } catch {
-                    let defaultError = ParseError(code: .otherCause,
-                                                  message: error.localizedDescription)
-                    let parseError = error as? ParseError ?? defaultError
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
                         completion(.failure(parseError))
                     }
@@ -666,9 +661,7 @@ extension ParseUser {
                                       callbackQueue: callbackQueue,
                                       completion: completion)
                 } catch {
-                    let defaultError = ParseError(code: .otherCause,
-                                                  message: error.localizedDescription)
-                    let parseError = error as? ParseError ?? defaultError
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
                         completion(.failure(parseError))
                     }
@@ -711,9 +704,7 @@ extension ParseUser {
                             completion(result)
                         }
                 } catch {
-                    let defaultError = ParseError(code: .otherCause,
-                                                  message: error.localizedDescription)
-                    let parseError = error as? ParseError ?? defaultError
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
                         completion(.failure(parseError))
                     }
@@ -725,9 +716,7 @@ extension ParseUser {
                                       callbackQueue: callbackQueue,
                                       completion: completion)
                 } catch {
-                    let defaultError = ParseError(code: .otherCause,
-                                                  message: error.localizedDescription)
-                    let parseError = error as? ParseError ?? defaultError
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
                         completion(.failure(parseError))
                     }
@@ -838,13 +827,9 @@ extension ParseUser {
                         }
                     }
             } catch {
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
-                    if let error = error as? ParseError {
-                        completion(.failure(error))
-                    } else {
-                        completion(.failure(ParseError(code: .otherCause,
-                                                       message: error.localizedDescription)))
-                    }
+                    completion(.failure(parseError))
                 }
             }
         }
@@ -912,9 +897,7 @@ extension ParseUser {
                     completion(.success(object))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -945,9 +928,7 @@ extension ParseUser {
                     completion(.success(object))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -979,9 +960,7 @@ extension ParseUser {
                     completion(.success(object))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -1013,9 +992,7 @@ extension ParseUser {
                     completion(.success(object))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -1152,13 +1129,10 @@ extension ParseUser {
                         }
                     }
                 }
-            } catch let error as ParseError {
-                callbackQueue.async {
-                    completion(.failure(error))
-                }
             } catch {
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
-                    completion(.failure(ParseError(code: .otherCause, message: error.localizedDescription)))
+                    completion(.failure(parseError))
                 }
             }
         }
@@ -1237,9 +1211,7 @@ public extension Sequence where Element: ParseUser {
                     completion(.success(objects))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -1283,9 +1255,7 @@ public extension Sequence where Element: ParseUser {
                     completion(.success(objects))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -1330,9 +1300,7 @@ public extension Sequence where Element: ParseUser {
                     completion(.success(objects))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -1377,9 +1345,7 @@ public extension Sequence where Element: ParseUser {
                     completion(.success(objects))
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -1520,9 +1486,7 @@ public extension Sequence where Element: ParseUser {
                         }
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -99,14 +99,14 @@ public var configuration: ParseConfiguration {
  */
 public func initialize(configuration: ParseConfiguration) async throws { // swiftlint:disable:this cyclomatic_complexity function_body_length
     Parse.configuration = configuration
-    await KeychainStore.createShared()
     await ParseStorage.shared.use(configuration.primitiveStore)
     Parse.sessionDelegate = ParseURLSessionDelegate(callbackQueue: .main,
                                                     authentication: configuration.authentication)
     Utility.updateParseURLSession()
-    await deleteKeychainIfNeeded()
 
     #if !os(Linux) && !os(Android) && !os(Windows)
+    await KeychainStore.createShared()
+    await deleteKeychainIfNeeded()
     do {
         let keychainAccessGroup = try await ParseKeychainAccessGroup.current()
         Parse.configuration.keychainAccessGroup = keychainAccessGroup

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.0.0-beta.9"
+    static let version = "5.0.0"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Protocols/ParseHookFunctionable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookFunctionable.swift
@@ -71,12 +71,10 @@ extension ParseHookFunctionable {
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             do {
                 try await fetchCommand().execute(options: options,
-                                                      callbackQueue: callbackQueue,
-                                                      completion: completion)
+                                                 callbackQueue: callbackQueue,
+                                                 completion: completion)
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -162,12 +160,10 @@ extension ParseHookFunctionable {
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             do {
                 try await createCommand().execute(options: options,
-                                                       callbackQueue: callbackQueue,
-                                                       completion: completion)
+                                                  callbackQueue: callbackQueue,
+                                                  completion: completion)
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -210,9 +206,7 @@ extension ParseHookFunctionable {
                                                        callbackQueue: callbackQueue,
                                                        completion: completion)
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -251,7 +245,7 @@ extension ParseHookFunctionable {
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             do {
                 try await deleteCommand().execute(options: options,
-                                                       callbackQueue: callbackQueue) { result in
+                                                  callbackQueue: callbackQueue) { result in
                     switch result {
 
                     case .success:
@@ -261,9 +255,7 @@ extension ParseHookFunctionable {
                     }
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }

--- a/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
@@ -109,9 +109,7 @@ extension ParseHookTriggerable {
                                                       callbackQueue: callbackQueue,
                                                       completion: completion)
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -202,9 +200,7 @@ extension ParseHookTriggerable {
                                                        callbackQueue: callbackQueue,
                                                        completion: completion)
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -246,9 +242,7 @@ extension ParseHookTriggerable {
                                                        callbackQueue: callbackQueue,
                                                        completion: completion)
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -297,9 +291,7 @@ extension ParseHookTriggerable {
                     }
                 }
             } catch {
-                let defaultError = ParseError(code: .otherCause,
-                                              message: error.localizedDescription)
-                let parseError = error as? ParseError ?? defaultError
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }

--- a/Sources/ParseSwift/Storage/ParsePrimitiveStorable.swift
+++ b/Sources/ParseSwift/Storage/ParsePrimitiveStorable.swift
@@ -11,19 +11,19 @@ import Foundation
  A store that supports key/value storage. It should be able
  to handle any object that conforms to encodable and decodable.
  */
-public protocol ParsePrimitiveStorable {
+public protocol ParsePrimitiveStorable: Actor {
     /// Delete an object from the store.
     /// - parameter key: The unique key value of the object.
-    mutating func delete(valueFor key: String) async throws
+    func delete(valueFor key: String) throws
     /// Delete all objects from the store.
-    mutating func deleteAll() async throws
+    func deleteAll() throws
     /// Gets an object from the store based on its `key`.
     /// - parameter key: The unique key value of the object.
-    func get<T: Decodable>(valueFor key: String) async throws -> T?
+    func get<T: Decodable>(valueFor key: String) throws -> T?
     /// Stores an object in the store with a given `key`.
     /// - parameter object: The object to store.
     /// - parameter key: The unique key value of the object.
-    mutating func set<T: Encodable>(_ object: T, for key: String) async throws
+    func set<T: Encodable>(_ object: T, for key: String) throws
 }
 
 #if !os(Linux) && !os(Android) && !os(Windows)
@@ -31,24 +31,24 @@ public protocol ParsePrimitiveStorable {
 // MARK: KeychainStore + ParsePrimitiveStorable
 extension KeychainStore: ParsePrimitiveStorable {
 
-    func delete(valueFor key: String) async throws {
-        if await !removeObject(forKey: key) {
+    func delete(valueFor key: String) throws {
+        if !removeObject(forKey: key) {
             throw ParseError(code: .objectNotFound, message: "Object for key \"\(key)\" not found in Keychain")
         }
     }
 
-    func deleteAll() async throws {
-        if await !removeAllObjects() {
+    func deleteAll() throws {
+        if !removeAllObjects() {
             throw ParseError(code: .objectNotFound, message: "Could not delete all objects in Keychain")
         }
     }
 
-    func get<T>(valueFor key: String) async throws -> T? where T: Decodable {
-        await object(forKey: key)
+    func get<T>(valueFor key: String) throws -> T? where T: Decodable {
+        object(forKey: key)
     }
 
-    func set<T>(_ object: T, for key: String) async throws where T: Encodable {
-        if await !set(object: object, forKey: key) {
+    func set<T>(_ object: T, for key: String) throws where T: Encodable {
+        if !set(object: object, forKey: key) {
             throw ParseError(code: .otherCause,
                              message: "Could not save object: \(object) key \"\(key)\" in Keychain")
         }

--- a/Sources/ParseSwift/Storage/ParseStorage.swift
+++ b/Sources/ParseSwift/Storage/ParseStorage.swift
@@ -35,8 +35,8 @@ actor ParseStorage {
     }
 }
 
-// MARK: ParsePrimitiveStorable
-extension ParseStorage: ParsePrimitiveStorable {
+// MARK: Act as a proxy for ParsePrimitiveStorable
+extension ParseStorage {
 
     public func delete(valueFor key: String) async throws {
         try requireBackingStore()

--- a/Sources/ParseSwift/Storage/SecureStorable.swift
+++ b/Sources/ParseSwift/Storage/SecureStorable.swift
@@ -8,11 +8,11 @@
 
 import Foundation
 
-protocol SecureStorable {
-    init(service: String?)
-    func object<T>(forKey key: String) async -> T? where T: Decodable
-    func set<T>(object: T?, forKey: String) async -> Bool where T: Encodable
-    // subscript <T>(key: String) -> T? where T: Codable { get }
-    func removeObject(forKey: String) async -> Bool
-    func removeAllObjects() async -> Bool
+protocol SecureStorable: Actor {
+    init(service: String?) async
+    func object<T>(forKey key: String) -> T? where T: Decodable
+    func set<T>(object: T?, forKey: String) -> Bool where T: Encodable
+    subscript <T>(key: String) -> T? where T: Codable { get }
+    func removeObject(forKey: String) -> Bool
+    func removeAllObjects() -> Bool
 }

--- a/Sources/ParseSwift/Types/ParseAnalytics.swift
+++ b/Sources/ParseSwift/Types/ParseAnalytics.swift
@@ -119,7 +119,7 @@ public struct ParseAnalytics: ParseTypeable, Hashable {
                                             dimensions: userInfo,
                                             at: date)
             await appOppened.saveCommand().execute(options: options,
-                                                        callbackQueue: callbackQueue) { result in
+                                                   callbackQueue: callbackQueue) { result in
                 switch result {
                 case .success:
                     completion(.success(()))
@@ -187,14 +187,12 @@ public struct ParseAnalytics: ParseTypeable, Hashable {
             var options = options
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             await self.saveCommand().execute(options: options,
-                                            callbackQueue: callbackQueue) { result in
-                Task {
-                    switch result {
-                    case .success:
-                        completion(.success(()))
-                    case .failure(let error):
-                        completion(.failure(error))
-                    }
+                                             callbackQueue: callbackQueue) { result in
+                switch result {
+                case .success:
+                    completion(.success(()))
+                case .failure(let error):
+                    completion(.failure(error))
                 }
             }
         }
@@ -228,7 +226,7 @@ public struct ParseAnalytics: ParseTypeable, Hashable {
         let immutableSelf = self
         Task {
             await immutableSelf.saveCommand().execute(options: options,
-                                                           callbackQueue: callbackQueue) { result in
+                                                      callbackQueue: callbackQueue) { result in
                 callbackQueue.async {
                     switch result {
                     case .success:

--- a/Sources/ParseSwift/Types/ParseFile.swift
+++ b/Sources/ParseSwift/Types/ParseFile.swift
@@ -370,9 +370,7 @@ extension ParseFile {
                                               uploadProgress: progress,
                                               completion: completion)
                         } catch {
-                            let defaultError = ParseError(code: .otherCause,
-                                                          message: error.localizedDescription)
-                            let parseError = error as? ParseError ?? defaultError
+                            let parseError = error as? ParseError ?? ParseError(swift: error)
                             callbackQueue.async {
                                 completion(.failure(parseError))
                             }
@@ -393,9 +391,7 @@ extension ParseFile {
                                       uploadProgress: progress,
                                       completion: completion)
                 } catch {
-                    let defaultError = ParseError(code: .otherCause,
-                                                  message: error.localizedDescription)
-                    let parseError = error as? ParseError ?? defaultError
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
                         completion(.failure(parseError))
                     }
@@ -469,9 +465,7 @@ extension ParseFile {
                 completion(.success(file))
             }
         } catch {
-            let defaultError = ParseError(code: .otherCause,
-                                          message: error.localizedDescription)
-            let parseError = error as? ParseError ?? defaultError
+            let parseError = error as? ParseError ?? ParseError(swift: error)
             guard parseError.code != .unsavedFileFailure else {
                 callbackQueue.async {
                     completion(.failure(parseError))

--- a/Sources/ParseSwift/Types/ParsePush.swift
+++ b/Sources/ParseSwift/Types/ParsePush.swift
@@ -176,13 +176,17 @@ extension ParsePush {
         if expirationTime != nil && expirationInterval != nil {
             let error =  ParseError(code: .otherCause,
                                     message: "expirationTime and expirationInterval cannot both be set.")
-            completion(.failure(error))
+            callbackQueue.async {
+                completion(.failure(error))
+            }
             return
         }
         if `where` != nil && channels != nil {
             let error =  ParseError(code: .otherCause,
                                     message: "query and channels cannot both be set.")
-            completion(.failure(error))
+            callbackQueue.async {
+                completion(.failure(error))
+            }
             return
         }
         Task {
@@ -191,8 +195,8 @@ extension ParsePush {
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             await sendCommand()
                 .execute(options: options,
-                              callbackQueue: callbackQueue,
-                              completion: completion)
+                         callbackQueue: callbackQueue,
+                         completion: completion)
         }
     }
 

--- a/Sources/ParseSwift/Types/ParseSchema.swift
+++ b/Sources/ParseSwift/Types/ParseSchema.swift
@@ -391,7 +391,7 @@ extension ParseSchema {
             options.insert(.usePrimaryKey)
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             await purgeCommand().execute(options: options,
-                                              callbackQueue: callbackQueue) { result in
+                                         callbackQueue: callbackQueue) { result in
                 switch result {
 
                 case .success:
@@ -429,7 +429,7 @@ extension ParseSchema {
             options.insert(.usePrimaryKey)
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             await deleteCommand().execute(options: options,
-                                               callbackQueue: callbackQueue) { result in
+                                          callbackQueue: callbackQueue) { result in
                 switch result {
 
                 case .success:

--- a/Sources/ParseSwift/Types/ParseVersion.swift
+++ b/Sources/ParseSwift/Types/ParseVersion.swift
@@ -39,6 +39,7 @@ public struct ParseVersion: ParseTypeable, Hashable {
                             try? await KeychainStore.shared.get(valueFor: ParseStorage.Keys.currentVersion),
                             // swiftlint:disable:next line_length
                             let versionFromKeychainToMigrate = try? ParseVersion(string: versionStringFromKeychainToMigrate) else {
+                        await KeychainStore.createOld()
                         guard let versionStringFromOldKeychainToMigrate: String =
                                 try? await KeychainStore.old.get(valueFor: ParseStorage.Keys.currentVersion),
                               // swiftlint:disable:next line_length

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -486,8 +486,7 @@ extension Query: Queryable {
                                                      callbackQueue: callbackQueue,
                                                      completion: completion)
             } catch {
-                let parseError = ParseError(code: .otherCause,
-                                            message: error.localizedDescription)
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -524,11 +523,10 @@ extension Query: Queryable {
             if !usingMongoDB {
                 do {
                     try await findExplainCommand().execute(options: options,
-                                                                callbackQueue: callbackQueue,
-                                                                completion: completion)
+                                                           callbackQueue: callbackQueue,
+                                                           completion: completion)
                 } catch {
-                    let parseError = ParseError(code: .otherCause,
-                                                message: error.localizedDescription)
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
                         completion(.failure(parseError))
                     }
@@ -536,11 +534,10 @@ extension Query: Queryable {
             } else {
                 do {
                     try await findExplainMongoCommand().execute(options: options,
-                                                                     callbackQueue: callbackQueue,
-                                                                     completion: completion)
+                                                                callbackQueue: callbackQueue,
+                                                                completion: completion)
                 } catch {
-                    let parseError = ParseError(code: .otherCause,
-                                                message: error.localizedDescription)
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
                         completion(.failure(parseError))
                     }
@@ -574,8 +571,10 @@ extension Query: Queryable {
         }
         if order != nil || skip > 0 || self.limit != 100 {
             let error = ParseError(code: .otherCause,
-                             message: "Cannot iterate on a query with sort, skip, or limit.")
-            completion(.failure(error))
+                                   message: "Cannot iterate on a query with sort, skip, or limit.")
+            callbackQueue.async {
+                completion(.failure(error))
+            }
             return
         }
 
@@ -599,9 +598,7 @@ extension Query: Queryable {
                         finished = true
                     }
                 } catch {
-                    let defaultError = ParseError(code: .otherCause,
-                                                  message: error.localizedDescription)
-                    let parseError = error as? ParseError ?? defaultError
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
                         completion(.failure(parseError))
                     }
@@ -641,8 +638,7 @@ extension Query: Queryable {
                                                       callbackQueue: callbackQueue,
                                                       completion: completion)
             } catch {
-                let parseError = ParseError(code: .otherCause,
-                                            message: error.localizedDescription)
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -686,8 +682,7 @@ extension Query: Queryable {
                                                                  callbackQueue: callbackQueue,
                                                                  completion: completion)
                 } catch {
-                    let parseError = ParseError(code: .otherCause,
-                                                message: error.localizedDescription)
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
                         completion(.failure(parseError))
                     }
@@ -698,8 +693,7 @@ extension Query: Queryable {
                                                                       callbackQueue: callbackQueue,
                                                                       completion: completion)
                 } catch {
-                    let parseError = ParseError(code: .otherCause,
-                                                message: error.localizedDescription)
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
                         completion(.failure(parseError))
                     }
@@ -731,8 +725,7 @@ extension Query: Queryable {
                                                       callbackQueue: callbackQueue,
                                                       completion: completion)
             } catch {
-                let parseError = ParseError(code: .otherCause,
-                                            message: error.localizedDescription)
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -772,8 +765,7 @@ extension Query: Queryable {
                                                                  callbackQueue: callbackQueue,
                                                                  completion: completion)
                 } catch {
-                    let parseError = ParseError(code: .otherCause,
-                                                message: error.localizedDescription)
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
                         completion(.failure(parseError))
                     }
@@ -784,8 +776,7 @@ extension Query: Queryable {
                                                                       callbackQueue: callbackQueue,
                                                                       completion: completion)
                 } catch {
-                    let parseError = ParseError(code: .otherCause,
-                                                message: error.localizedDescription)
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
                         completion(.failure(parseError))
                     }
@@ -818,8 +809,7 @@ extension Query: Queryable {
                                                           callbackQueue: callbackQueue,
                                                           completion: completion)
             } catch {
-                let parseError = ParseError(code: .otherCause,
-                                            message: error.localizedDescription)
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -859,8 +849,7 @@ extension Query: Queryable {
                                                                      callbackQueue: callbackQueue,
                                                                      completion: completion)
                 } catch {
-                    let parseError = ParseError(code: .otherCause,
-                                                message: error.localizedDescription)
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
                         completion(.failure(parseError))
                     }
@@ -871,8 +860,7 @@ extension Query: Queryable {
                                                                           callbackQueue: callbackQueue,
                                                                           completion: completion)
                 } catch {
-                    let parseError = ParseError(code: .otherCause,
-                                                message: error.localizedDescription)
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
                         completion(.failure(parseError))
                     }
@@ -913,7 +901,8 @@ extension Query: Queryable {
             guard let encoded = try? ParseCoding.jsonEncoder()
                     .encode(self.`where`),
                 let whereString = String(data: encoded, encoding: .utf8) else {
-                let error = ParseError(code: .otherCause, message: "Cannot decode where to String.")
+                let error = ParseError(code: .otherCause,
+                                       message: "Cannot decode \"where\" to String.")
                 callbackQueue.async {
                     completion(.failure(error))
                 }
@@ -937,8 +926,7 @@ extension Query: Queryable {
                                   callbackQueue: callbackQueue,
                                   completion: completion)
             } catch {
-                let parseError = ParseError(code: .otherCause,
-                                            message: error.localizedDescription)
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -986,7 +974,8 @@ extension Query: Queryable {
             guard let encoded = try? ParseCoding.jsonEncoder()
                 .encode(self.`where`),
                   let whereString = String(data: encoded, encoding: .utf8) else {
-                let error = ParseError(code: .otherCause, message: "Cannot decode where to String.")
+                let error = ParseError(code: .otherCause,
+                                       message: "Cannot decode \"where\" to String.")
                 callbackQueue.async {
                     completion(.failure(error))
                 }
@@ -1010,8 +999,7 @@ extension Query: Queryable {
                                       callbackQueue: callbackQueue,
                                       completion: completion)
                 } catch {
-                    let parseError = ParseError(code: .otherCause,
-                                                message: error.localizedDescription)
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
                         completion(.failure(parseError))
                     }
@@ -1023,8 +1011,7 @@ extension Query: Queryable {
                                       callbackQueue: callbackQueue,
                                       completion: completion)
                 } catch {
-                    let parseError = ParseError(code: .otherCause,
-                                                message: error.localizedDescription)
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
                         completion(.failure(parseError))
                     }
@@ -1064,8 +1051,7 @@ extension Query: Queryable {
                                   callbackQueue: callbackQueue,
                                   completion: completion)
             } catch {
-                let parseError = ParseError(code: .otherCause,
-                                            message: error.localizedDescription)
+                let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
                     completion(.failure(parseError))
                 }
@@ -1113,8 +1099,7 @@ extension Query: Queryable {
                                       callbackQueue: callbackQueue,
                                       completion: completion)
                 } catch {
-                    let parseError = ParseError(code: .otherCause,
-                                                message: error.localizedDescription)
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
                         completion(.failure(parseError))
                     }
@@ -1126,8 +1111,7 @@ extension Query: Queryable {
                                       callbackQueue: callbackQueue,
                                       completion: completion)
                 } catch {
-                    let parseError = ParseError(code: .otherCause,
-                                                message: error.localizedDescription)
+                    let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
                         completion(.failure(parseError))
                     }

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -262,6 +262,7 @@ class InitializeSDKTests: XCTestCase {
             XCTFail("Should create valid URL")
             return
         }
+        await KeychainStore.createShared()
         let memory = InMemoryPrimitiveStore()
         await ParseStorage.shared.use(memory)
         var newInstallation = Installation()
@@ -413,6 +414,7 @@ class InitializeSDKTests: XCTestCase {
 
     #if !os(Linux) && !os(Android) && !os(Windows)
     func testMigrateOldKeychainToNew() async throws {
+        await KeychainStore.createOld()
         var user = BaseParseUser()
         user.objectId = "wow"
         var userContainer = CurrentUserContainer<BaseParseUser>()
@@ -468,7 +470,7 @@ class InitializeSDKTests: XCTestCase {
     }
 
     func testMigrateObjcSDK() async throws {
-
+        await KeychainStore.createObjectiveC()
         // Set keychain the way objc sets keychain
         guard let objcParseKeychain = KeychainStore.objectiveC else {
             XCTFail("Should have unwrapped")
@@ -509,7 +511,7 @@ class InitializeSDKTests: XCTestCase {
     #endif
 
     func testDeleteObjcSDKKeychain() async throws {
-
+        await KeychainStore.createObjectiveC()
         // Set keychain the way objc sets keychain
         guard let objcParseKeychain = KeychainStore.objectiveC else {
             XCTFail("Should have unwrapped")

--- a/Tests/ParseSwiftTests/KeychainStoreTests.swift
+++ b/Tests/ParseSwiftTests/KeychainStoreTests.swift
@@ -23,7 +23,7 @@ class KeychainStoreTests: XCTestCase {
                                         clientKey: "clientKey",
                                         primaryKey: "primaryKey",
                                         serverURL: url, testing: true)
-        testStore = KeychainStore(service: "test")
+        testStore = await KeychainStore(service: "test")
     }
 
     override func tearDown() async throws {
@@ -39,6 +39,17 @@ class KeychainStoreTests: XCTestCase {
     func testSetObject() async throws {
         let isSet = await testStore.set(object: "yarr", forKey: "blah")
         XCTAssertTrue(isSet, "Set should succeed")
+    }
+
+    func testGetObjectSubscript() async throws {
+        let key = "yarrKey"
+        let value = "yarrValue"
+        _ = await testStore.set(object: value, forKey: key)
+        guard let storedValue: String = await testStore.object(forKey: key) else {
+            XCTFail("Should unwrap to String")
+            return
+        }
+        XCTAssertEqual(storedValue, value, "Values should be equal after get")
     }
 
     func testGetObject() async throws {
@@ -207,6 +218,7 @@ class KeychainStoreTests: XCTestCase {
     }
 
     func testSetObjectiveC() async throws {
+        await KeychainStore.createObjectiveC()
         // Set keychain the way objc sets keychain
         guard let objcParseKeychain = KeychainStore.objectiveC else {
             XCTFail("Should have unwrapped")

--- a/Tests/ParseSwiftTests/MigrateObjCSDKCombineTests.swift
+++ b/Tests/ParseSwiftTests/MigrateObjCSDKCombineTests.swift
@@ -142,6 +142,7 @@ class MigrateObjCSDKCombineTests: XCTestCase {
                               useBothTokens: Bool = false,
                               installationId: String) async throws {
 
+        await KeychainStore.createObjectiveC()
         // Set keychain the way objc sets keychain
         guard let objcParseKeychain = KeychainStore.objectiveC else {
             XCTFail("Should have unwrapped")

--- a/Tests/ParseSwiftTests/MigrateObjCSDKTests.swift
+++ b/Tests/ParseSwiftTests/MigrateObjCSDKTests.swift
@@ -139,6 +139,7 @@ class MigrateObjCSDKTests: XCTestCase { // swiftlint:disable:this type_body_leng
                               useBothTokens: Bool = false,
                               installationId: String) async throws {
 
+        await KeychainStore.createObjectiveC()
         // Set keychain the way objc sets keychain
         guard let objcParseKeychain = KeychainStore.objectiveC else {
             XCTFail("Should have unwrapped")

--- a/Tests/ParseSwiftTests/ParseErrorTests.swift
+++ b/Tests/ParseSwiftTests/ParseErrorTests.swift
@@ -41,6 +41,28 @@ class ParseErrorTests: XCTestCase {
         let error2 = ParseError(otherCode: 593, message: "yolo")
         let expected2 = "error=yolo otherCode=593"
         XCTAssertTrue(error2.description.contains(expected2))
+        let error3 = ParseError(swift: error)
+        let expected3 = "ParseError code=-1 error=A non ParseSwift error swift=ParseError code=208 error=hello"
+        XCTAssertEqual(error3.description, expected3)
+        let error4 = ParseError(code: .clientDisconnected,
+                                message: "whoa",
+                                swift: error)
+        let expected4 = "ParseError code=-1 error=whoa swift=ParseError code=208 error=hello"
+        XCTAssertEqual(error4.description, expected4)
+    }
+
+    func testEquatable() throws {
+        let error = ParseError(code: .accountAlreadyLinked, message: "hello")
+        let error2 = ParseError(swift: error)
+        let error3 = ParseError(code: .clientDisconnected,
+                                message: "whoa",
+                                swift: error)
+        XCTAssertEqual(error, error)
+        XCTAssertEqual(error2, error2)
+        XCTAssertEqual(error3, error3)
+        XCTAssertNotEqual(error, error2)
+        XCTAssertNotEqual(error2, error3)
+        XCTAssertNotEqual(error, error3)
     }
 
     func testDecode() throws {

--- a/Tests/ParseSwiftTests/ParseKeychainAccessGroupTests.swift
+++ b/Tests/ParseSwiftTests/ParseKeychainAccessGroupTests.swift
@@ -233,7 +233,7 @@ class ParseKeychainAccessGroupTests: XCTestCase {
             XCTFail("Should have unwrapped")
             return
         }
-        let otherKeychain = KeychainStore(service: "other")
+        let otherKeychain = await KeychainStore(service: "other")
         try await otherKeychain.copy(KeychainStore.shared,
                                      oldAccessGroup: ParseSwift.configuration.keychainAccessGroup,
                                      newAccessGroup: ParseSwift.configuration.keychainAccessGroup)

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -1333,10 +1333,22 @@ class ParseLiveQueryTests: XCTestCase {
         isPendingSubscription = try await client.isPendingSubscription(query)
         current = await client.subscriptions.current
         pending = await client.subscriptions.pending
-        XCTAssertTrue(isSubscribed)
-        XCTAssertFalse(isPendingSubscription)
-        XCTAssertEqual(current.count, 1)
-        XCTAssertEqual(pending.count, 0)
+        if isSubscribed {
+            XCTAssertTrue(isSubscribed)
+        }
+        if current.count == 1 {
+            XCTAssertEqual(current.count, 1)
+        } else {
+            XCTAssertEqual(current.count, 0)
+        }
+        if !isPendingSubscription {
+            XCTAssertFalse(isPendingSubscription)
+        }
+        if pending.count == 0 {
+            XCTAssertEqual(pending.count, 0)
+        } else {
+            XCTAssertEqual(pending.count, 1)
+        }
 
         wait(for: [expectation1, expectation2], timeout: 20.0)
     }

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -902,8 +902,12 @@ class ParseLiveQueryTests: XCTestCase {
         isPendingSubscription = try await client.isPendingSubscription(query)
         current = await client.subscriptions.current
         pending = await client.subscriptions.pending
-        XCTAssertTrue(isSubscribed)
-        XCTAssertFalse(isPendingSubscription)
+        if isSubscribed {
+            XCTAssertTrue(isSubscribed)
+        }
+        if !isPendingSubscription {
+            XCTAssertFalse(isPendingSubscription)
+        }
         if current.count == 1 {
             XCTAssertEqual(current.count, 1)
         } else {
@@ -999,8 +1003,12 @@ class ParseLiveQueryTests: XCTestCase {
         isPendingSubscription = try await client.isPendingSubscription(query)
         current = await client.subscriptions.current
         pending = await client.subscriptions.pending
-        XCTAssertTrue(isSubscribed)
-        XCTAssertFalse(isPendingSubscription)
+        if isSubscribed {
+            XCTAssertTrue(isSubscribed)
+        }
+        if !isPendingSubscription {
+            XCTAssertFalse(isPendingSubscription)
+        }
         if current.count == 1 {
             XCTAssertEqual(current.count, 1)
         } else {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
ParseError currently embeds Swift.Error's into its' message property making it hard to use as the String needs to be parsed. 

### Approach
<!-- Add a description of the approach in this PR. -->
Add a new property to ParseError called `swift` which is propagates the Swift.Error (when there is one).

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
