### PR TITLE
feat: Add loginAs method to impersonate users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.2.0...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.3.0...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 5.3.0
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.2.0...5.3.0), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.3.0/documentation/parseswift)
+
+__New features__
+* Add ParseUser.loginAs(objectId: String) method to allow impersonating a user. This method requires the server primaryKey and is intended to run server-side ([#79](https://github.com/netreconlab/Parse-Swift/pull/79)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 5.2.0
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.1.1...5.2.0), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.2.0/documentation/parseswift)

--- a/ParseSwift.playground/Pages/3 - User - Sign Up.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/3 - User - Sign Up.xcplaygroundpage/Contents.swift
@@ -52,18 +52,10 @@ struct User: ParseUser {
     }
 }
 
-Task {
-    do {
-        let user = try await User.become(sessionToken: "r:4a9c3abeb9272a98897f6bae28ba0163")
-        print(user)
-    } catch {
-        print(error)
-    }
-}
-
-/*: Sign up user asynchronously - Performs work on background
-    queue and returns to specified callbackQueue.
-    If no callbackQueue is specified it returns to main queue.
+/*:
+ Sign up user asynchronously - Performs work on background
+ queue and returns to specified callbackQueue.
+ If no callbackQueue is specified it returns to main queue.
 */
 User.signup(username: "hello", password: "TestMePass123^") { results in
 

--- a/ParseSwift.playground/Pages/3 - User - Sign Up.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/3 - User - Sign Up.xcplaygroundpage/Contents.swift
@@ -52,16 +52,6 @@ struct User: ParseUser {
     }
 }
 
