### PR TITLE
feat: Make it easier to login with email or authData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
 __New features__
+* Make it easier to login with email or authData ([#67](https://github.com/netreconlab/Parse-Swift/pull/67)), thanks to [Corey Baker](https://github.com/cbaker6).
 * Add missing async/await and Combine ParseUser.become() type methods ([#66](https://github.com/netreconlab/Parse-Swift/pull/66)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 5.0.1

--- a/Sources/ParseSwift/Objects/ParseUser+async.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+async.swift
@@ -60,20 +60,27 @@ public extension ParseUser {
      Returns an instance of the successfully logged in `ParseUser`.
 
      This also caches the user locally so that calls to *current* will use the latest logged in user.
-     - parameter username: The username of the user.
+     - parameter username: The username of the user. Defauilts to **nil**.
+     - parameter email: The email address associated with the user that forgot their password.
+     Defauilts to **nil**.
      - parameter password: The password of the user.
+     - parameter authData: The authentication data for the `ParseUser`. Defauilts to **nil**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Returns the logged in `ParseUser`.
      - throws: An error of type `ParseError`.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    @discardableResult static func login(username: String,
+    @discardableResult static func login(username: String? = nil,
+                                         email: String? = nil,
                                          password: String,
+                                         authData: [String: [String: String]?]? = nil,
                                          options: API.Options = []) async throws -> Self {
         try await withCheckedThrowingContinuation { continuation in
             Self.login(username: username,
+                       email: email,
                        password: password,
+                       authData: authData,
                        options: options,
                        completion: continuation.resume)
         }

--- a/Sources/ParseSwift/Objects/ParseUser+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+combine.swift
@@ -18,11 +18,11 @@ public extension ParseUser {
 
      This will also enforce that the username is not already taken.
 
-     - warning: Make sure that password and username are set before calling this method.
      - parameter username: The username of the user.
      - parameter password: The password of the user.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - warning: Make sure that password and username are set before calling this method.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
@@ -42,9 +42,9 @@ public extension ParseUser {
 
      This will also enforce that the username is not already taken.
 
-     - warning: Make sure that password and username are set before calling this method.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - warning: Make sure that password and username are set before calling this method.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
@@ -60,19 +60,26 @@ public extension ParseUser {
      Publishes an instance of the successfully logged in `ParseUser`.
 
      This also caches the user locally so that calls to *current* will use the latest logged in user.
-     - parameter username: The username of the user.
+     - parameter username: The username of the user. Defauilts to **nil**.
+     - parameter email: The email address associated with the user that forgot their password.
+     Defauilts to **nil**.
      - parameter password: The password of the user.
+     - parameter authData: The authentication data for the `ParseUser`. Defauilts to **nil**.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
      - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
      desires a different policy, it should be inserted in `options`.
     */
-    static func loginPublisher(username: String,
+    static func loginPublisher(username: String? = nil,
+                               email: String? = nil,
                                password: String,
+                               authData: [String: [String: String]?]? = nil,
                                options: API.Options = []) -> Future<Self, ParseError> {
         Future { promise in
             Self.login(username: username,
+                       email: email,
                        password: password,
+                       authData: authData,
                        options: options,
                        completion: promise)
         }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
The login method currently doesn't except a password or authData. The workaround is to create an instance of `ParseUser` and add any properties.

### Approach
<!-- Add a description of the approach in this PR. -->
Add email and authData as optional parameters. Make the already provided parameter, `username` optional.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
