### PR TITLE
fix: Only retry connections on specific codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.3.2...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.3.3...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 5.3.2
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.3.2...5.3.3), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.3.2/documentation/parseswift)
+
+__Fixes__
+* Only retry connections on specific codes ([#84](https://github.com/netreconlab/Parse-Swift/pull/84)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 5.3.2
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.3.1...5.3.2), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.3.2/documentation/parseswift)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.3.3...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
-### 5.3.2
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.3.2...5.3.3), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.3.2/documentation/parseswift)
+### 5.3.3
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.3.2...5.3.3), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.3.3/documentation/parseswift)
 
 __Fixes__
 * Only retry connections on specific codes ([#84](https://github.com/netreconlab/Parse-Swift/pull/84)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ import PackageDescription
 let package = Package(
     name: "YOUR_PROJECT_NAME",
     dependencies: [
-        .package(url: "https://github.com/netreconlab/Parse-Swift", .upToNextMajor(from: "5.1.1")),
+        .package(url: "https://github.com/netreconlab/Parse-Swift", .upToNextMajor(from: "5.3.3")),
     ]
 )
 ```

--- a/Sources/ParseSwift/Extensions/URLSession.swift
+++ b/Sources/ParseSwift/Extensions/URLSession.swift
@@ -222,23 +222,11 @@ internal extension URLSession {
                     completion(result)
                 }
 
-                #if !os(Linux) && !os(Android) && !os(Windows)
-                if #available(iOS 16.0, macCatalyst 16.0, tvOS 16.0, watchOS 9.0, macOS 13.0, *) {
-                    try await Task.sleep(for: .seconds(delayInterval))
-                } else {
-                    if delayInterval < 1.0 {
-                        delayInterval = 1.0
-                    }
-                    let delayIntervalNanoSeconds = UInt64(delayInterval * 1_000_000_000)
-                    try await Task.sleep(nanoseconds: delayIntervalNanoSeconds)
-                }
-                #else
                 if delayInterval < 1.0 {
                     delayInterval = 1.0
                 }
                 let delayIntervalNanoSeconds = UInt64(delayInterval * 1_000_000_000)
                 try await Task.sleep(nanoseconds: delayIntervalNanoSeconds)
-                #endif
 
                 await self.dataTask(with: request,
                                     callbackQueue: callbackQueue,

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -58,6 +58,9 @@ internal func initialize(applicationId: String,
     configuration.isMigratingFromObjcSDK = migratingFromObjcSDK
     configuration.isTestingSDK = testing
     configuration.isTestingLiveQueryDontCloseSocket = testLiveQueryDontCloseSocket
+    if testing && maxConnectionAttempts == 5 {
+        configuration.maxConnectionAttempts = 1
+    }
     try await initialize(configuration: configuration)
 }
 

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.3.2"
+    static let version = "5.3.3"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Tests/ParseSwiftTests/APICommandMultipleAttemptsTests.swift
+++ b/Tests/ParseSwiftTests/APICommandMultipleAttemptsTests.swift
@@ -41,6 +41,7 @@ class APICommandMultipleAttemptsTests: XCTestCase {
                                         clientKey: "clientKey",
                                         primaryKey: "primaryKey",
                                         serverURL: url,
+                                        maxConnectionAttempts: 2,
                                         testing: true)
     }
 
@@ -71,7 +72,6 @@ class APICommandMultipleAttemptsTests: XCTestCase {
             errorKey: errorValue,
             codeKey: codeValue
         ]
-        Parse.configuration.maxConnectionAttempts = 2
         let currentAttempts = Result()
 
         MockURLProtocol.mockRequests { _ in
@@ -104,7 +104,7 @@ class APICommandMultipleAttemptsTests: XCTestCase {
                     await currentAttempts.incrementAttempts()
                     let current = await currentAttempts.attempts
                     DispatchQueue.main.async {
-                        if current >= Parse.configuration.maxConnectionAttempts {
+                        if current == 1 {
                             expectation1.fulfill()
                         }
                     }
@@ -115,7 +115,6 @@ class APICommandMultipleAttemptsTests: XCTestCase {
     }
 
     func testErrorHTTPReturns400NoDataFromServer() async throws {
-        Parse.configuration.maxConnectionAttempts = 2
         let originalError = ParseError(code: .otherCause, message: "Could not decode")
         MockURLProtocol.mockRequests { _ in
             return MockURLResponse(error: originalError) // Status code defaults to 400
@@ -155,7 +154,6 @@ class APICommandMultipleAttemptsTests: XCTestCase {
         let headerKey = "x-rate-limit-reset"
         let headerValue = "2"
         let headerFields = [headerKey: headerValue]
-        Parse.configuration.maxConnectionAttempts = 2
         let currentAttempts = Result()
 
         MockURLProtocol.mockRequests { _ in
@@ -219,7 +217,6 @@ class APICommandMultipleAttemptsTests: XCTestCase {
         dateFormatter.dateFormat = "E, d MMM yyyy HH:mm:ss z"
         let headerValue = dateFormatter.string(from: date)
         let headerFields = [headerKey: headerValue]
-        Parse.configuration.maxConnectionAttempts = 2
         let currentAttempts = Result()
 
         MockURLProtocol.mockRequests { _ in
@@ -272,7 +269,6 @@ class APICommandMultipleAttemptsTests: XCTestCase {
             errorKey: errorValue,
             codeKey: codeValue
         ]
-        Parse.configuration.maxConnectionAttempts = 2
         let currentAttempts = Result()
 
         MockURLProtocol.mockRequests { _ in
@@ -328,7 +324,6 @@ class APICommandMultipleAttemptsTests: XCTestCase {
         let headerKey = "retry-after"
         let headerValue = "2"
         let headerFields = [headerKey: headerValue]
-        Parse.configuration.maxConnectionAttempts = 2
         let currentAttempts = Result()
 
         MockURLProtocol.mockRequests { _ in
@@ -392,7 +387,6 @@ class APICommandMultipleAttemptsTests: XCTestCase {
         dateFormatter.dateFormat = "E, d MMM yyyy HH:mm:ss z"
         let headerValue = dateFormatter.string(from: date)
         let headerFields = [headerKey: headerValue]
-        Parse.configuration.maxConnectionAttempts = 2
         let currentAttempts = Result()
 
         MockURLProtocol.mockRequests { _ in
@@ -445,7 +439,6 @@ class APICommandMultipleAttemptsTests: XCTestCase {
             errorKey: errorValue,
             codeKey: codeValue
         ]
-        Parse.configuration.maxConnectionAttempts = 2
         let currentAttempts = Result()
 
         MockURLProtocol.mockRequests { _ in

--- a/Tests/ParseSwiftTests/APICommandTests.swift
+++ b/Tests/ParseSwiftTests/APICommandTests.swift
@@ -213,7 +213,6 @@ class APICommandTests: XCTestCase {
             errorKey: errorValue,
             codeKey: codeValue
         ]
-        Parse.configuration.maxConnectionAttempts = 1
 
         MockURLProtocol.mockRequests { _ in
             do {
@@ -245,7 +244,6 @@ class APICommandTests: XCTestCase {
     }
 
     func testErrorHTTPReturns400NoDataFromServer() async {
-        Parse.configuration.maxConnectionAttempts = 1
         let originalError = ParseError(code: .otherCause, message: "Could not decode")
         MockURLProtocol.mockRequests { _ in
             return MockURLResponse(error: originalError) // Status code defaults to 400
@@ -270,7 +268,6 @@ class APICommandTests: XCTestCase {
 
     // This is how errors HTTP errors should typically come in
     func testErrorHTTP500JSON() async {
-        Parse.configuration.maxConnectionAttempts = 1
         let parseError = ParseError(code: .connectionFailed, message: "Connection failed")
         let errorKey = "error"
         let errorValue = "yarr"
@@ -311,7 +308,6 @@ class APICommandTests: XCTestCase {
     }
 
     func testErrorHTTPReturns500NoDataFromServer() async {
-        Parse.configuration.maxConnectionAttempts = 1
         let originalError = ParseError(code: .otherCause, message: "Could not decode")
         MockURLProtocol.mockRequests { _ in
             var response = MockURLResponse(error: originalError)

--- a/Tests/ParseSwiftTests/ParseHealthCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseHealthCombineTests.swift
@@ -86,7 +86,7 @@ class ParseHealthCombineTests: XCTestCase {
         }
 
         MockURLProtocol.mockRequests { _ in
-            return MockURLResponse(data: encoded, statusCode: 200)
+            return MockURLResponse(data: encoded, statusCode: 503)
         }
 
         ParseHealth.checkPublisher()
@@ -119,7 +119,7 @@ class ParseHealthCombineTests: XCTestCase {
         }
 
         MockURLProtocol.mockRequests { _ in
-            return MockURLResponse(data: encoded, statusCode: 200)
+            return MockURLResponse(data: encoded, statusCode: 429)
         }
 
         ParseHealth.checkPublisher()
@@ -153,7 +153,7 @@ class ParseHealthCombineTests: XCTestCase {
         }
 
         MockURLProtocol.mockRequests { _ in
-            return MockURLResponse(data: encoded, statusCode: 200)
+            return MockURLResponse(data: encoded, statusCode: 429)
         }
 
         ParseHealth.checkPublisher()


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
The SDK was previously retrying connections after any type of error code up to max attempts. An issue that first popped up in #63

### Approach
<!-- Add a description of the approach in this PR. -->
Only retry on specific error codes, otherwise return the current error. Provides a better solution than 63 which can mess with idempotency.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