-Task {
-    do {
-        let user = try await User.become(sessionToken: "r:4a9c3abeb9272a98897f6bae28ba0163")
-        print(user)
-    } catch {
-        print(error)
-    }
-}
-
-
 /*: Sign up user asynchronously - Performs work on background
     queue and returns to specified callbackQueue.
     If no callbackQueue is specified it returns to main queue.

--- a/ParseSwift.playground/Pages/3 - User - Sign Up.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/3 - User - Sign Up.xcplaygroundpage/Contents.swift
@@ -52,6 +52,16 @@ struct User: ParseUser {
     }
 }
 
+Task {
+    do {
+        let user = try await User.become(sessionToken: "r:4a9c3abeb9272a98897f6bae28ba0163")
+        print(user)
+    } catch {
+        print(error)
+    }
+}
+
+
 /*: Sign up user asynchronously - Performs work on background
     queue and returns to specified callbackQueue.
     If no callbackQueue is specified it returns to main queue.

--- a/ParseSwift.playground/Pages/3 - User - Sign Up.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/3 - User - Sign Up.xcplaygroundpage/Contents.swift
@@ -52,6 +52,15 @@ struct User: ParseUser {
     }
 }
 
+Task {
+    do {
+        let user = try await User.become(sessionToken: "r:4a9c3abeb9272a98897f6bae28ba0163")
+        print(user)
+    } catch {
+        print(error)
+    }
+}
+
 /*: Sign up user asynchronously - Performs work on background
     queue and returns to specified callbackQueue.
     If no callbackQueue is specified it returns to main queue.

--- a/Sources/ParseSwift/API/API+Command+async.swift
+++ b/Sources/ParseSwift/API/API+Command+async.swift
@@ -40,15 +40,15 @@ internal extension API.Command {
         try await withCheckedThrowingContinuation { continuation in
             Task {
                 await self.execute(options: options,
-                                        batching: batching,
-                                        callbackQueue: callbackQueue,
-                                        notificationQueue: notificationQueue,
-                                        childObjects: childObjects,
-                                        childFiles: childFiles,
-                                        allowIntermediateResponses: allowIntermediateResponses,
-                                        uploadProgress: uploadProgress,
-                                        downloadProgress: downloadProgress,
-                                        completion: continuation.resume)
+                                   batching: batching,
+                                   callbackQueue: callbackQueue,
+                                   notificationQueue: notificationQueue,
+                                   childObjects: childObjects,
+                                   childFiles: childFiles,
+                                   allowIntermediateResponses: allowIntermediateResponses,
+                                   uploadProgress: uploadProgress,
+                                   downloadProgress: downloadProgress,
+                                   completion: continuation.resume)
             }
         }
     }

--- a/Sources/ParseSwift/API/API+NonParseBodyCommand+async.swift
+++ b/Sources/ParseSwift/API/API+NonParseBodyCommand+async.swift
@@ -19,9 +19,9 @@ extension API.NonParseBodyCommand {
         try await withCheckedThrowingContinuation { continuation in
             Task {
                 await self.execute(options: options,
-                                        callbackQueue: callbackQueue,
-                                        allowIntermediateResponses: allowIntermediateResponses,
-                                        completion: continuation.resume)
+                                   callbackQueue: callbackQueue,
+                                   allowIntermediateResponses: allowIntermediateResponses,
+                                   completion: continuation.resume)
             }
         }
     }

--- a/Sources/ParseSwift/API/API.swift
+++ b/Sources/ParseSwift/API/API.swift
@@ -34,6 +34,7 @@ public struct API {
         case roles
         case role(objectId: String)
         case login
+        case loginAs
         case logout
         case file(fileName: String)
         case passwordReset
@@ -84,6 +85,8 @@ public struct API {
                 return "/roles/\(objectId)"
             case .login:
                 return "/login"
+            case .loginAs:
+                return "/loginAs"
             case .logout:
                 return "/logout"
             case .file(let fileName):

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -1177,7 +1177,7 @@ public extension Sequence where Element: ParseInstallation {
                     await API.Command<Self.Element, ParseError?>
                         .batch(commands: batch, transaction: transaction)
                         .execute(options: options,
-                                      callbackQueue: callbackQueue) { results in
+                                 callbackQueue: callbackQueue) { results in
                             switch results {
 
                             case .success(let saved):

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -674,7 +674,7 @@ transactions for this call.
                     await API.Command<Self.Element, ParseError?>
                         .batch(commands: batch, transaction: transaction)
                         .execute(options: immutableOptions,
-                                      callbackQueue: callbackQueue) { results in
+                                 callbackQueue: callbackQueue) { results in
                             switch results {
 
                             case .success(let saved):
@@ -745,8 +745,8 @@ extension ParseObject {
             do {
                 try await fetchCommand(include: includeKeys)
                     .execute(options: options,
-                                  callbackQueue: callbackQueue,
-                                  completion: completion)
+                             callbackQueue: callbackQueue,
+                             completion: completion)
             } catch {
                 let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
@@ -943,7 +943,7 @@ extension ParseObject {
         Task {
             do {
                 try await deleteCommand().execute(options: options,
-                                                       callbackQueue: callbackQueue) { result in
+                                                  callbackQueue: callbackQueue) { result in
                     switch result {
 
                     case .success:

--- a/Sources/ParseSwift/Objects/ParseUser+async.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+async.swift
@@ -125,6 +125,36 @@ public extension ParseUser {
         }
     }
 
+    /**
+     Logs in a `ParseUser` *asynchronously* with a given `objectId` allowing the impersonation of a User.
+     On success, this saves the logged in `ParseUser`with this session to the keychain, so you can retrieve
+     the currently logged in user using *current*.
+
+     - parameter objectId: The objectId of the user to login.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: Returns the logged in `ParseUser`.
+     - throws: An error of type `ParseError`.
+     - important: The Parse Keychain currently only supports one(1) user at a time. This means
+     if you use `loginAs()`, the current logged in user will be replaced. If you would like to revert
+     back to the previous user, you should capture the `sesionToken` of the previous user before
+     calling `loginAs()`. When you are ready to revert, 1) `logout()`, then `become()` with
+     the sessionToken.
+     - note: Calling this endpoint does not invoke session triggers such as beforeLogin and
+     afterLogin. This action will always succeed if the supplied user exists in the database, regardless
+     of whether the user is currently locked out.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
+     use the primary key in server-side applications where the key is kept secure and not
+     exposed to the public.
+    */
+    @discardableResult static func loginAs(objectId: String,
+                                           options: API.Options = []) async throws -> Self {
+        try await withCheckedThrowingContinuation { continuation in
+            Self.loginAs(objectId: objectId, options: options, completion: continuation.resume)
+        }
+    }
+
 #if !os(Linux) && !os(Android) && !os(Windows)
     /**
      Logs in a `ParseUser` *asynchronously* using the session token from the Parse Objective-C SDK Keychain.

--- a/Sources/ParseSwift/Objects/ParseUser+combine.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+combine.swift
@@ -121,6 +121,35 @@ public extension ParseUser {
         }
     }
 
+    /**
+     Logs in a `ParseUser` *asynchronously* with a given `objectId` allowing the impersonation of a User.
+     On success, this saves the logged in `ParseUser`with this session to the keychain, so you can retrieve
+     the currently logged in user using *current*.
+
+     - parameter objectId: The objectId of the user to login.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - important: The Parse Keychain currently only supports one(1) user at a time. This means
+     if you use `loginAs()`, the current logged in user will be replaced. If you would like to revert
+     back to the previous user, you should capture the `sesionToken` of the previous user before
+     calling `loginAs()`. When you are ready to revert, 1) `logout()`, then `become()` with
+     the sessionToken.
+     - note: Calling this endpoint does not invoke session triggers such as beforeLogin and
+     afterLogin. This action will always succeed if the supplied user exists in the database, regardless
+     of whether the user is currently locked out.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
+     use the primary key in server-side applications where the key is kept secure and not
+     exposed to the public.
+    */
+    static func loginAsPublisher(objectId: String,
+                                 options: API.Options = []) -> Future<Self, ParseError> {
+        Future { promise in
+            Self.loginAs(objectId: objectId, options: options, completion: promise)
+        }
+    }
+
 #if !os(Linux) && !os(Android) && !os(Windows)
     /**
      Logs in a `ParseUser` *asynchronously* using the session token from the Parse Objective-C SDK Keychain.

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -468,11 +468,8 @@ extension ParseUser {
         return API.Command(method: .POST,
                            path: .loginAs,
                            body: body) { (data) async throws -> Self in
-            var sessionToken = await Self.currentContainer()?.sessionToken
-            if let decodedSessionToken = try? ParseCoding.jsonDecoder()
-                .decode(LoginSignupResponse.self, from: data).sessionToken {
-                sessionToken = decodedSessionToken
-            }
+            let sessionToken = try ParseCoding.jsonDecoder()
+                .decode(LoginSignupResponse.self, from: data).sessionToken
             let user = try ParseCoding.jsonDecoder().decode(Self.self, from: data)
             await Self.setCurrentContainer(.init(
                 currentUser: user,

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -235,8 +235,8 @@ extension ParseUser {
                                password: password,
                                authData: authData)
                 .execute(options: options,
-                              callbackQueue: callbackQueue,
-                              completion: completion)
+                         callbackQueue: callbackQueue,
+                         completion: completion)
         }
     }
 
@@ -315,8 +315,8 @@ extension ParseUser {
             do {
                 try await newUser.meCommand(sessionToken: sessionToken)
                     .execute(options: options,
-                                  callbackQueue: callbackQueue,
-                                  completion: completion)
+                             callbackQueue: callbackQueue,
+                             completion: completion)
             } catch {
                 let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
@@ -433,7 +433,7 @@ extension ParseUser {
             var options = options
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             await logoutCommand().execute(options: options,
-                                               callbackQueue: callbackQueue) { result in
+                                          callbackQueue: callbackQueue) { result in
                 Task {
                     // Always let user logout locally, no matter the error.
                     await deleteCurrentKeychain()
@@ -486,7 +486,7 @@ extension ParseUser {
             var options = options
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             await passwordResetCommand(email: email).execute(options: options,
-                                                                  callbackQueue: callbackQueue) { result in
+                                                             callbackQueue: callbackQueue) { result in
                 switch result {
 
                 case .success(let error):
@@ -543,8 +543,8 @@ extension ParseUser {
                                         password: password,
                                         method: method)
             .execute(options: options,
-                          callbackQueue: callbackQueue,
-                          completion: completion)
+                     callbackQueue: callbackQueue,
+                     completion: completion)
         }
     }
 
@@ -601,7 +601,8 @@ extension ParseUser {
             var options = options
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             await verificationEmailCommand(email: email)
-                .execute(options: options, callbackQueue: callbackQueue) { result in
+                .execute(options: options,
+                         callbackQueue: callbackQueue) { result in
                     switch result {
 
                     case .success(let error):
@@ -649,12 +650,16 @@ extension ParseUser {
             var options = options
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             do {
-                _ = try await Self.current()
+                let currentUser = try await Self.current()
+                guard hasSameObjectId(as: currentUser) else {
+                    throw ParseError(code: .otherCause,
+                                     message: "The user objectId does not match the logged in user")
+                }
                 do {
                     try await self.linkCommand()
                         .execute(options: options,
-                                      callbackQueue: callbackQueue,
-                                      completion: completion)
+                                 callbackQueue: callbackQueue,
+                                 completion: completion)
                 } catch {
                     let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
@@ -665,8 +670,8 @@ extension ParseUser {
                 do {
                     try await signupCommand()
                         .execute(options: options,
-                                      callbackQueue: callbackQueue,
-                                      completion: completion)
+                                 callbackQueue: callbackQueue,
+                                 completion: completion)
                 } catch {
                     let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
@@ -720,8 +725,8 @@ extension ParseUser {
                 do {
                     try await signupCommand(body: body)
                         .execute(options: options,
-                                      callbackQueue: callbackQueue,
-                                      completion: completion)
+                                 callbackQueue: callbackQueue,
+                                 completion: completion)
                 } catch {
                     let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
@@ -1122,7 +1127,7 @@ extension ParseUser {
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             do {
                 try await deleteCommand().execute(options: options,
-                                                       callbackQueue: callbackQueue) { result in
+                                                  callbackQueue: callbackQueue) { result in
                     switch result {
 
                     case .success:
@@ -1470,7 +1475,7 @@ public extension Sequence where Element: ParseUser {
                     await API.Command<Self.Element, ParseError?>
                         .batch(commands: batch, transaction: transaction)
                         .execute(options: options,
-                                      callbackQueue: callbackQueue) { results in
+                                 callbackQueue: callbackQueue) { results in
                             switch results {
 
                             case .success(let saved):

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -650,11 +650,7 @@ extension ParseUser {
             var options = options
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             do {
-                let currentUser = try await Self.current()
-                guard hasSameObjectId(as: currentUser) else {
-                    throw ParseError(code: .otherCause,
-                                     message: "The user objectId does not match the logged in user")
-                }
+                _ = try await Self.current()
                 do {
                     try await self.linkCommand()
                         .execute(options: options,

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -193,6 +193,11 @@ struct SignupLoginBody: ParseEncodable {
     var authData: [String: [String: String]?]?
 }
 
+// MARK: LoginAsBody
+struct LoginAsBody: ParseEncodable, Hashable {
+    var userId: String
+}
+
 // MARK: EmailBody
 struct EmailBody: ParseEncodable {
     let email: String
@@ -326,6 +331,53 @@ extension ParseUser {
         }
     }
 
+    /**
+     Logs in a `ParseUser` *asynchronously* with a given `objectId` allowing the impersonation of a User.
+     On success, this saves the logged in `ParseUser`with this session to the keychain, so you can retrieve
+     the currently logged in user using *current*.
+
+     - parameter objectId: The objectId of the user to login.
+     - parameter options: A set of header options sent to the server. Defaults to an empty set.
+     - parameter callbackQueue: The queue to return to after completion. Default
+     value of .main.
+     - parameter completion: The block to execute when completed.
+     It should have the following argument signature: `(Result<Self, ParseError>)`.
+     - important: The Parse Keychain currently only supports one(1) user at a time. This means
+     if you use `loginAs()`, the current logged in user will be replaced. If you would like to revert
+     back to the previous user, you should capture the `sesionToken` of the previous user before
+     calling `loginAs()`. When you are ready to revert, 1) `logout()`, then `become()` with
+     the sessionToken.
+     - note: Calling this endpoint does not invoke session triggers such as beforeLogin and
+     afterLogin. This action will always succeed if the supplied user exists in the database, regardless
+     of whether the user is currently locked out.
+     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
+     desires a different policy, it should be inserted in `options`.
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
+     use the primary key in server-side applications where the key is kept secure and not
+     exposed to the public.
+    */
+    public static func loginAs(objectId: String,
+                               options: API.Options = [],
+                               callbackQueue: DispatchQueue = .main,
+                               completion: @escaping (Result<Self, ParseError>) -> Void) {
+        Task {
+            var options = options
+            options.insert(.usePrimaryKey)
+            options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
+            do {
+                try await loginAsCommand(objectId: objectId)
+                    .execute(options: options,
+                             callbackQueue: callbackQueue,
+                             completion: completion)
+            } catch {
+                let parseError = error as? ParseError ?? ParseError(swift: error)
+                callbackQueue.async {
+                    completion(.failure(parseError))
+                }
+            }
+        }
+    }
+
 #if !os(Linux) && !os(Android) && !os(Windows)
     /**
      Logs in a `ParseUser` *asynchronously* using the session token from the Parse Objective-C SDK Keychain.
@@ -403,6 +455,25 @@ extension ParseUser {
                 }
             }
 
+            await Self.setCurrentContainer(.init(
+                currentUser: user,
+                sessionToken: sessionToken
+            ))
+            return user
+        }
+    }
+
+    internal static func loginAsCommand(objectId: String) throws -> API.Command<LoginAsBody, Self> {
+        let body = LoginAsBody(userId: objectId)
+        return API.Command(method: .POST,
+                           path: .loginAs,
+                           body: body) { (data) async throws -> Self in
+            var sessionToken = await Self.currentContainer()?.sessionToken
+            if let decodedSessionToken = try? ParseCoding.jsonDecoder()
+                .decode(LoginSignupResponse.self, from: data).sessionToken {
+                sessionToken = decodedSessionToken
+            }
+            let user = try ParseCoding.jsonDecoder().decode(Self.self, from: data)
             await Self.setCurrentContainer(.init(
                 currentUser: user,
                 sessionToken: sessionToken

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -445,9 +445,9 @@ extension ParseUser {
 #endif
 
     internal func meCommand(sessionToken: String) throws -> API.Command<Self, Self> {
-
+        // BAKER: path endpoint isn't working here for some reason
         return API.Command(method: .GET,
-                           path: endpoint) { (data) async throws -> Self in
+                           path: .user(objectId: "me")) { (data) async throws -> Self in
             let user = try ParseCoding.jsonDecoder().decode(Self.self, from: data)
 
             if let current = try? await Self.current() {

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.2.1"
+    static let version = "5.3.0"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Protocols/ParseCloudable.swift
+++ b/Sources/ParseSwift/Protocols/ParseCloudable.swift
@@ -41,8 +41,8 @@ extension ParseCloudable {
         Task {
             await runFunctionCommand()
                 .execute(options: options,
-                              callbackQueue: callbackQueue,
-                              completion: completion)
+                         callbackQueue: callbackQueue,
+                         completion: completion)
         }
     }
 
@@ -72,8 +72,8 @@ extension ParseCloudable {
         Task {
             await startJobCommand()
                 .execute(options: options,
-                              callbackQueue: callbackQueue,
-                              completion: completion)
+                         callbackQueue: callbackQueue,
+                         completion: completion)
         }
     }
 

--- a/Sources/ParseSwift/Protocols/ParseConfig.swift
+++ b/Sources/ParseSwift/Protocols/ParseConfig.swift
@@ -37,8 +37,8 @@ extension ParseConfig {
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             await fetchCommand()
                 .execute(options: options,
-                              callbackQueue: callbackQueue,
-                              completion: completion)
+                         callbackQueue: callbackQueue,
+                         completion: completion)
         }
     }
 
@@ -74,8 +74,8 @@ extension ParseConfig {
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             await updateCommand()
                 .execute(options: options,
-                              callbackQueue: callbackQueue,
-                              completion: completion)
+                         callbackQueue: callbackQueue,
+                         completion: completion)
         }
     }
 

--- a/Sources/ParseSwift/Protocols/ParseHookFunctionable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookFunctionable.swift
@@ -126,8 +126,8 @@ extension ParseHookFunctionable {
             options.insert(.usePrimaryKey)
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             await fetchAllCommand().execute(options: options,
-                                                 callbackQueue: callbackQueue,
-                                                 completion: completion)
+                                            callbackQueue: callbackQueue,
+                                            completion: completion)
         }
     }
 
@@ -203,8 +203,8 @@ extension ParseHookFunctionable {
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             do {
                 try await updateCommand().execute(options: options,
-                                                       callbackQueue: callbackQueue,
-                                                       completion: completion)
+                                                  callbackQueue: callbackQueue,
+                                                  completion: completion)
             } catch {
                 let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {

--- a/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
@@ -106,8 +106,8 @@ extension ParseHookTriggerable {
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             do {
                 try await fetchCommand().execute(options: options,
-                                                      callbackQueue: callbackQueue,
-                                                      completion: completion)
+                                                 callbackQueue: callbackQueue,
+                                                 completion: completion)
             } catch {
                 let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
@@ -163,8 +163,8 @@ extension ParseHookTriggerable {
             options.insert(.usePrimaryKey)
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             await fetchAllCommand().execute(options: options,
-                                                 callbackQueue: callbackQueue,
-                                                 completion: completion)
+                                            callbackQueue: callbackQueue,
+                                            completion: completion)
         }
     }
 
@@ -197,8 +197,8 @@ extension ParseHookTriggerable {
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             do {
                 try await createCommand().execute(options: options,
-                                                       callbackQueue: callbackQueue,
-                                                       completion: completion)
+                                                  callbackQueue: callbackQueue,
+                                                  completion: completion)
             } catch {
                 let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
@@ -239,8 +239,8 @@ extension ParseHookTriggerable {
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             do {
                 try await updateCommand().execute(options: options,
-                                                       callbackQueue: callbackQueue,
-                                                       completion: completion)
+                                                  callbackQueue: callbackQueue,
+                                                  completion: completion)
             } catch {
                 let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
@@ -281,7 +281,7 @@ extension ParseHookTriggerable {
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             do {
                 try await deleteCommand().execute(options: options,
-                                                       callbackQueue: callbackQueue) { result in
+                                                  callbackQueue: callbackQueue) { result in
                     switch result {
 
                     case .success:

--- a/Sources/ParseSwift/Types/ParseAnalytics.swift
+++ b/Sources/ParseSwift/Types/ParseAnalytics.swift
@@ -157,7 +157,7 @@ public struct ParseAnalytics: ParseTypeable, Hashable {
                                             dimensions: dimensions,
                                             at: date)
             await appOppened.saveCommand().execute(options: options,
-                                                        callbackQueue: callbackQueue) { result in
+                                                   callbackQueue: callbackQueue) { result in
                 callbackQueue.async {
                     switch result {
                     case .success:

--- a/Sources/ParseSwift/Types/ParseConfigCodable.swift
+++ b/Sources/ParseSwift/Types/ParseConfigCodable.swift
@@ -37,8 +37,8 @@ extension ParseConfigCodable {
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             await fetchCommand()
                 .execute(options: options,
-                              callbackQueue: callbackQueue,
-                              completion: completion)
+                         callbackQueue: callbackQueue,
+                         completion: completion)
         }
     }
 

--- a/Sources/ParseSwift/Types/ParseFile.swift
+++ b/Sources/ParseSwift/Types/ParseFile.swift
@@ -234,7 +234,8 @@ extension ParseFile {
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             options = options.union(self.options)
 
-            await deleteFileCommand().execute(options: options, callbackQueue: callbackQueue) { result in
+            await deleteFileCommand().execute(options: options,
+                                              callbackQueue: callbackQueue) { result in
                 switch result {
                 case .success:
                     completion(.success(()))
@@ -366,9 +367,9 @@ extension ParseFile {
                         do {
                             try await fetched.uploadFileCommand()
                                 .execute(options: options,
-                                              callbackQueue: callbackQueue,
-                                              uploadProgress: progress,
-                                              completion: completion)
+                                         callbackQueue: callbackQueue,
+                                         uploadProgress: progress,
+                                         completion: completion)
                         } catch {
                             let parseError = error as? ParseError ?? ParseError(swift: error)
                             callbackQueue.async {
@@ -387,9 +388,9 @@ extension ParseFile {
                 do {
                     try await uploadFileCommand()
                         .execute(options: options,
-                                      callbackQueue: callbackQueue,
-                                      uploadProgress: progress,
-                                      completion: completion)
+                                 callbackQueue: callbackQueue,
+                                 uploadProgress: progress,
+                                 completion: completion)
                 } catch {
                     let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {

--- a/Sources/ParseSwift/Types/ParseHealth.swift
+++ b/Sources/ParseSwift/Types/ParseHealth.swift
@@ -44,9 +44,9 @@ public struct ParseHealth: ParseTypeable {
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             await healthCommand()
                 .execute(options: options,
-                              callbackQueue: callbackQueue,
-                              allowIntermediateResponses: allowIntermediateResponses,
-                              completion: completion)
+                         callbackQueue: callbackQueue,
+                         allowIntermediateResponses: allowIntermediateResponses,
+                         completion: completion)
         }
     }
 

--- a/Sources/ParseSwift/Types/ParseOperation.swift
+++ b/Sources/ParseSwift/Types/ParseOperation.swift
@@ -369,8 +369,8 @@ extension ParseOperation {
         }
         Task {
             await self.saveCommand().execute(options: options,
-                                                  callbackQueue: callbackQueue,
-                                                  completion: completion)
+                                             callbackQueue: callbackQueue,
+                                             completion: completion)
         }
     }
 

--- a/Sources/ParseSwift/Types/ParseSchema.swift
+++ b/Sources/ParseSwift/Types/ParseSchema.swift
@@ -268,8 +268,8 @@ extension ParseSchema {
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             await fetchCommand()
                 .execute(options: options,
-                              callbackQueue: callbackQueue,
-                              completion: completion)
+                         callbackQueue: callbackQueue,
+                         completion: completion)
         }
     }
 
@@ -307,8 +307,8 @@ extension ParseSchema {
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             await createCommand()
                 .execute(options: options,
-                              callbackQueue: callbackQueue,
-                              completion: completion)
+                         callbackQueue: callbackQueue,
+                         completion: completion)
         }
     }
 
@@ -341,8 +341,8 @@ extension ParseSchema {
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
             await schema.updateCommand()
                 .execute(options: options,
-                              callbackQueue: callbackQueue,
-                              completion: completion)
+                         callbackQueue: callbackQueue,
+                         completion: completion)
         }
     }
 

--- a/Sources/ParseSwift/Types/Pointer.swift
+++ b/Sources/ParseSwift/Types/Pointer.swift
@@ -120,8 +120,8 @@ public extension Pointer {
                                                path: path) { (data) -> T in
                 try ParseCoding.jsonDecoder().decode(T.self, from: data)
             }.execute(options: options,
-                           callbackQueue: callbackQueue,
-                           completion: completion)
+                      callbackQueue: callbackQueue,
+                      completion: completion)
         }
     }
 }

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -483,8 +483,8 @@ extension Query: Queryable {
         Task {
             do {
                 try await findCommand().execute(options: options,
-                                                     callbackQueue: callbackQueue,
-                                                     completion: completion)
+                                                callbackQueue: callbackQueue,
+                                                completion: completion)
             } catch {
                 let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
@@ -635,8 +635,8 @@ extension Query: Queryable {
         Task {
             do {
                 try await firstCommand().execute(options: options,
-                                                      callbackQueue: callbackQueue,
-                                                      completion: completion)
+                                                 callbackQueue: callbackQueue,
+                                                 completion: completion)
             } catch {
                 let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
@@ -679,8 +679,8 @@ extension Query: Queryable {
             if !usingMongoDB {
                 do {
                     try await firstExplainCommand().execute(options: options,
-                                                                 callbackQueue: callbackQueue,
-                                                                 completion: completion)
+                                                            callbackQueue: callbackQueue,
+                                                            completion: completion)
                 } catch {
                     let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
@@ -690,8 +690,8 @@ extension Query: Queryable {
             } else {
                 do {
                     try await firstExplainMongoCommand().execute(options: options,
-                                                                      callbackQueue: callbackQueue,
-                                                                      completion: completion)
+                                                                 callbackQueue: callbackQueue,
+                                                                 completion: completion)
                 } catch {
                     let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
@@ -722,8 +722,8 @@ extension Query: Queryable {
         Task {
             do {
                 try await countCommand().execute(options: options,
-                                                      callbackQueue: callbackQueue,
-                                                      completion: completion)
+                                                 callbackQueue: callbackQueue,
+                                                 completion: completion)
             } catch {
                 let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
@@ -762,8 +762,8 @@ extension Query: Queryable {
             if !usingMongoDB {
                 do {
                     try await countExplainCommand().execute(options: options,
-                                                                 callbackQueue: callbackQueue,
-                                                                 completion: completion)
+                                                            callbackQueue: callbackQueue,
+                                                            completion: completion)
                 } catch {
                     let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
@@ -773,8 +773,8 @@ extension Query: Queryable {
             } else {
                 do {
                     try await countExplainMongoCommand().execute(options: options,
-                                                                      callbackQueue: callbackQueue,
-                                                                      completion: completion)
+                                                                 callbackQueue: callbackQueue,
+                                                                 completion: completion)
                 } catch {
                     let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
@@ -806,8 +806,8 @@ extension Query: Queryable {
         Task {
             do {
                 try await withCountCommand().execute(options: options,
-                                                          callbackQueue: callbackQueue,
-                                                          completion: completion)
+                                                     callbackQueue: callbackQueue,
+                                                     completion: completion)
             } catch {
                 let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
@@ -846,8 +846,8 @@ extension Query: Queryable {
             if !usingMongoDB {
                 do {
                     try await withCountExplainCommand().execute(options: options,
-                                                                     callbackQueue: callbackQueue,
-                                                                     completion: completion)
+                                                                callbackQueue: callbackQueue,
+                                                                completion: completion)
                 } catch {
                     let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
@@ -857,8 +857,8 @@ extension Query: Queryable {
             } else {
                 do {
                     try await withCountExplainMongoCommand().execute(options: options,
-                                                                          callbackQueue: callbackQueue,
-                                                                          completion: completion)
+                                                                     callbackQueue: callbackQueue,
+                                                                     completion: completion)
                 } catch {
                     let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
@@ -923,8 +923,8 @@ extension Query: Queryable {
             do {
                 try await query.aggregateCommand()
                     .execute(options: options,
-                                  callbackQueue: callbackQueue,
-                                  completion: completion)
+                             callbackQueue: callbackQueue,
+                             completion: completion)
             } catch {
                 let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
@@ -996,8 +996,8 @@ extension Query: Queryable {
                 do {
                     try await query.aggregateExplainCommand()
                         .execute(options: options,
-                                      callbackQueue: callbackQueue,
-                                      completion: completion)
+                                 callbackQueue: callbackQueue,
+                                 completion: completion)
                 } catch {
                     let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
@@ -1008,8 +1008,8 @@ extension Query: Queryable {
                 do {
                     try await query.aggregateExplainMongoCommand()
                         .execute(options: options,
-                                      callbackQueue: callbackQueue,
-                                      completion: completion)
+                                 callbackQueue: callbackQueue,
+                                 completion: completion)
                 } catch {
                     let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
@@ -1048,8 +1048,8 @@ extension Query: Queryable {
             do {
                 try await distinctCommand(key: key)
                     .execute(options: options,
-                                  callbackQueue: callbackQueue,
-                                  completion: completion)
+                             callbackQueue: callbackQueue,
+                             completion: completion)
             } catch {
                 let parseError = error as? ParseError ?? ParseError(swift: error)
                 callbackQueue.async {
@@ -1096,8 +1096,8 @@ extension Query: Queryable {
                 do {
                     try await distinctExplainCommand(key: key)
                         .execute(options: options,
-                                      callbackQueue: callbackQueue,
-                                      completion: completion)
+                                 callbackQueue: callbackQueue,
+                                 completion: completion)
                 } catch {
                     let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {
@@ -1108,8 +1108,8 @@ extension Query: Queryable {
                 do {
                     try await distinctExplainMongoCommand(key: key)
                         .execute(options: options,
-                                      callbackQueue: callbackQueue,
-                                      completion: completion)
+                                 callbackQueue: callbackQueue,
+                                 completion: completion)
                 } catch {
                     let parseError = error as? ParseError ?? ParseError(swift: error)
                     callbackQueue.async {

--- a/Tests/ParseSwiftTests/APICommandMultipleAttemptsTests.swift
+++ b/Tests/ParseSwiftTests/APICommandMultipleAttemptsTests.swift
@@ -92,8 +92,8 @@ class APICommandMultipleAttemptsTests: XCTestCase {
                                                       mapper: { _ -> NoBody in
             throw parseError
         }).execute(options: [],
-                        callbackQueue: .main,
-                        allowIntermediateResponses: true) { result in
+                   callbackQueue: .main,
+                   allowIntermediateResponses: true) { result in
             switch result {
             case .success:
                 XCTFail("Should have thrown an error")
@@ -128,8 +128,8 @@ class APICommandMultipleAttemptsTests: XCTestCase {
                                                       mapper: { _ -> NoBody in
             throw originalError
         }).execute(options: [],
-                        callbackQueue: .main,
-                        allowIntermediateResponses: true) { result in
+                   callbackQueue: .main,
+                   allowIntermediateResponses: true) { result in
             switch result {
             case .success:
                 XCTFail("Should have thrown an error")
@@ -176,8 +176,8 @@ class APICommandMultipleAttemptsTests: XCTestCase {
                                                       mapper: { _ -> NoBody in
             throw parseError
         }).execute(options: [],
-                        callbackQueue: .main,
-                        allowIntermediateResponses: true) { result in
+                   callbackQueue: .main,
+                   allowIntermediateResponses: true) { result in
             switch result {
             case .success:
                 XCTFail("Should have thrown an error")
@@ -240,8 +240,8 @@ class APICommandMultipleAttemptsTests: XCTestCase {
                                                       mapper: { _ -> NoBody in
             throw parseError
         }).execute(options: [],
-                        callbackQueue: .main,
-                        allowIntermediateResponses: true) { result in
+                   callbackQueue: .main,
+                   allowIntermediateResponses: true) { result in
             switch result {
             case .success:
                 XCTFail("Should have thrown an error")
@@ -293,8 +293,8 @@ class APICommandMultipleAttemptsTests: XCTestCase {
                                                       mapper: { _ -> NoBody in
             throw parseError
         }).execute(options: [],
-                        callbackQueue: .main,
-                        allowIntermediateResponses: true) { result in
+                   callbackQueue: .main,
+                   allowIntermediateResponses: true) { result in
             switch result {
             case .success:
                 XCTFail("Should have thrown an error")
@@ -349,8 +349,8 @@ class APICommandMultipleAttemptsTests: XCTestCase {
                                                       mapper: { _ -> NoBody in
             throw parseError
         }).execute(options: [],
-                        callbackQueue: .main,
-                        allowIntermediateResponses: true) { result in
+                   callbackQueue: .main,
+                   allowIntermediateResponses: true) { result in
             switch result {
             case .success:
                 XCTFail("Should have thrown an error")
@@ -413,8 +413,8 @@ class APICommandMultipleAttemptsTests: XCTestCase {
                                                       mapper: { _ -> NoBody in
             throw parseError
         }).execute(options: [],
-                        callbackQueue: .main,
-                        allowIntermediateResponses: true) { result in
+                   callbackQueue: .main,
+                   allowIntermediateResponses: true) { result in
             switch result {
             case .success:
                 XCTFail("Should have thrown an error")
@@ -466,8 +466,8 @@ class APICommandMultipleAttemptsTests: XCTestCase {
                                                       mapper: { _ -> NoBody in
             throw parseError
         }).execute(options: [],
-                        callbackQueue: .main,
-                        allowIntermediateResponses: true) { result in
+                   callbackQueue: .main,
+                   allowIntermediateResponses: true) { result in
             switch result {
             case .success:
                 XCTFail("Should have thrown an error")

--- a/Tests/ParseSwiftTests/ParseAnonymousTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousTests.swift
@@ -285,6 +285,7 @@ class ParseAnonymousTests: XCTestCase {
 
     func testReplaceAnonymousUser() async throws {
         try await testLogin()
+        MockURLProtocol.removeAll()
         let user = try await User.current()
         guard let updatedAt = user.updatedAt else {
             XCTFail("Shold have unwrapped")
@@ -304,7 +305,6 @@ class ParseAnonymousTests: XCTestCase {
             XCTFail("Should encode/decode. Error \(error)")
             return
         }
-        MockURLProtocol.removeAll()
         MockURLProtocol.mockRequests { _ in
             return MockURLResponse(data: encoded, statusCode: 200)
         }
@@ -331,6 +331,7 @@ class ParseAnonymousTests: XCTestCase {
 
     func testReplaceAnonymousUserBody() async throws {
         try await testLogin()
+        MockURLProtocol.removeAll()
         let user = try await User.current()
         guard let updatedAt = user.updatedAt else {
             XCTFail("Shold have unwrapped")
@@ -350,7 +351,6 @@ class ParseAnonymousTests: XCTestCase {
             XCTFail("Should encode/decode. Error \(error)")
             return
         }
-        MockURLProtocol.removeAll()
         MockURLProtocol.mockRequests { _ in
             return MockURLResponse(data: encoded, statusCode: 200)
         }
@@ -375,6 +375,8 @@ class ParseAnonymousTests: XCTestCase {
 
     func testReplaceAnonymousUserSync() async throws {
         try await testLogin()
+        MockURLProtocol.removeAll()
+
         var user = try await User.current()
         guard let updatedAt = user.updatedAt else {
             XCTFail("Shold have unwrapped")
@@ -383,7 +385,7 @@ class ParseAnonymousTests: XCTestCase {
         XCTAssertTrue(ParseAnonymous<User>.isLinked(with: user))
 
         var response = UpdateSessionTokenResponse(updatedAt: updatedAt.addingTimeInterval(+300),
-            sessionToken: "blast")
+                                                  sessionToken: "blast")
 
         let encoded: Data!
         do {
@@ -394,7 +396,6 @@ class ParseAnonymousTests: XCTestCase {
             XCTFail("Should encode/decode. Error \(error)")
             return
         }
-        MockURLProtocol.removeAll()
         MockURLProtocol.mockRequests { _ in
             return MockURLResponse(data: encoded, statusCode: 200)
         }
@@ -411,6 +412,7 @@ class ParseAnonymousTests: XCTestCase {
 
     func testReplaceAnonymousUserBodySync() async throws {
         try await testLogin()
+        MockURLProtocol.removeAll()
         let user = try await User.current()
         guard let updatedAt = user.updatedAt else {
             XCTFail("Shold have unwrapped")
@@ -419,7 +421,7 @@ class ParseAnonymousTests: XCTestCase {
         XCTAssertTrue(ParseAnonymous<User>.isLinked(with: user))
 
         var response = UpdateSessionTokenResponse(updatedAt: updatedAt.addingTimeInterval(+300),
-            sessionToken: "blast")
+                                                  sessionToken: "blast")
 
         let encoded: Data!
         do {
@@ -430,7 +432,7 @@ class ParseAnonymousTests: XCTestCase {
             XCTFail("Should encode/decode. Error \(error)")
             return
         }
-        MockURLProtocol.removeAll()
+
         MockURLProtocol.mockRequests { _ in
             return MockURLResponse(data: encoded, statusCode: 200)
         }

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -512,7 +512,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
         let user = try await User.current()
 
         var serverResponse = LoginSignupResponse()
-        serverResponse.updatedAt = user.updatedAt?.addingTimeInterval(+300)
+        serverResponse.updatedAt = Date()
         serverResponse.sessionToken = "newValue"
         serverResponse.username = "stop"
 
@@ -553,13 +553,8 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     @MainActor
     func testBecomeTypeMethod() async throws {
-        try await login()
-        MockURLProtocol.removeAll()
-
-        let user = try await User.current()
-
         var serverResponse = LoginSignupResponse()
-        serverResponse.updatedAt = user.updatedAt?.addingTimeInterval(+300)
+        serverResponse.updatedAt = Date()
         serverResponse.sessionToken = "newValue"
         serverResponse.username = "stop"
 

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -300,13 +300,13 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
             XCTAssertTrue(error.containedIn([.otherCause]))
         }
         try await userSignUp()
-        
+
         // Remove sessionToken from Keychain
         _ = try await User.sessionToken()
         var container = await User.currentContainer()
         container?.sessionToken = nil
         await User.setCurrentContainer(container)
-        
+
         do {
             _ = try await User.sessionToken()
             XCTFail("Should have failed")


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
The Swift SDK currently doesn't support the server `loginAs` endpoint to allow impersonating a user.

### Approach
<!-- Add a description of the approach in this PR. -->
- [x] Add the following `loginAs` methods:

```swift
/**
     Logs in a `ParseUser` *asynchronously* with a given `objectId` allowing the impersonation of a User.
     On success, this saves the logged in `ParseUser`with this session to the keychain, so you can retrieve
     the currently logged in user using *current*.

     - parameter objectId: The objectId of the user to login.
     - parameter options: A set of header options sent to the server. Defaults to an empty set.
     - parameter callbackQueue: The queue to return to after completion. Default
     value of .main.
     - parameter completion: The block to execute when completed.
     It should have the following argument signature: `(Result<Self, ParseError>)`.
     - important: The Parse Keychain currently only supports one(1) user at a time. This means
     if you use `loginAs()`, the current logged in user will be replaced. If you would like to revert
     back to the previous user, you should capture the `sesionToken` of the previous user before
     calling `loginAs()`. When you are ready to revert, 1) `logout()`, then `become()` with
     the sessionToken.
     - note: Calling this endpoint does not invoke session triggers such as beforeLogin and
     afterLogin. This action will always succeed if the supplied user exists in the database, regardless
     of whether the user is currently locked out.
     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
     desires a different policy, it should be inserted in `options`.
     - requires: `.usePrimaryKey` has to be available. It is recommended to only
     use the primary key in server-side applications where the key is kept secure and not
     exposed to the public.
    */
    public static func loginAs(objectId: String,
                               options: API.Options = [],
                               callbackQueue: DispatchQueue = .main,
                               completion: @escaping (Result<Self, ParseError>) -> Void)

