### PR TITLE
feat: Add the ability to login users automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.4.3...5.5.0), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.5.0/documentation/parseswift)
 
 __New features__
+* Adds a setting to enable automatic user login by calling User.current(). The setting can be enabled/disabled when initializing the SDK by setting "usingAutomaticLogin" or at anytime after initialization using User.enableAutomaticLogin() ([#98](https://github.com/netreconlab/Parse-Swift/pull/98)), thanks to [Corey Baker](https://github.com/cbaker6).
 * Add ParseServer.information() to retrieve version and info from a Parse Server. Depracates ParseHealth and check() in favor of ParseServer and health() respectively ([#97](https://github.com/netreconlab/Parse-Swift/pull/97)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 5.4.3

--- a/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication+async.swift
+++ b/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication+async.swift
@@ -89,4 +89,15 @@ public extension ParseUser {
         }
     }
 
+    internal static func signupWithAuthData(_ type: String,
+                                            authData: [String: String],
+                                            options: API.Options = []) async throws -> Self {
+        try await withCheckedThrowingContinuation { continuation in
+            Self.signupWithAuthData(type,
+                                    authData: authData,
+                                    options: options,
+                                    completion: continuation.resume)
+        }
+    }
+
 }

--- a/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
+++ b/Sources/ParseSwift/Authentication/Protocols/ParseAuthentication.swift
@@ -255,17 +255,31 @@ public extension ParseUser {
                           callbackQueue: callbackQueue,
                           completion: completion)
             } catch {
-                let body = SignupLoginBody(authData: [type: authData])
-                do {
-                    try await signupCommand(body: body)
-                        .execute(options: options,
-                                 callbackQueue: callbackQueue,
-                                 completion: completion)
-                } catch {
-                    let parseError = error as? ParseError ?? ParseError(swift: error)
-                    callbackQueue.async {
-                        completion(.failure(parseError))
-                    }
+                signupWithAuthData(type,
+                                   authData: authData,
+                                   options: options,
+                                   callbackQueue: callbackQueue,
+                                   completion: completion)
+            }
+        }
+    }
+
+    internal static func signupWithAuthData(_ type: String,
+                                            authData: [String: String],
+                                            options: API.Options = [],
+                                            callbackQueue: DispatchQueue = .main,
+                                            completion: @escaping (Result<Self, ParseError>) -> Void) {
+        let body = SignupLoginBody(authData: [type: authData])
+        Task {
+            do {
+                try await signupCommand(body: body)
+                    .execute(options: options,
+                             callbackQueue: callbackQueue,
+                             completion: completion)
+            } catch {
+                let parseError = error as? ParseError ?? ParseError(swift: error)
+                callbackQueue.async {
+                    completion(.failure(parseError))
                 }
             }
         }

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -1595,8 +1595,8 @@ public extension ParseObject {
      `Self.current()` will always have a value or throw an error from the server.
      When enabled, the user will only be created on the server once.
      
-     - parameter enable: **true** enables if automatic user is not already enabled in
-     `ParseConfiguration`, **false** otherwise. Defaults to **true**.
+     - parameter enable: **true** allows automatic user logins, **false**
+     disables automatic user logins. Defaults to **true**.
      - throws: An error of `ParseError` type.
      */
     static func enableAutomaticLogin(_ enable: Bool = true) async throws {

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -29,7 +29,7 @@ internal func initialize(applicationId: String,
                          usingDataProtectionKeychain: Bool = false,
                          deletingKeychainIfNeeded: Bool = false,
                          httpAdditionalHeaders: [AnyHashable: Any]? = nil,
-                         usingAutomaticUser: Bool = false,
+                         usingAutomaticLogin: Bool = false,
                          maxConnectionAttempts: Int = 5,
                          liveQueryMaxConnectionAttempts: Int = 20,
                          testing: Bool = false,
@@ -53,7 +53,7 @@ internal func initialize(applicationId: String,
                                            usingDataProtectionKeychain: usingDataProtectionKeychain,
                                            deletingKeychainIfNeeded: deletingKeychainIfNeeded,
                                            httpAdditionalHeaders: httpAdditionalHeaders,
-                                           usingAutomaticUser: usingAutomaticUser,
+                                           usingAutomaticLogin: usingAutomaticLogin,
                                            maxConnectionAttempts: maxConnectionAttempts,
                                            liveQueryMaxConnectionAttempts: liveQueryMaxConnectionAttempts,
                                            authentication: authentication)
@@ -237,7 +237,7 @@ public func initialize(configuration: ParseConfiguration) async throws { // swif
  - parameter httpAdditionalHeaders: A dictionary of additional headers to send with requests. See Apple's
  [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
  for more info.
- - parameter isUsingAutomaticUser: If ** true**, automatic creation of anonymous users are enabled.
+ - parameter usingAutomaticLogin: If **true**, automatic creation of anonymous users are enabled.
  When enabled, `User.current()` will always have a value or throw an error from the server. The user will only be created on
  the server once.
  - parameter maxConnectionAttempts: Maximum number of times to try to connect to Parse Server.
@@ -275,7 +275,7 @@ public func initialize(
     usingDataProtectionKeychain: Bool = false,
     deletingKeychainIfNeeded: Bool = false,
     httpAdditionalHeaders: [AnyHashable: Any]? = nil,
-    usingAutomaticUser: Bool = false,
+    usingAutomaticLogin: Bool = false,
     maxConnectionAttempts: Int = 5,
     liveQueryMaxConnectionAttempts: Int = 20,
     parseFileTransfer: ParseFileTransferable? = nil,
@@ -299,7 +299,7 @@ public func initialize(
                                            usingDataProtectionKeychain: usingDataProtectionKeychain,
                                            deletingKeychainIfNeeded: deletingKeychainIfNeeded,
                                            httpAdditionalHeaders: httpAdditionalHeaders,
-                                           usingAutomaticUser: usingAutomaticUser,
+                                           usingAutomaticLogin: usingAutomaticLogin,
                                            maxConnectionAttempts: maxConnectionAttempts,
                                            liveQueryMaxConnectionAttempts: liveQueryMaxConnectionAttempts,
                                            parseFileTransfer: parseFileTransfer,

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -237,7 +237,7 @@ public func initialize(configuration: ParseConfiguration) async throws { // swif
  - parameter httpAdditionalHeaders: A dictionary of additional headers to send with requests. See Apple's
  [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
  for more info.
- - parameter usingAutomaticLogin: If **true**, automatic creation of anonymous users are enabled.
+ - parameter usingAutomaticLogin: If **true**, automatic creation of anonymous users is enabled.
  When enabled, `User.current()` will always have a value or throw an error from the server. The user will only be created on
  the server once.
  - parameter maxConnectionAttempts: Maximum number of times to try to connect to Parse Server.

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -29,6 +29,7 @@ internal func initialize(applicationId: String,
                          usingDataProtectionKeychain: Bool = false,
                          deletingKeychainIfNeeded: Bool = false,
                          httpAdditionalHeaders: [AnyHashable: Any]? = nil,
+                         usingAutomaticUser: Bool = false,
                          maxConnectionAttempts: Int = 5,
                          liveQueryMaxConnectionAttempts: Int = 20,
                          testing: Bool = false,
@@ -52,6 +53,7 @@ internal func initialize(applicationId: String,
                                            usingDataProtectionKeychain: usingDataProtectionKeychain,
                                            deletingKeychainIfNeeded: deletingKeychainIfNeeded,
                                            httpAdditionalHeaders: httpAdditionalHeaders,
+                                           usingAutomaticUser: usingAutomaticUser,
                                            maxConnectionAttempts: maxConnectionAttempts,
                                            liveQueryMaxConnectionAttempts: liveQueryMaxConnectionAttempts,
                                            authentication: authentication)
@@ -235,6 +237,9 @@ public func initialize(configuration: ParseConfiguration) async throws { // swif
  - parameter httpAdditionalHeaders: A dictionary of additional headers to send with requests. See Apple's
  [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
  for more info.
+ - parameter isUsingAutomaticUser: If ** true**, automatic creation of anonymous users are enabled.
+ When enabled, `User.current()` will always have a value or throw an error from the server. The user will only be created on
+ the server once.
  - parameter maxConnectionAttempts: Maximum number of times to try to connect to Parse Server.
  Defaults to 5.
  - parameter liveQueryMaxConnectionAttempts: Maximum number of times to try to connect to a Parse
@@ -270,6 +275,7 @@ public func initialize(
     usingDataProtectionKeychain: Bool = false,
     deletingKeychainIfNeeded: Bool = false,
     httpAdditionalHeaders: [AnyHashable: Any]? = nil,
+    usingAutomaticUser: Bool = false,
     maxConnectionAttempts: Int = 5,
     liveQueryMaxConnectionAttempts: Int = 20,
     parseFileTransfer: ParseFileTransferable? = nil,
@@ -293,6 +299,7 @@ public func initialize(
                                            usingDataProtectionKeychain: usingDataProtectionKeychain,
                                            deletingKeychainIfNeeded: deletingKeychainIfNeeded,
                                            httpAdditionalHeaders: httpAdditionalHeaders,
+                                           usingAutomaticUser: usingAutomaticUser,
                                            maxConnectionAttempts: maxConnectionAttempts,
                                            liveQueryMaxConnectionAttempts: liveQueryMaxConnectionAttempts,
                                            parseFileTransfer: parseFileTransfer,

--- a/Sources/ParseSwift/Types/ParseConfiguration.swift
+++ b/Sources/ParseSwift/Types/ParseConfiguration.swift
@@ -91,6 +91,12 @@ public struct ParseConfiguration {
     ///  apps do not have credentials to setup a Keychain.
     public internal(set) var isUsingDataProtectionKeychain: Bool = false
 
+    /// If ** true**, automatic creation of anonymous users are enabled.
+    /// When enabled, `User.current()` will always have a value or throw an error from the server.
+    /// The user will only be created on the server once.
+    /// Defaults to **false**.
+    public internal(set) var isUsingAutomaticUser: Bool = false
+
     /// Maximum number of times to try to connect to a Parse Server.
     /// Defaults to 5.
     public internal(set) var maxConnectionAttempts: Int = 5
@@ -147,6 +153,9 @@ public struct ParseConfiguration {
      - parameter httpAdditionalHeaders: A dictionary of additional headers to send with requests. See Apple's
      [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
      for more info.
+     - parameter isUsingAutomaticUser: If ** true**, automatic creation of anonymous users are enabled.
+     When enabled, `User.current()` will always have a value or throw an error from the server. The user will only be created on
+     the server once.
      - parameter maxConnectionAttempts: Maximum number of times to try to connect to a Parse Server.
      Defaults to 5.
      - parameter liveQueryMaxConnectionAttempts: Maximum number of times to try to connect to a Parse
@@ -181,6 +190,7 @@ public struct ParseConfiguration {
                 usingDataProtectionKeychain: Bool = false,
                 deletingKeychainIfNeeded: Bool = false,
                 httpAdditionalHeaders: [AnyHashable: Any]? = nil,
+                usingAutomaticUser: Bool = false,
                 maxConnectionAttempts: Int = 5,
                 liveQueryMaxConnectionAttempts: Int = 20,
                 parseFileTransfer: ParseFileTransferable? = nil,
@@ -206,6 +216,7 @@ public struct ParseConfiguration {
         self.isUsingDataProtectionKeychain = usingDataProtectionKeychain
         self.isDeletingKeychainIfNeeded = deletingKeychainIfNeeded
         self.httpAdditionalHeaders = httpAdditionalHeaders
+        self.isUsingAutomaticUser = usingAutomaticUser
         self.maxConnectionAttempts = maxConnectionAttempts
         self.liveQueryMaxConnectionAttempts = liveQueryMaxConnectionAttempts
         self.parseFileTransfer = parseFileTransfer ?? ParseFileDefaultTransfer()

--- a/Sources/ParseSwift/Types/ParseConfiguration.swift
+++ b/Sources/ParseSwift/Types/ParseConfiguration.swift
@@ -91,11 +91,11 @@ public struct ParseConfiguration {
     ///  apps do not have credentials to setup a Keychain.
     public internal(set) var isUsingDataProtectionKeychain: Bool = false
 
-    /// If ** true**, automatic creation of anonymous users are enabled.
+    /// If **true**, automatic creation of anonymous users are enabled.
     /// When enabled, `User.current()` will always have a value or throw an error from the server.
     /// The user will only be created on the server once.
     /// Defaults to **false**.
-    public internal(set) var isUsingAutomaticUser: Bool = false
+    public internal(set) var isUsingAutomaticLogin: Bool = false
 
     /// Maximum number of times to try to connect to a Parse Server.
     /// Defaults to 5.
@@ -153,7 +153,7 @@ public struct ParseConfiguration {
      - parameter httpAdditionalHeaders: A dictionary of additional headers to send with requests. See Apple's
      [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
      for more info.
-     - parameter isUsingAutomaticUser: If ** true**, automatic creation of anonymous users are enabled.
+     - parameter usingAutomaticLogin: If **true**, automatic creation of anonymous users are enabled.
      When enabled, `User.current()` will always have a value or throw an error from the server. The user will only be created on
      the server once.
      - parameter maxConnectionAttempts: Maximum number of times to try to connect to a Parse Server.
@@ -190,7 +190,7 @@ public struct ParseConfiguration {
                 usingDataProtectionKeychain: Bool = false,
                 deletingKeychainIfNeeded: Bool = false,
                 httpAdditionalHeaders: [AnyHashable: Any]? = nil,
-                usingAutomaticUser: Bool = false,
+                usingAutomaticLogin: Bool = false,
                 maxConnectionAttempts: Int = 5,
                 liveQueryMaxConnectionAttempts: Int = 20,
                 parseFileTransfer: ParseFileTransferable? = nil,
@@ -216,7 +216,7 @@ public struct ParseConfiguration {
         self.isUsingDataProtectionKeychain = usingDataProtectionKeychain
         self.isDeletingKeychainIfNeeded = deletingKeychainIfNeeded
         self.httpAdditionalHeaders = httpAdditionalHeaders
-        self.isUsingAutomaticUser = usingAutomaticUser
+        self.isUsingAutomaticLogin = usingAutomaticLogin
         self.maxConnectionAttempts = maxConnectionAttempts
         self.liveQueryMaxConnectionAttempts = liveQueryMaxConnectionAttempts
         self.parseFileTransfer = parseFileTransfer ?? ParseFileDefaultTransfer()

--- a/Sources/ParseSwift/Types/ParseConfiguration.swift
+++ b/Sources/ParseSwift/Types/ParseConfiguration.swift
@@ -91,7 +91,7 @@ public struct ParseConfiguration {
     ///  apps do not have credentials to setup a Keychain.
     public internal(set) var isUsingDataProtectionKeychain: Bool = false
 
-    /// If **true**, automatic creation of anonymous users are enabled.
+    /// If **true**, automatic creation of anonymous users is enabled.
     /// When enabled, `User.current()` will always have a value or throw an error from the server.
     /// The user will only be created on the server once.
     /// Defaults to **false**.
@@ -153,7 +153,7 @@ public struct ParseConfiguration {
      - parameter httpAdditionalHeaders: A dictionary of additional headers to send with requests. See Apple's
      [documentation](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411532-httpadditionalheaders)
      for more info.
-     - parameter usingAutomaticLogin: If **true**, automatic creation of anonymous users are enabled.
+     - parameter usingAutomaticLogin: If **true**, automatic creation of anonymous users is enabled.
      When enabled, `User.current()` will always have a value or throw an error from the server. The user will only be created on
      the server once.
      - parameter maxConnectionAttempts: Maximum number of times to try to connect to a Parse Server.

--- a/Sources/ParseSwift/Types/ParseVersion.swift
+++ b/Sources/ParseSwift/Types/ParseVersion.swift
@@ -172,7 +172,7 @@ public struct ParseVersion: ParseTypeable, Hashable {
 }
 
 // MARK: Default Implementation
-extension ParseVersion {
+public extension ParseVersion {
 
     init(string: String) throws {
         self = try Self.convertVersionString(string)

--- a/Tests/ParseSwiftTests/ParseAuthenticationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationAsyncTests.swift
@@ -223,4 +223,5 @@ class ParseAuthenticationAsyncTests: XCTestCase {
         XCTAssertEqual(user.username, "hello10")
         XCTAssertNil(user.password)
     }
+
 }

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -2543,5 +2543,14 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
                 }
         }
     }
+
+    func testEnableAutomaticLogin() async throws {
+        XCTAssertFalse(Parse.configuration.isUsingAutomaticLogin)
+        try await User.enableAutomaticLogin()
+        XCTAssertTrue(Parse.configuration.isUsingAutomaticLogin)
+        try await User.enableAutomaticLogin(false)
+        XCTAssertFalse(Parse.configuration.isUsingAutomaticLogin)
+    }
+
 }
 // swiftlint:disable:this file_length

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -2546,6 +2546,8 @@ class ParseUserTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testEnableAutomaticLogin() async throws {
         XCTAssertFalse(Parse.configuration.isUsingAutomaticLogin)
+        try await User.enableAutomaticLogin(false)
+        XCTAssertFalse(Parse.configuration.isUsingAutomaticLogin)
         try await User.enableAutomaticLogin()
         XCTAssertTrue(Parse.configuration.isUsingAutomaticLogin)
         try await User.enableAutomaticLogin(false)


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Currently there is now to automatically login a user.

### Approach
<!-- Add a description of the approach in this PR. -->
Add the ability to configure the SDK to allow automatic login by setting `usingAutomaticLogin` to **true** or by calling `try await User.enableAutomaticLogin()` at anytime after SDK initialization.

The automatic login leverages [ParseAnonynous](https://swiftpackageindex.com/netreconlab/parse-swift/5.4.3/documentation/parseswift/parseanonymous) to login, so anonymous login needs to be enabled on the Parse Server to use this feature.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
