### PR TITLE
fix: Prevent crash when the SDK has not been initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.4.1...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.4.2...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+### 5.4.2
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.4.1...5.4.2), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.4.2/documentation/parseswift)
+
 __Fixes__
+* Prevent crash when the developer makes query, fetch, etc. calls before the SDK is properly initialized ([#95](https://github.com/netreconlab/Parse-Swift/pull/95)), thanks to [Corey Baker](https://github.com/cbaker6).
 * Add backwards compatability to Xcode 13.2. Building on Xcode <13.3 only works for SPM ([#92](https://github.com/netreconlab/Parse-Swift/pull/92)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 5.4.1

--- a/Sources/ParseSwift/API/API+NonParseBodyCommand.swift
+++ b/Sources/ParseSwift/API/API+NonParseBodyCommand.swift
@@ -169,6 +169,7 @@ internal extension API.NonParseBodyCommand {
                       objectsSavedBeforeThisOne: [String: PointerType]?,
                       // swiftlint:disable:next line_length
                       filesSavedBeforeThisOne: [String: ParseFile]?) async throws -> RESTBatchCommandTypeEncodablePointer<AnyCodable> {
+        try await yieldIfNotInitialized()
         let defaultACL = try? await ParseACL.defaultACL()
         let batchCommands = try objects.compactMap { (object) -> API.BatchCommand<AnyCodable, PointerType>? in
             guard var objectable = object as? Objectable else {

--- a/Sources/ParseSwift/Objects/ParseInstallation+async.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation+async.swift
@@ -341,7 +341,7 @@ internal extension ParseInstallation {
             case .save:
                 command = try await self.saveCommand(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig)
             case .create:
-                command = await self.createCommand()
+                command = try await self.createCommand()
             case .replace:
                 command = try self.replaceCommand()
             case .update:
@@ -400,7 +400,7 @@ internal extension Sequence where Element: ParseInstallation {
                         try await object.saveCommand(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig)
                     )
                 case .create:
-                    commands.append(await object.createCommand())
+                    commands.append(try await object.createCommand())
                 case .replace:
                     commands.append(try object.replaceCommand())
                 case .update:

--- a/Sources/ParseSwift/Objects/ParseInstallation.swift
+++ b/Sources/ParseSwift/Objects/ParseInstallation.swift
@@ -172,7 +172,8 @@ public extension ParseInstallation {
 // MARK: Convenience
 extension ParseInstallation {
 
-    func endpoint(_ method: API.Method) -> API.Endpoint {
+    func endpoint(_ method: API.Method) async throws -> API.Endpoint {
+        try await yieldIfNotInitialized()
         if !Parse.configuration.isRequiringCustomObjectIds || method != .POST {
             return endpoint
         } else {
@@ -727,17 +728,19 @@ extension ParseInstallation {
     }
 
     func saveCommand(ignoringCustomObjectIdConfig: Bool = false) async throws -> API.Command<Self, Self> {
+        try await yieldIfNotInitialized()
         if Parse.configuration.isRequiringCustomObjectIds && objectId == nil && !ignoringCustomObjectIdConfig {
             throw ParseError(code: .missingObjectId, message: "objectId must not be nil")
         }
-        if isSaved {
+        if try await isSaved() {
             return try replaceCommand() // MARK: Should be switched to "updateCommand" when server supports PATCH.
         }
-        return await createCommand()
+        return try await createCommand()
     }
 
     // MARK: Saving ParseObjects - private
-    func createCommand() async -> API.Command<Self, Self> {
+    func createCommand() async throws -> API.Command<Self, Self> {
+        try await yieldIfNotInitialized()
         var object = self
         if object.ACL == nil,
             let acl = try? await ParseACL.defaultACL() {
@@ -747,7 +750,7 @@ extension ParseInstallation {
             try ParseCoding.jsonDecoder().decode(CreateResponse.self, from: data).apply(to: object)
         }
         return API.Command<Self, Self>(method: .POST,
-                                       path: endpoint(.POST),
+                                       path: try await endpoint(.POST),
                                        body: object,
                                        mapper: mapper)
     }
@@ -854,8 +857,8 @@ extension ParseInstallation {
         }
     }
 
-    func deleteCommand() throws -> API.NonParseBodyCommand<NoBody, NoBody> {
-        guard isSaved else {
+    func deleteCommand() async throws -> API.NonParseBodyCommand<NoBody, NoBody> {
+        guard try await isSaved() else {
             throw ParseError(code: .otherCause, message: "Cannot Delete an object without id")
         }
 

--- a/Sources/ParseSwift/Objects/ParseObject+async.swift
+++ b/Sources/ParseSwift/Objects/ParseObject+async.swift
@@ -385,7 +385,7 @@ or disable transactions for this call.
             case .save:
                 command = try await self.saveCommand(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig)
             case .create:
-                command = await self.createCommand()
+                command = try await self.createCommand()
             case .replace:
                 command = try self.replaceCommand()
             case .update:
@@ -442,7 +442,7 @@ internal extension Sequence where Element: ParseObject {
                         try await object.saveCommand(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig)
                     )
                 case .create:
-                    commands.append(await object.createCommand())
+                    commands.append(try await object.createCommand())
                 case .replace:
                     commands.append(try object.replaceCommand())
                 case .update:

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -909,8 +909,8 @@ extension ParseObject {
                                                ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig)
     }
 
-    internal func createCommand() async -> API.Command<Self, Self> {
-        await API.Command<Self, Self>.create(self)
+    internal func createCommand() async throws -> API.Command<Self, Self> {
+        try await API.Command<Self, Self>.create(self)
     }
 
     internal func replaceCommand() throws -> API.Command<Self, Self> {

--- a/Sources/ParseSwift/Objects/ParseUser+async.swift
+++ b/Sources/ParseSwift/Objects/ParseUser+async.swift
@@ -572,7 +572,7 @@ internal extension ParseUser {
             case .save:
                 command = try await self.saveCommand(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig)
             case .create:
-                command = await self.createCommand()
+                command = try await self.createCommand()
             case .replace:
                 command = try await self.replaceCommand()
             case .update:
@@ -631,7 +631,7 @@ internal extension Sequence where Element: ParseUser {
                         try await object.saveCommand(ignoringCustomObjectIdConfig: ignoringCustomObjectIdConfig)
                     )
                 case .create:
-                    commands.append(await object.createCommand())
+                    commands.append(try await object.createCommand())
                 case .replace:
                     commands.append(try await object.replaceCommand())
                 case .update:

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -102,7 +102,8 @@ public extension ParseUser {
 // MARK: Convenience
 extension ParseUser {
 
-    func endpoint(_ method: API.Method) -> API.Endpoint {
+    func endpoint(_ method: API.Method) async throws -> API.Endpoint {
+        try await yieldIfNotInitialized()
         if !Parse.configuration.isRequiringCustomObjectIds || method != .POST {
             return endpoint
         } else {
@@ -1079,17 +1080,18 @@ extension ParseUser {
     }
 
     func saveCommand(ignoringCustomObjectIdConfig: Bool = false) async throws -> API.Command<Self, Self> {
+        try await yieldIfNotInitialized()
         if Parse.configuration.isRequiringCustomObjectIds && objectId == nil && !ignoringCustomObjectIdConfig {
             throw ParseError(code: .missingObjectId, message: "objectId must not be nil")
         }
         if isSaved {
             return try await replaceCommand() // MARK: Should be switched to "updateCommand" when server supports PATCH.
         }
-        return await createCommand()
+        return try await createCommand()
     }
 
     // MARK: Saving ParseObjects - private
-    func createCommand() async -> API.Command<Self, Self> {
+    func createCommand() async throws -> API.Command<Self, Self> {
         var object = self
         if object.ACL == nil,
             let acl = try? await ParseACL.defaultACL() {
@@ -1099,7 +1101,7 @@ extension ParseUser {
             try ParseCoding.jsonDecoder().decode(CreateResponse.self, from: data).apply(to: object)
         }
         return API.Command<Self, Self>(method: .POST,
-                                       path: endpoint(.POST),
+                                       path: try await endpoint(.POST),
                                        body: object,
                                        mapper: mapper)
     }

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.4.1"
+    static let version = "5.4.2"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Protocols/Objectable.swift
+++ b/Sources/ParseSwift/Protocols/Objectable.swift
@@ -80,7 +80,19 @@ extension Objectable {
     }
 
     /// Specifies if a `ParseObject` has been saved.
+    /// - warning: This will not be available in ParseSwift 6.0.0. Use `isSaved()` instead.
+    /// BAKER mark this internal.
     public var isSaved: Bool {
+        if !Parse.configuration.isRequiringCustomObjectIds {
+            return objectId != nil
+        } else {
+            return objectId != nil && createdAt != nil
+        }
+    }
+
+    /// Specifies if a `ParseObject` has been saved.
+    public func isSaved() async throws -> Bool {
+        try await yieldIfNotInitialized()
         if !Parse.configuration.isRequiringCustomObjectIds {
             return objectId != nil
         } else {
@@ -92,7 +104,8 @@ extension Objectable {
         return try PointerType(self)
     }
 
-    func endpoint(_ method: API.Method) -> API.Endpoint {
+    func endpoint(_ method: API.Method) async throws -> API.Endpoint {
+        try await yieldIfNotInitialized()
         if !Parse.configuration.isRequiringCustomObjectIds || method != .POST {
             return endpoint
         } else {

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -1123,7 +1123,8 @@ extension Query: Queryable {
 
 extension Query {
 
-    func findCommand() throws -> API.NonParseBodyCommand<Query<ResultType>, [ResultType]> {
+    func findCommand() async throws -> API.NonParseBodyCommand<Query<ResultType>, [ResultType]> {
+        try await yieldIfNotInitialized()
         if !Parse.configuration.isUsingPostForQuery {
             return API.NonParseBodyCommand(method: .GET,
                                            path: endpoint,
@@ -1139,7 +1140,8 @@ extension Query {
         }
     }
 
-    func firstCommand() throws -> API.NonParseBodyCommand<Query<ResultType>, ResultType> {
+    func firstCommand() async throws -> API.NonParseBodyCommand<Query<ResultType>, ResultType> {
+        try await yieldIfNotInitialized()
         var query = self
         query.limit = 1
         if !Parse.configuration.isUsingPostForQuery {
@@ -1163,7 +1165,8 @@ extension Query {
         }
     }
 
-    func countCommand() throws -> API.NonParseBodyCommand<Query<ResultType>, Int> {
+    func countCommand() async throws -> API.NonParseBodyCommand<Query<ResultType>, Int> {
+        try await yieldIfNotInitialized()
         var query = self
         query.limit = 0
         query.isCount = true
@@ -1182,7 +1185,8 @@ extension Query {
         }
     }
 
-    func withCountCommand() throws -> API.NonParseBodyCommand<Query<ResultType>, ([ResultType], Int)> {
+    func withCountCommand() async throws -> API.NonParseBodyCommand<Query<ResultType>, ([ResultType], Int)> {
+        try await yieldIfNotInitialized()
         var query = self
         query.isCount = true
         if !Parse.configuration.isUsingPostForQuery {
@@ -1202,7 +1206,8 @@ extension Query {
         }
     }
 
-    func aggregateCommand() throws -> API.NonParseBodyCommand<AggregateBody<ResultType>, [ResultType]> {
+    func aggregateCommand() async throws -> API.NonParseBodyCommand<AggregateBody<ResultType>, [ResultType]> {
+        try await yieldIfNotInitialized()
         let body = AggregateBody(query: self)
         if !Parse.configuration.isUsingPostForQuery {
             return API.NonParseBodyCommand(method: .GET,
@@ -1219,7 +1224,8 @@ extension Query {
         }
     }
 
-    func distinctCommand(key: String) throws -> API.NonParseBodyCommand<DistinctBody<ResultType>, [ResultType]> {
+    func distinctCommand(key: String) async throws -> API.NonParseBodyCommand<DistinctBody<ResultType>, [ResultType]> {
+        try await yieldIfNotInitialized()
         var query = self
         query.distinct = key
         let body = DistinctBody(query: query)
@@ -1238,7 +1244,8 @@ extension Query {
         }
     }
 
-    func findExplainCommand<U: Decodable>() throws -> API.NonParseBodyCommand<Query<ResultType>, [U]> {
+    func findExplainCommand<U: Decodable>() async throws -> API.NonParseBodyCommand<Query<ResultType>, [U]> {
+        try await yieldIfNotInitialized()
         var query = self
         query.explain = true
         if !Parse.configuration.isUsingPostForQuery {
@@ -1256,7 +1263,8 @@ extension Query {
         }
     }
 
-    func firstExplainCommand<U: Decodable>() throws -> API.NonParseBodyCommand<Query<ResultType>, U> {
+    func firstExplainCommand<U: Decodable>() async throws -> API.NonParseBodyCommand<Query<ResultType>, U> {
+        try await yieldIfNotInitialized()
         var query = self
         query.limit = 1
         query.explain = true
@@ -1289,7 +1297,8 @@ extension Query {
         }
     }
 
-    func countExplainCommand<U: Decodable>() throws -> API.NonParseBodyCommand<Query<ResultType>, [U]> {
+    func countExplainCommand<U: Decodable>() async throws -> API.NonParseBodyCommand<Query<ResultType>, [U]> {
+        try await yieldIfNotInitialized()
         var query = self
         query.limit = 1
         query.isCount = true
@@ -1309,7 +1318,8 @@ extension Query {
         }
     }
 
-    func withCountExplainCommand<U: Decodable>() throws -> API.NonParseBodyCommand<Query<ResultType>, [U]> {
+    func withCountExplainCommand<U: Decodable>() async throws -> API.NonParseBodyCommand<Query<ResultType>, [U]> {
+        try await yieldIfNotInitialized()
         var query = self
         query.isCount = true
         query.explain = true
@@ -1328,7 +1338,9 @@ extension Query {
         }
     }
 
-    func aggregateExplainCommand<U: Decodable>() throws -> API.NonParseBodyCommand<AggregateBody<ResultType>, [U]> {
+    // swiftlint:disable:next line_length
+    func aggregateExplainCommand<U: Decodable>() async throws -> API.NonParseBodyCommand<AggregateBody<ResultType>, [U]> {
+        try await yieldIfNotInitialized()
         var query = self
         query.explain = true
         let body = AggregateBody(query: query)
@@ -1348,7 +1360,8 @@ extension Query {
     }
 
     // swiftlint:disable:next line_length
-    func distinctExplainCommand<U: Decodable>(key: String) throws -> API.NonParseBodyCommand<DistinctBody<ResultType>, [U]> {
+    func distinctExplainCommand<U: Decodable>(key: String) async throws -> API.NonParseBodyCommand<DistinctBody<ResultType>, [U]> {
+        try await yieldIfNotInitialized()
         var query = self
         query.explain = true
         query.distinct = key
@@ -1366,7 +1379,8 @@ extension Query {
         }
     }
 
-    func findExplainMongoCommand<U: Decodable>() throws -> API.NonParseBodyCommand<Query<ResultType>, [U]> {
+    func findExplainMongoCommand<U: Decodable>() async throws -> API.NonParseBodyCommand<Query<ResultType>, [U]> {
+        try await yieldIfNotInitialized()
         var query = self
         query.explain = true
         if !Parse.configuration.isUsingPostForQuery {
@@ -1384,7 +1398,8 @@ extension Query {
         }
     }
 
-    func firstExplainMongoCommand<U: Decodable>() throws -> API.NonParseBodyCommand<Query<ResultType>, U> {
+    func firstExplainMongoCommand<U: Decodable>() async throws -> API.NonParseBodyCommand<Query<ResultType>, U> {
+        try await yieldIfNotInitialized()
         var query = self
         query.limit = 1
         query.explain = true
@@ -1413,7 +1428,8 @@ extension Query {
         }
     }
 
-    func countExplainMongoCommand<U: Decodable>() throws -> API.NonParseBodyCommand<Query<ResultType>, [U]> {
+    func countExplainMongoCommand<U: Decodable>() async throws -> API.NonParseBodyCommand<Query<ResultType>, [U]> {
+        try await yieldIfNotInitialized()
         var query = self
         query.limit = 1
         query.isCount = true
@@ -1433,7 +1449,8 @@ extension Query {
         }
     }
 
-    func withCountExplainMongoCommand<U: Decodable>() throws -> API.NonParseBodyCommand<Query<ResultType>, [U]> {
+    func withCountExplainMongoCommand<U: Decodable>() async throws -> API.NonParseBodyCommand<Query<ResultType>, [U]> {
+        try await yieldIfNotInitialized()
         var query = self
         query.isCount = true
         query.explain = true
@@ -1453,7 +1470,8 @@ extension Query {
     }
 
     // swiftlint:disable:next line_length
-    func aggregateExplainMongoCommand<U: Decodable>() throws -> API.NonParseBodyCommand<AggregateBody<ResultType>, [U]> {
+    func aggregateExplainMongoCommand<U: Decodable>() async throws -> API.NonParseBodyCommand<AggregateBody<ResultType>, [U]> {
+        try await yieldIfNotInitialized()
         var query = self
         query.explain = true
         let body = AggregateBody(query: query)
@@ -1473,7 +1491,8 @@ extension Query {
     }
 
     // swiftlint:disable:next line_length
-    func distinctExplainMongoCommand<U: Decodable>(key: String) throws -> API.NonParseBodyCommand<DistinctBody<ResultType>, [U]> {
+    func distinctExplainMongoCommand<U: Decodable>(key: String) async throws -> API.NonParseBodyCommand<DistinctBody<ResultType>, [U]> {
+        try await yieldIfNotInitialized()
         var query = self
         query.explain = true
         query.distinct = key

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -214,7 +214,7 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
     func testCreateCommand() async throws {
         let installation = Installation()
 
-        let command = await installation.createCommand()
+        let command = try await installation.createCommand()
         XCTAssertNotNil(command)
         XCTAssertEqual(command.path.urlComponent, "/installations")
         XCTAssertEqual(command.method, API.Method.POST)
@@ -1820,14 +1820,19 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         var installation = Installation()
         let objectId = "yarr"
         installation.objectId = objectId
-        let command = try installation.deleteCommand()
+        let command = try await installation.deleteCommand()
         XCTAssertNotNil(command)
         XCTAssertEqual(command.path.urlComponent, "/installations/\(objectId)")
         XCTAssertEqual(command.method, API.Method.DELETE)
         XCTAssertNil(command.body)
 
         let installation2 = Installation()
-        XCTAssertThrowsError(try installation2.deleteCommand())
+        do {
+            _ = try await installation2.deleteCommand()
+            XCTFail("Should have thrown error")
+        } catch {
+            XCTAssertNotNil(error as? ParseError)
+        }
     }
 
     func testDeleteCurrent() async throws {

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -963,7 +963,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
     func testCreateCommand() async throws {
         let score = GameScore(points: 10)
 
-        let command = await score.createCommand()
+        let command = try await score.createCommand()
         XCTAssertNotNil(command)
         XCTAssertEqual(command.path.urlComponent, "/classes/\(score.className)")
         XCTAssertEqual(command.method, API.Method.POST)

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -414,9 +414,9 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(query.`where`.constraints.values.count, 2)
     }
 
-    func testFindCommand() throws {
+    func testFindCommand() async throws {
         let query = GameScore.query
-        let command = try query.findCommand()
+        let command = try await query.findCommand()
         // swiftlint:disable:next line_length
         let expected = "{\"body\":{\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{}},\"method\":\"POST\",\"path\":\"\\/classes\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()
@@ -432,10 +432,10 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(query.description, expected)
     }
 
-    func testFindExplainCommand() throws {
+    func testFindExplainCommand() async throws {
         let query = GameScore.query()
         let command: API.NonParseBodyCommand<Query<ParseQueryTests.GameScore>,
-                                             [GameScore]> = try query.findExplainCommand()
+                                             [GameScore]> = try await query.findExplainCommand()
         // swiftlint:disable:next line_length
         let expected = "{\"body\":{\"_method\":\"GET\",\"explain\":true,\"limit\":100,\"skip\":0,\"where\":{}},\"method\":\"POST\",\"path\":\"\\/classes\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()
@@ -757,9 +757,9 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         wait(for: [expectation], timeout: 20.0)
     }
 
-    func testFirstCommand() throws {
+    func testFirstCommand() async throws {
         let query = GameScore.query()
-        let command = try query.firstCommand()
+        let command = try await query.firstCommand()
         // swiftlint:disable:next line_length
         let expected = "{\"body\":{\"_method\":\"GET\",\"limit\":1,\"skip\":0,\"where\":{}},\"method\":\"POST\",\"path\":\"\\/classes\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()
@@ -768,10 +768,10 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(decoded, expected)
     }
 
-    func testFirstExplainCommand() throws {
+    func testFirstExplainCommand() async throws {
         let query = GameScore.query()
         let command: API.NonParseBodyCommand<Query<ParseQueryTests.GameScore>,
-                                             GameScore> = try query.firstExplainCommand()
+                                             GameScore> = try await query.firstExplainCommand()
         // swiftlint:disable:next line_length
         let expected = "{\"body\":{\"_method\":\"GET\",\"explain\":true,\"limit\":1,\"skip\":0,\"where\":{}},\"method\":\"POST\",\"path\":\"\\/classes\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()
@@ -1009,9 +1009,9 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         wait(for: [expectation], timeout: 20.0)
     }
 
-    func testCountCommand() throws {
+    func testCountCommand() async throws {
         let query = GameScore.query()
-        let command = try query.countCommand()
+        let command = try await query.countCommand()
         // swiftlint:disable:next line_length
         let expected = "{\"body\":{\"_method\":\"GET\",\"count\":true,\"limit\":0,\"skip\":0,\"where\":{}},\"method\":\"POST\",\"path\":\"\\/classes\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()
@@ -1020,10 +1020,10 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(decoded, expected)
     }
 
-    func testCountExplainCommand() throws {
+    func testCountExplainCommand() async throws {
         let query = GameScore.query()
         let command: API.NonParseBodyCommand<Query<ParseQueryTests.GameScore>,
-                                             [Int]> = try query.countExplainCommand()
+                                             [Int]> = try await query.countExplainCommand()
         // swiftlint:disable:next line_length
         let expected = "{\"body\":{\"_method\":\"GET\",\"count\":true,\"explain\":true,\"limit\":1,\"skip\":0,\"where\":{}},\"method\":\"POST\",\"path\":\"\\/classes\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()
@@ -3454,11 +3454,11 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         wait(for: [expectation], timeout: 20.0)
     }
 
-    func testAggregateCommand() throws {
+    func testAggregateCommand() async throws {
         var query = GameScore.query()
         let value = AnyCodable("world")
         query.pipeline = [["hello": value]]
-        let aggregate = try query.aggregateCommand()
+        let aggregate = try await query.aggregateCommand()
         // swiftlint:disable:next line_length
         let expected = "{\"body\":{\"pipeline\":[{\"hello\":\"\(value)\"}]},\"method\":\"POST\",\"path\":\"\\/aggregate\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()
@@ -3467,10 +3467,10 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(decoded, expected)
     }
 
-    func testAggregateExplainCommand() throws {
+    func testAggregateExplainCommand() async throws {
         let query = GameScore.query()
         let command: API.NonParseBodyCommand<Query<GameScore>.AggregateBody<GameScore>,
-                                             [String]> = try query.aggregateExplainCommand()
+                                             [String]> = try await query.aggregateExplainCommand()
         let expected = "{\"body\":{\"explain\":true},\"method\":\"POST\",\"path\":\"\\/aggregate\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()
             .encode(command)
@@ -3478,9 +3478,9 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(decoded, expected)
     }
 
-    func testDistinctCommand() throws {
+    func testDistinctCommand() async throws {
         let query = GameScore.query()
-        let aggregate = try query.distinctCommand(key: "hello")
+        let aggregate = try await query.distinctCommand(key: "hello")
         let expected = "{\"body\":{\"distinct\":\"hello\"},\"method\":\"POST\",\"path\":\"\\/aggregate\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()
             .encode(aggregate)
@@ -3488,10 +3488,10 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertEqual(decoded, expected)
     }
 
-    func testDistinctExplainCommand() throws {
+    func testDistinctExplainCommand() async throws {
         let query = GameScore.query()
         let command: API.NonParseBodyCommand<Query<GameScore>.DistinctBody<GameScore>,
-                                             [String]> = try query.distinctExplainCommand(key: "hello")
+                                             [String]> = try await query.distinctExplainCommand(key: "hello")
         // swiftlint:disable:next line_length
         let expected = "{\"body\":{\"distinct\":\"hello\",\"explain\":true},\"method\":\"POST\",\"path\":\"\\/aggregate\\/GameScore\"}"
         let encoded = try ParseCoding.jsonEncoder()

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -1293,7 +1293,7 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
     func testCreateCommand() async throws {
         let user = User()
 
-        let command = await user.createCommand()
+        let command = try await user.createCommand()
         XCTAssertNotNil(command)
         XCTAssertEqual(command.path.urlComponent, "/users")
         XCTAssertEqual(command.method, API.Method.POST)


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
The SDK can crash if the developer makes a call that requires a ParseSwift config parameter, but hasn't properly configured the SDK.

### Approach
<!-- Add a description of the approach in this PR. -->
Suspend all method calls that access the SDK config parameters until the SDK is initialized or throw an error after the default time limit (current 5 seconds) if the suspend time is exceeded.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