/**
     Logs in a `ParseUser` *asynchronously* with a given `objectId` allowing the impersonation of a User.
     On success, this saves the logged in `ParseUser`with this session to the keychain, so you can retrieve
     the currently logged in user using *current*.

     - parameter objectId: The objectId of the user to login.
     - parameter options: A set of header options sent to the server. Defaults to an empty set.
     - returns: Returns the logged in `ParseUser`.
     - throws: An error of type `ParseError`.
     - important: The Parse Keychain currently only supports one(1) user at a time. This means
     if you use `loginAs()`, the current logged in user will be replaced. If you would like to revert
     back to the previous user, you should capture the `sesionToken` of the previous user before
     calling `loginAs()`. When you are ready to revert, 1) `logout()`, then `become()` with
     the sessionToken.
     - note: Calling this endpoint does not invoke session triggers such as beforeLogin and
     afterLogin. This action will always succeed if the supplied user exists in the database, regardless
     of whether the user is currently locked out.
     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
     desires a different policy, it should be inserted in `options`.
     - requires: `.usePrimaryKey` has to be available. It is recommended to only
     use the primary key in server-side applications where the key is kept secure and not
     exposed to the public.
    */
    @discardableResult static func loginAs(objectId: String,
                                           options: API.Options = []) async throws -> Self

