### PR TITLE
feat: View models now update on the MainActor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.1.1...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.2.0...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 5.2.0
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.1.1...5.2.0), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.2.0/documentation/parseswift)
+
+__New features__
+* All Parse-Swift view models now update on the MainActor to make view changes more predictable ([#75](https://github.com/netreconlab/Parse-Swift/pull/75)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 5.1.1
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.1.0...5.1.1), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.1.1/documentation/parseswift)

--- a/ParseSwift.playground/Pages/17 - SwiftUI - Finding Objects.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/17 - SwiftUI - Finding Objects.xcplaygroundpage/Contents.swift
@@ -95,6 +95,8 @@ struct ContentView: View {
                 TextField("Name", text: $name)
                 TextField("Points", text: $points)
                 Button(action: {
+                    //: Code below should normally be in a ViewModel
+                    //: This is just a simple example...
                     guard let pointsValue = Int(points),
                           let linkToFile = URL(string: "https://parseplatform.org/img/logo.svg") else {
                         return
@@ -111,7 +113,9 @@ struct ContentView: View {
                         switch result {
                         case .success:
                             savedLabel = "Saved score"
-                            self.viewModel.find()
+                            Task {
+                                await self.viewModel.find()
+                            }
                         case .failure(let error):
                             savedLabel = "Error: \(error.message)"
                         }
@@ -136,14 +140,14 @@ struct ContentView: View {
                 }
             }
             Spacer()
-        }.onAppear(perform: {
-            viewModel.find()
-        }).alert(isPresented: $isShowingAction, content: {
+        }.task {
+            await viewModel.find()
+        }.alert(isPresented: $isShowingAction) {
             Alert(title: Text("GameScore"),
                   message: Text(savedLabel),
                   dismissButton: .default(Text("Ok"), action: {
             }))
-        })
+        }
     }
 }
 