/**
     Logs in a `ParseUser` *asynchronously* with a given `objectId` allowing the impersonation of a User.
     On success, this saves the logged in `ParseUser`with this session to the keychain, so you can retrieve
     the currently logged in user using *current*.

     - parameter objectId: The objectId of the user to login.
     - parameter options: A set of header options sent to the server. Defaults to an empty set.
     - returns: A publisher that eventually produces a single value and then finishes or fails.
     - important: The Parse Keychain currently only supports one(1) user at a time. This means
     if you use `loginAs()`, the current logged in user will be replaced. If you would like to revert
     back to the previous user, you should capture the `sesionToken` of the previous user before
     calling `loginAs()`. When you are ready to revert, 1) `logout()`, then `become()` with
     the sessionToken.
     - note: Calling this endpoint does not invoke session triggers such as beforeLogin and
     afterLogin. This action will always succeed if the supplied user exists in the database, regardless
     of whether the user is currently locked out.
     - note: The default cache policy for this method is `.reloadIgnoringLocalCacheData`. If a developer
     desires a different policy, it should be inserted in `options`.
     - requires: `.usePrimaryKey` has to be available. It is recommended to only
     use the primary key in server-side applications where the key is kept secure and not
     exposed to the public.
    */
    static func loginAsPublisher(objectId: String,
                                 options: API.Options = []) -> Future<Self, ParseError>
```

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