--- a/ParseSwift.playground/Pages/19 - SwiftUI - LiveQuery.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/19 - SwiftUI - LiveQuery.xcplaygroundpage/Contents.swift
@@ -75,9 +75,9 @@ struct ContentView: View {
     var body: some View {
         VStack {
 
-            if subscription.subscribed != nil {
+            if subscription.isSubscribed {
                 Text("Subscribed to query!")
-            } else if subscription.unsubscribed != nil {
+            } else if subscription.isUnsubscribed {
                 Text("Unsubscribed from query!")
             } else if let event = subscription.event {
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,6 @@ You are not limited to a single Live Query Client - you can create multiple inst
 ## Migrating from Older Versions and SDKs
 
 1. See the [discussion](https://github.com/netreconlab/Parse-Swift/discussions/74) to learn how to migrate from Parse-Swift<sup>OG</sup> 4.15.0+ to 5.1.1+
-1. See the [discussion](https://github.com/netreconlab/Parse-Swift/discussions/70) to learn how to migrate from the [Parse-Swift](https://github.com/parse-community/Parse-Swift)
-1. See the [discussion](https://github.com/netreconlab/Parse-Swift/discussions/71) to learn how to migrate from the [Parse-SDK-iOS-OSX](https://github.com/parse-community/Parse-SDK-iOS-OSX)
+1. See the [discussion](https://github.com/netreconlab/Parse-Swift/discussions/70) to learn how to migrate from [parse-community/Parse-Swift](https://github.com/parse-community/Parse-Swift)
+1. See the [discussion](https://github.com/netreconlab/Parse-Swift/discussions/71) to learn how to migrate from [Parse-SDK-iOS-OSX](https://github.com/parse-community/Parse-SDK-iOS-OSX)
 

--- a/Sources/ParseSwift/LiveQuery/Subscription.swift
+++ b/Sources/ParseSwift/LiveQuery/Subscription.swift
@@ -25,11 +25,15 @@ open class Subscription<T: ParseObject>: QueryViewModel<T>, QuerySubscribable {
             if newValue != nil {
                 subscribed = nil
                 unsubscribed = nil
-                DispatchQueue.main.async {
-                    self.objectWillChange.send()
-                }
+                self.objectWillChange.send()
             }
         }
+    }
+
+    /// If **true** the LiveQuery subscription is currently active,
+    /// **false** otherwise.
+    open var isSubscribed: Bool {
+        subscribed != nil
     }
 
     /// Updates and notifies when a subscription request has been fulfilled and if it is new.
@@ -38,11 +42,15 @@ open class Subscription<T: ParseObject>: QueryViewModel<T>, QuerySubscribable {
             if newValue != nil {
                 unsubscribed = nil
                 event = nil
-                DispatchQueue.main.async {
-                    self.objectWillChange.send()
-                }
+                self.objectWillChange.send()
             }
         }
+    }
+
+    /// If **true** the LiveQuery subscription is currently inactive,
+    /// **false** otherwise.
+    open var isUnsubscribed: Bool {
+        unsubscribed != nil
     }
 
     /// Updates and notifies when an unsubscribe request has been fulfilled.
@@ -51,9 +59,7 @@ open class Subscription<T: ParseObject>: QueryViewModel<T>, QuerySubscribable {
             if newValue != nil {
                 subscribed = nil
                 event = nil
-                DispatchQueue.main.async {
-                    self.objectWillChange.send()
-                }
+                self.objectWillChange.send()
             }
         }
     }
@@ -69,7 +75,7 @@ open class Subscription<T: ParseObject>: QueryViewModel<T>, QuerySubscribable {
     }
 
     // MARK: QuerySubscribable
-
+    @MainActor
     open func didReceive(_ eventData: Data) throws {
         // Need to decode the event with respect to the `ParseObject`.
         let eventMessage = try ParseCoding.jsonDecoder().decode(EventResponse<T>.self, from: eventData)
@@ -79,10 +85,12 @@ open class Subscription<T: ParseObject>: QueryViewModel<T>, QuerySubscribable {
         self.event = (query, event)
     }
 
+    @MainActor
     open func didSubscribe(_ new: Bool) {
         self.subscribed = (query, new)
     }
 
+    @MainActor
     open func didUnsubscribe() {
         self.unsubscribed = query
     }

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.1.1"
+    static let version = "5.2.1"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Protocols/CloudObservable.swift
+++ b/Sources/ParseSwift/Protocols/CloudObservable.swift
@@ -5,7 +5,7 @@
 //  Created by Corey Baker on 7/11/21.
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
-#if canImport(SwiftUI)
+#if canImport(Combine)
 import Foundation
 
 /**
@@ -27,12 +27,14 @@ public protocol CloudObservable: ObservableObject {
      when the result of its execution.
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
     */
-    func runFunction(options: API.Options)
+    @MainActor
+    func runFunction(options: API.Options) async
 
     /**
      Starts a Cloud Code Job *asynchronously* and updates the view model with the result and jobStatusId of the job.
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
     */
-    func startJob(options: API.Options)
+    @MainActor
+    func startJob(options: API.Options) async
 }
 #endif

--- a/Sources/ParseSwift/Protocols/QueryObservable.swift
+++ b/Sources/ParseSwift/Protocols/QueryObservable.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
-#if canImport(SwiftUI)
+#if canImport(Combine)
 import Foundation
 
 /**
@@ -32,7 +32,8 @@ public protocol QueryObservable: ObservableObject {
 
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
     */
-    func find(options: API.Options)
+    @MainActor
+    func find(options: API.Options) async
 
     /**
      Retrieves *asynchronously* a complete list of `ParseObject`'s  that satisfy this query
@@ -42,8 +43,9 @@ public protocol QueryObservable: ObservableObject {
      - warning: The items are processed in an unspecified order. The query may not have any sort
      order, and may not use limit or skip.
     */
+    @MainActor
     func findAll(batchLimit: Int?,
-                 options: API.Options)
+                 options: API.Options) async
 
     /**
       Gets an object *asynchronously* and updates the view model when complete.
@@ -51,7 +53,8 @@ public protocol QueryObservable: ObservableObject {
       - warning: This method mutates the query. It will reset the limit to `1`.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
     */
-    func first(options: API.Options)
+    @MainActor
+    func first(options: API.Options) async
 
     /**
       Counts objects *synchronously* based on the constructed query and updates the view model
@@ -59,7 +62,8 @@ public protocol QueryObservable: ObservableObject {
 
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
     */
-    func count(options: API.Options)
+    @MainActor
+    func count(options: API.Options) async
 
     /**
       Executes an aggregate query *asynchronously* and updates the view model when complete.
@@ -70,7 +74,8 @@ public protocol QueryObservable: ObservableObject {
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
         - warning: This has not been tested thoroughly.
     */
+    @MainActor
     func aggregate(_ pipeline: [[String: Encodable]],
-                   options: API.Options)
+                   options: API.Options) async
 }
 #endif

--- a/Sources/ParseSwift/Types/CloudViewModel.swift
+++ b/Sources/ParseSwift/Types/CloudViewModel.swift
@@ -5,7 +5,7 @@
 //  Created by Corey Baker on 7/11/21.
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
-#if canImport(SwiftUI)
+#if canImport(Combine)
 import Foundation
 
 /**
@@ -24,9 +24,7 @@ open class CloudViewModel<T: ParseCloudable>: CloudObservable {
         willSet {
             if newValue != nil {
                 self.error = nil
-                DispatchQueue.main.async {
-                    self.objectWillChange.send()
-                }
+                self.objectWillChange.send()
             }
         }
     }
@@ -36,9 +34,7 @@ open class CloudViewModel<T: ParseCloudable>: CloudObservable {
         willSet {
             if newValue != nil {
                 self.results = nil
-                DispatchQueue.main.async {
-                    self.objectWillChange.send()
-                }
+                self.objectWillChange.send()
             }
         }
     }
@@ -47,27 +43,21 @@ open class CloudViewModel<T: ParseCloudable>: CloudObservable {
         self.cloudCode = cloudCode
     }
 
-    public func runFunction(options: API.Options = []) {
-        cloudCode.runFunction(options: options) { results in
-            switch results {
-
-            case .success(let results):
-                self.results = results
-            case .failure(let error):
-                self.error = error
-            }
+    @MainActor
+    public func runFunction(options: API.Options = []) async {
+        do {
+            self.results = try await cloudCode.runFunction(options: options)
+        } catch {
+            self.error = error as? ParseError ?? ParseError(swift: error)
         }
     }
 
-    public func startJob(options: API.Options = []) {
-        cloudCode.startJob(options: options) { results in
-            switch results {
-
-            case .success(let results):
-                self.results = results
-            case .failure(let error):
-                self.error = error
-            }
+    @MainActor
+    public func startJob(options: API.Options = []) async {
+        do {
+            self.results = try await cloudCode.startJob(options: options)
+        } catch {
+            self.error = error as? ParseError ?? ParseError(swift: error)
         }
     }
 }

--- a/Tests/ParseSwiftTests/ParseCloudViewModelTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudViewModelTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
-#if canImport(SwiftUI)
+#if canImport(Combine)
 import Foundation
 import XCTest
 @testable import ParseSwift
@@ -43,7 +43,7 @@ class ParseCloudViewModelTests: XCTestCase {
         try await ParseStorage.shared.deleteAll()
     }
 
-    func testFunction() {
+    func testFunction() async throws {
         let response = AnyResultResponse<String>(result: "hello")
 
         MockURLProtocol.mockRequests { _ in
@@ -57,18 +57,13 @@ class ParseCloudViewModelTests: XCTestCase {
         let viewModel = Cloud(functionJobName: "test")
             .viewModel
         viewModel.error = ParseError(code: .otherCause, message: "error")
-        viewModel.runFunction()
+        await viewModel.runFunction()
 
-        let expectation = XCTestExpectation(description: "Run Function")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-            XCTAssertEqual(viewModel.results, "hello")
-            XCTAssertNil(viewModel.error)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 20.0)
+        XCTAssertEqual(viewModel.results, "hello")
+        XCTAssertNil(viewModel.error)
     }
 
-    func testFunctionError() {
+    func testFunctionError() async throws {
         let response = ParseError(code: .otherCause, message: "Custom error")
 
         MockURLProtocol.mockRequests { _ in
@@ -82,18 +77,13 @@ class ParseCloudViewModelTests: XCTestCase {
         let viewModel = Cloud(functionJobName: "test")
             .viewModel
         viewModel.results = "Test"
-        viewModel.runFunction()
+        await viewModel.runFunction()
 
-        let expectation = XCTestExpectation(description: "Run Function")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-            XCTAssertEqual(viewModel.results, nil)
-            XCTAssertNotNil(viewModel.error)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 20.0)
+        XCTAssertEqual(viewModel.results, nil)
+        XCTAssertNotNil(viewModel.error)
     }
 
-    func testJob() {
+    func testJob() async throws {
         let response = AnyResultResponse<String>(result: "hello")
 
         MockURLProtocol.mockRequests { _ in
@@ -107,18 +97,13 @@ class ParseCloudViewModelTests: XCTestCase {
         let viewModel = Cloud(functionJobName: "test")
             .viewModel
         viewModel.error = ParseError(code: .otherCause, message: "error")
-        viewModel.startJob()
+        await viewModel.startJob()
 
-        let expectation = XCTestExpectation(description: "Start Job")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-            XCTAssertEqual(viewModel.results, "hello")
-            XCTAssertNil(viewModel.error)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 20.0)
+        XCTAssertEqual(viewModel.results, "hello")
+        XCTAssertNil(viewModel.error)
     }
 
-    func testViewModelStatic() {
+    func testViewModelStatic() async throws {
         let response = AnyResultResponse<String>(result: "hello")
 
         MockURLProtocol.mockRequests { _ in
@@ -132,18 +117,13 @@ class ParseCloudViewModelTests: XCTestCase {
         let cloud = Cloud(functionJobName: "test")
         let viewModel = Cloud.viewModel(cloud)
         viewModel.error = ParseError(code: .otherCause, message: "error")
-        viewModel.startJob()
+        await viewModel.startJob()
 
-        let expectation = XCTestExpectation(description: "Start Job")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-            XCTAssertEqual(viewModel.results, "hello")
-            XCTAssertNil(viewModel.error)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 20.0)
+        XCTAssertEqual(viewModel.results, "hello")
+        XCTAssertNil(viewModel.error)
     }
 
-    func testJobError() {
+    func testJobError() async throws {
         let response = ParseError(code: .otherCause, message: "Custom error")
 
         MockURLProtocol.mockRequests { _ in
@@ -157,15 +137,10 @@ class ParseCloudViewModelTests: XCTestCase {
         let viewModel = Cloud(functionJobName: "test")
             .viewModel
         viewModel.results = "Test"
-        viewModel.startJob()
+        await viewModel.startJob()
 
-        let expectation = XCTestExpectation(description: "Start Job")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-            XCTAssertEqual(viewModel.results, nil)
-            XCTAssertNotNil(viewModel.error)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 20.0)
+        XCTAssertEqual(viewModel.results, nil)
+        XCTAssertNotNil(viewModel.error)
     }
 }
 #endif

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -677,6 +677,8 @@ class ParseLiveQueryTests: XCTestCase {
             XCTFail("Should unwrap subscribed.")
             return
         }
+        XCTAssertTrue(subscription.isSubscribed)
+        XCTAssertFalse(subscription.isUnsubscribed)
         XCTAssertEqual(query, subscribed.query)
         XCTAssertTrue(subscribed.isNew)
         XCTAssertNil(subscription.unsubscribed)
@@ -714,6 +716,8 @@ class ParseLiveQueryTests: XCTestCase {
             XCTFail("Should unwrap unsubscribed.")
             return
         }
+        XCTAssertFalse(subscription.isSubscribed)
+        XCTAssertTrue(subscription.isUnsubscribed)
         XCTAssertEqual(query, unsubscribed)
         XCTAssertNil(subscription.subscribed)
         XCTAssertNil(subscription.event)

--- a/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
-#if canImport(SwiftUI)
+#if canImport(Combine)
 import Foundation
 import XCTest
 @testable import ParseSwift
@@ -54,7 +54,7 @@ class ParseQueryViewModelTests: XCTestCase {
         try await ParseStorage.shared.deleteAll()
     }
 
-    func testFind() {
+    func testFind() async throws {
         var scoreOnServer = GameScore(points: 10)
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
@@ -73,24 +73,18 @@ class ParseQueryViewModelTests: XCTestCase {
         let viewModel = GameScore.query
             .viewModel
         viewModel.error = ParseError(code: .otherCause, message: "error")
-        viewModel.find()
-        let expectation = XCTestExpectation(description: "Find objects")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+        await viewModel.find()
 
-            guard let score = viewModel.results.first else {
-                XCTFail("Should unwrap score count")
-                expectation.fulfill()
-                return
-            }
-            XCTAssertTrue(score.hasSameObjectId(as: scoreOnServer))
-            XCTAssertEqual(viewModel.count, 1)
-            XCTAssertNil(viewModel.error)
-            expectation.fulfill()
+        guard let score = viewModel.results.first else {
+            XCTFail("Should unwrap score count")
+            return
         }
-        wait(for: [expectation], timeout: 20.0)
+        XCTAssertTrue(score.hasSameObjectId(as: scoreOnServer))
+        XCTAssertEqual(viewModel.count, 1)
+        XCTAssertNil(viewModel.error)
     }
 
-    func testFindError() {
+    func testFindError() async throws {
 
         let results = ParseError(code: .otherCause, message: "Custom error")
         MockURLProtocol.mockRequests { _ in
@@ -105,19 +99,14 @@ class ParseQueryViewModelTests: XCTestCase {
             .viewModel
         viewModel.results = [GameScore(points: 10)]
         viewModel.count = 1
-        viewModel.find()
-        let expectation = XCTestExpectation(description: "Find objects")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+        await viewModel.find()
 
-            XCTAssertTrue(viewModel.results.isEmpty)
-            XCTAssertEqual(viewModel.count, 0)
-            XCTAssertNotNil(viewModel.error)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 20.0)
+        XCTAssertTrue(viewModel.results.isEmpty)
+        XCTAssertEqual(viewModel.count, 0)
+        XCTAssertNotNil(viewModel.error)
     }
 
-    func testViewModelStatic() {
+    func testViewModelStatic() async throws {
         var scoreOnServer = GameScore(points: 10)
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
@@ -136,24 +125,18 @@ class ParseQueryViewModelTests: XCTestCase {
         let query = GameScore.query
         let viewModel = Query.viewModel(query)
         viewModel.error = ParseError(code: .otherCause, message: "error")
-        viewModel.find()
-        let expectation = XCTestExpectation(description: "Find objects")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+        await viewModel.find()
 
-            guard let score = viewModel.results.first else {
-                XCTFail("Should unwrap score count")
-                expectation.fulfill()
-                return
-            }
-            XCTAssertTrue(score.hasSameObjectId(as: scoreOnServer))
-            XCTAssertEqual(viewModel.count, 1)
-            XCTAssertNil(viewModel.error)
-            expectation.fulfill()
+        guard let score = viewModel.results.first else {
+            XCTFail("Should unwrap score count")
+            return
         }
-        wait(for: [expectation], timeout: 20.0)
+        XCTAssertTrue(score.hasSameObjectId(as: scoreOnServer))
+        XCTAssertEqual(viewModel.count, 1)
+        XCTAssertNil(viewModel.error)
     }
 
-    func testFindAll() {
+    func testFindAll() async throws {
         var scoreOnServer = GameScore(points: 10)
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
@@ -172,24 +155,18 @@ class ParseQueryViewModelTests: XCTestCase {
         let viewModel = GameScore.query
             .viewModel
         viewModel.error = ParseError(code: .otherCause, message: "error")
-        viewModel.findAll()
-        let expectation = XCTestExpectation(description: "Find objects")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+        await viewModel.findAll()
 
-            guard let score = viewModel.results.first else {
-                XCTFail("Should unwrap score count")
-                expectation.fulfill()
-                return
-            }
-            XCTAssertTrue(score.hasSameObjectId(as: scoreOnServer))
-            XCTAssertEqual(viewModel.count, 1)
-            XCTAssertNil(viewModel.error)
-            expectation.fulfill()
+        guard let score = viewModel.results.first else {
+            XCTFail("Should unwrap score count")
+            return
         }
-        wait(for: [expectation], timeout: 20.0)
+        XCTAssertTrue(score.hasSameObjectId(as: scoreOnServer))
+        XCTAssertEqual(viewModel.count, 1)
+        XCTAssertNil(viewModel.error)
     }
 
-    func testFindAllError() {
+    func testFindAllError() async throws {
 
         let results = ParseError(code: .otherCause, message: "Custom error")
         MockURLProtocol.mockRequests { _ in
@@ -204,19 +181,14 @@ class ParseQueryViewModelTests: XCTestCase {
             .viewModel
         viewModel.results = [GameScore(points: 10)]
         viewModel.count = 1
-        viewModel.findAll()
-        let expectation = XCTestExpectation(description: "Find objects")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+        await viewModel.findAll()
 
-            XCTAssertTrue(viewModel.results.isEmpty)
-            XCTAssertEqual(viewModel.count, 0)
-            XCTAssertNotNil(viewModel.error)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 20.0)
+        XCTAssertTrue(viewModel.results.isEmpty)
+        XCTAssertEqual(viewModel.count, 0)
+        XCTAssertNotNil(viewModel.error)
     }
 
-    func testFirst() {
+    func testFirst() async throws {
         var scoreOnServer = GameScore(points: 10)
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
@@ -235,24 +207,18 @@ class ParseQueryViewModelTests: XCTestCase {
         let viewModel = GameScore.query
             .viewModel
         viewModel.error = ParseError(code: .otherCause, message: "error")
-        viewModel.first()
-        let expectation = XCTestExpectation(description: "Find objects")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+        await viewModel.first()
 
-            guard let score = viewModel.results.first else {
-                XCTFail("Should unwrap score count")
-                expectation.fulfill()
-                return
-            }
-            XCTAssertTrue(score.hasSameObjectId(as: scoreOnServer))
-            XCTAssertEqual(viewModel.count, 1)
-            XCTAssertNil(viewModel.error)
-            expectation.fulfill()
+        guard let score = viewModel.results.first else {
+            XCTFail("Should unwrap score count")
+            return
         }
-        wait(for: [expectation], timeout: 20.0)
+        XCTAssertTrue(score.hasSameObjectId(as: scoreOnServer))
+        XCTAssertEqual(viewModel.count, 1)
+        XCTAssertNil(viewModel.error)
     }
 
-    func testFirstError() {
+    func testFirstError() async throws {
 
         let results = ParseError(code: .otherCause, message: "Custom error")
         MockURLProtocol.mockRequests { _ in
@@ -267,19 +233,14 @@ class ParseQueryViewModelTests: XCTestCase {
             .viewModel
         viewModel.results = [GameScore(points: 10)]
         viewModel.count = 1
-        viewModel.first()
-        let expectation = XCTestExpectation(description: "Find objects")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+        await viewModel.first()
 
-            XCTAssertTrue(viewModel.results.isEmpty)
-            XCTAssertEqual(viewModel.count, 0)
-            XCTAssertNotNil(viewModel.error)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 20.0)
+        XCTAssertTrue(viewModel.results.isEmpty)
+        XCTAssertEqual(viewModel.count, 0)
+        XCTAssertNotNil(viewModel.error)
     }
 
-    func testCount() {
+    func testCount() async throws {
         var scoreOnServer = GameScore(points: 10)
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
@@ -298,19 +259,14 @@ class ParseQueryViewModelTests: XCTestCase {
         let viewModel = GameScore.query
             .viewModel
         viewModel.results = [GameScore(points: 10), GameScore(points: 12)]
-        viewModel.count()
-        let expectation = XCTestExpectation(description: "Find objects")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+        await viewModel.count()
 
-            XCTAssertEqual(viewModel.results.count, 2)
-            XCTAssertEqual(viewModel.count, 1)
-            XCTAssertNil(viewModel.error)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 20.0)
+        XCTAssertEqual(viewModel.results.count, 2)
+        XCTAssertEqual(viewModel.count, 1)
+        XCTAssertNil(viewModel.error)
     }
 
-    func testCountError() {
+    func testCountError() async throws {
 
         let results = ParseError(code: .otherCause, message: "Custom error")
         MockURLProtocol.mockRequests { _ in
@@ -325,19 +281,14 @@ class ParseQueryViewModelTests: XCTestCase {
             .viewModel
         viewModel.results = [GameScore(points: 10)]
         viewModel.count = 1
-        viewModel.count()
-        let expectation = XCTestExpectation(description: "Find objects")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+        await viewModel.count()
 
-            XCTAssertTrue(viewModel.results.isEmpty)
-            XCTAssertEqual(viewModel.count, 0)
-            XCTAssertNotNil(viewModel.error)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 20.0)
+        XCTAssertTrue(viewModel.results.isEmpty)
+        XCTAssertEqual(viewModel.count, 0)
+        XCTAssertNotNil(viewModel.error)
     }
 
-    func testAggregate() {
+    func testAggregate() async throws {
         var scoreOnServer = GameScore(points: 10)
         scoreOnServer.objectId = "yarr"
         scoreOnServer.createdAt = Date()
@@ -356,24 +307,18 @@ class ParseQueryViewModelTests: XCTestCase {
         let viewModel = GameScore.query
             .viewModel
         viewModel.error = ParseError(code: .otherCause, message: "error")
-        viewModel.aggregate([["hello": "world"]])
-        let expectation = XCTestExpectation(description: "Find objects")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+        await viewModel.aggregate([["hello": "world"]])
 
-            guard let score = viewModel.results.first else {
-                XCTFail("Should unwrap score count")
-                expectation.fulfill()
-                return
-            }
-            XCTAssertTrue(score.hasSameObjectId(as: scoreOnServer))
-            XCTAssertEqual(viewModel.count, 1)
-            XCTAssertNil(viewModel.error)
-            expectation.fulfill()
+        guard let score = viewModel.results.first else {
+            XCTFail("Should unwrap score count")
+            return
         }
-        wait(for: [expectation], timeout: 20.0)
+        XCTAssertTrue(score.hasSameObjectId(as: scoreOnServer))
+        XCTAssertEqual(viewModel.count, 1)
+        XCTAssertNil(viewModel.error)
     }
 
-    func testAggregateError() {
+    func testAggregateError() async throws {
 
         let results = ParseError(code: .otherCause, message: "Custom error")
         MockURLProtocol.mockRequests { _ in
@@ -387,16 +332,11 @@ class ParseQueryViewModelTests: XCTestCase {
         let viewModel = GameScore.query.viewModel
         viewModel.results = [GameScore(points: 10)]
         viewModel.count = 1
-        viewModel.aggregate([["hello": "world"]])
-        let expectation = XCTestExpectation(description: "Find objects")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+        await viewModel.aggregate([["hello": "world"]])
 
-            XCTAssertTrue(viewModel.results.isEmpty)
-            XCTAssertEqual(viewModel.count, 0)
-            XCTAssertNotNil(viewModel.error)
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 20.0)
+        XCTAssertTrue(viewModel.results.isEmpty)
+        XCTAssertEqual(viewModel.count, 0)
+        XCTAssertNotNil(viewModel.error)
     }
 }
 #endif


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Parse-Swift ViewModels currently dispatch to the main queue instead of updating on the MainActor which can cause unpredictable behavior.

### Approach
<!-- Add a description of the approach in this PR. -->
- [x] Make all updates on the MainActor by default
- [x] Add some computed properties to the view models
- [x] Improve SwiftUI Playground files to take advantage of the added features  

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
