### PR TITLE
feat: Add config setting for not sending additional properties for Li…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.5.1...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.6.0...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 5.6.0
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.5.1...5.6.0), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.6.0/documentation/parseswift)
+
+__New features__
+* Adds liveQueryConnectionAdditionalProperties parameter to SDK configuration to prevent additional properties from being sent to LiveQuery servers. This is useful for Parse Servers < 4.0.0 ([#103](https://github.com/netreconlab/Parse-Swift/pull/103)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Fixes__
 * Modernize Xcode project by using only one framework target. Also removes Carthage testing from CI ([#101](https://github.com/netreconlab/Parse-Swift/pull/101)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/ParseSwift.playground/Pages/11 - LiveQuery.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/11 - LiveQuery.xcplaygroundpage/Contents.swift
@@ -24,13 +24,6 @@ class LiveQueryDelegate: ParseLiveQueryDelegate {
 Task {
     do {
         try await initializeParse()
-        //: Set the delegate.
-        let delegate = LiveQueryDelegate()
-        if let client = ParseLiveQuery.defaultClient {
-            client.receiveDelegate = delegate
-        } else {
-            assertionFailure("LiveQuery should have a default client")
-        }
     } catch {
         assertionFailure("Error initializing Parse-Swift: \(error)")
     }
@@ -119,6 +112,14 @@ Task {
     } catch {
         assertionFailure("Error subscribing: \(error)")
     }
+}
+
+//: This is how you set a delegate for the default client.
+let delegate = LiveQueryDelegate()
+if let client = ParseLiveQuery.defaultClient {
+    client.receiveDelegate = delegate
+} else {
+    assertionFailure("LiveQuery should have a default client")
 }
 
 //: Ping the LiveQuery server
@@ -234,9 +235,13 @@ Task {
             print("Unsubscribed from \(query)")
         }
 
+        //: Delay for 2 seconds
+        let nanoSeconds = UInt64(2 * 1_000_000_000)
+        try await Task.sleep(nanoseconds: nanoSeconds)
+
         //: To unsubscribe from your query.
         do {
-            try await query2.unsubscribe()
+            try await query.unsubscribe()
         } catch {
             print(error)
         }

--- a/Sources/ParseSwift/Documentation.docc/ParseSwift.md
+++ b/Sources/ParseSwift/Documentation.docc/ParseSwift.md
@@ -19,7 +19,7 @@ This repo is maintained by [Corey E. Baker](https://github.com/cbaker6), [1 of 2
 ### Configure SDK
 
 - ``ParseSwift/initialize(configuration:)``
-- ``ParseSwift/initialize(applicationId:clientKey:primaryKey:serverURL:liveQueryServerURL:requiringCustomObjectIds:usingTransactions:usingEqualQueryConstraint:usingPostForQuery:primitiveStore:requestCachePolicy:cacheMemoryCapacity:cacheDiskCapacity:usingDataProtectionKeychain:deletingKeychainIfNeeded:httpAdditionalHeaders:usingAutomaticLogin:maxConnectionAttempts:liveQueryMaxConnectionAttempts:parseFileTransfer:authentication:)``
+- ``ParseSwift/initialize(applicationId:clientKey:primaryKey:serverURL:liveQueryServerURL:requiringCustomObjectIds:usingTransactions:usingEqualQueryConstraint:usingPostForQuery:primitiveStore:requestCachePolicy:cacheMemoryCapacity:cacheDiskCapacity:usingDataProtectionKeychain:deletingKeychainIfNeeded:httpAdditionalHeaders:usingAutomaticLogin:maxConnectionAttempts:liveQueryConnectionAdditionalProperties:liveQueryMaxConnectionAttempts:parseFileTransfer:authentication:)``
 - ``ParseSwift/configuration``
 - ``ParseSwift/setAccessGroup(_:synchronizeAcrossDevices:)``
 - ``ParseSwift/updateAuthentication(_:)``

--- a/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
+++ b/Sources/ParseSwift/LiveQuery/LiveQuerySocket.swift
@@ -52,9 +52,11 @@ extension LiveQuerySocket {
 // MARK: Connect
 extension LiveQuerySocket {
     func connect(_ task: URLSessionWebSocketTask) async throws {
+        try await yieldIfNotInitialized()
         let encoded = try ParseCoding.jsonEncoder()
             .encode(await StandardMessage(operation: .connect,
-                                          additionalProperties: true))
+                                          // swiftlint:disable:next line_length
+                                          additionalProperties: Parse.configuration.liveQueryConnectionAdditionalProperties))
         guard let encodedAsString = String(data: encoded, encoding: .utf8) else {
             throw ParseError(code: .otherCause,
                              message: "Could not encode connect message: \(encoded)")

--- a/Sources/ParseSwift/LiveQuery/Messages.swift
+++ b/Sources/ParseSwift/LiveQuery/Messages.swift
@@ -20,12 +20,23 @@ struct StandardMessage: LiveQueryable, Codable {
 
     init(operation: ClientOperation, additionalProperties: Bool = false) async {
         self.op = operation
-        if additionalProperties {
+        switch operation {
+        case .connect:
             self.applicationId = Parse.configuration.applicationId
             self.primaryKey = Parse.configuration.primaryKey
             self.clientKey = Parse.configuration.clientKey
             self.sessionToken = await BaseParseUser.currentContainer()?.sessionToken
-            self.installationId = await BaseParseInstallation.currentContainer().installationId
+            if additionalProperties {
+                self.installationId = await BaseParseInstallation.currentContainer().installationId
+            }
+        default:
+            if additionalProperties {
+                self.applicationId = Parse.configuration.applicationId
+                self.primaryKey = Parse.configuration.primaryKey
+                self.clientKey = Parse.configuration.clientKey
+                self.sessionToken = await BaseParseUser.currentContainer()?.sessionToken
+                self.installationId = await BaseParseInstallation.currentContainer().installationId
+            }
         }
     }
 

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -31,6 +31,7 @@ internal func initialize(applicationId: String,
                          httpAdditionalHeaders: [AnyHashable: Any]? = nil,
                          usingAutomaticLogin: Bool = false,
                          maxConnectionAttempts: Int = 5,
+                         liveQueryConnectionAdditionalProperties: Bool = true,
                          liveQueryMaxConnectionAttempts: Int = 20,
                          testing: Bool = false,
                          testLiveQueryDontCloseSocket: Bool = false,
@@ -55,6 +56,7 @@ internal func initialize(applicationId: String,
                                            httpAdditionalHeaders: httpAdditionalHeaders,
                                            usingAutomaticLogin: usingAutomaticLogin,
                                            maxConnectionAttempts: maxConnectionAttempts,
+                                           liveQueryConnectionAdditionalProperties: liveQueryConnectionAdditionalProperties,
                                            liveQueryMaxConnectionAttempts: liveQueryMaxConnectionAttempts,
                                            authentication: authentication)
     configuration.isMigratingFromObjcSDK = migratingFromObjcSDK
@@ -242,6 +244,7 @@ public func initialize(configuration: ParseConfiguration) async throws { // swif
  the server once.
  - parameter maxConnectionAttempts: Maximum number of times to try to connect to Parse Server.
  Defaults to 5.
+ - parameter liveQueryConnectionAdditionalProperties: Send additional information when establishing Parse LiveQuery connections.
  - parameter liveQueryMaxConnectionAttempts: Maximum number of times to try to connect to a Parse
  LiveQuery Server. Defaults to 20.
  - parameter parseFileTransfer: Override the default transfer behavior for `ParseFile`'s.
@@ -277,6 +280,7 @@ public func initialize(
     httpAdditionalHeaders: [AnyHashable: Any]? = nil,
     usingAutomaticLogin: Bool = false,
     maxConnectionAttempts: Int = 5,
+    liveQueryConnectionAdditionalProperties: Bool = true,
     liveQueryMaxConnectionAttempts: Int = 20,
     parseFileTransfer: ParseFileTransferable? = nil,
     authentication: ((URLAuthenticationChallenge,
@@ -301,6 +305,7 @@ public func initialize(
                                            httpAdditionalHeaders: httpAdditionalHeaders,
                                            usingAutomaticLogin: usingAutomaticLogin,
                                            maxConnectionAttempts: maxConnectionAttempts,
+                                           liveQueryConnectionAdditionalProperties: liveQueryConnectionAdditionalProperties,
                                            liveQueryMaxConnectionAttempts: liveQueryMaxConnectionAttempts,
                                            parseFileTransfer: parseFileTransfer,
                                            authentication: authentication)

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.5.1"
+    static let version = "5.6.0"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Types/ParseConfiguration.swift
+++ b/Sources/ParseSwift/Types/ParseConfiguration.swift
@@ -101,6 +101,10 @@ public struct ParseConfiguration {
     /// Defaults to 5.
     public internal(set) var maxConnectionAttempts: Int = 5
 
+    /// Send additional information when establishing Parse LiveQuery connections.
+    /// Defaults to **true**.
+    public internal(set) var liveQueryConnectionAdditionalProperties: Bool = true
+
     /// Maximum number of times to try to connect to a Parse LiveQuery Server.
     /// Defaults to 20.
     public internal(set) var liveQueryMaxConnectionAttempts: Int = 20
@@ -158,6 +162,7 @@ public struct ParseConfiguration {
      the server once.
      - parameter maxConnectionAttempts: Maximum number of times to try to connect to a Parse Server.
      Defaults to 5.
+     - parameter liveQueryConnectionAdditionalProperties: Send additional information when establishing Parse LiveQuery connections.
      - parameter liveQueryMaxConnectionAttempts: Maximum number of times to try to connect to a Parse
      LiveQuery Server. Defaults to 20.
      - parameter parseFileTransfer: Override the default transfer behavior for `ParseFile`'s.
@@ -192,6 +197,7 @@ public struct ParseConfiguration {
                 httpAdditionalHeaders: [AnyHashable: Any]? = nil,
                 usingAutomaticLogin: Bool = false,
                 maxConnectionAttempts: Int = 5,
+                liveQueryConnectionAdditionalProperties: Bool = true,
                 liveQueryMaxConnectionAttempts: Int = 20,
                 parseFileTransfer: ParseFileTransferable? = nil,
                 authentication: ((URLAuthenticationChallenge,
@@ -218,6 +224,7 @@ public struct ParseConfiguration {
         self.httpAdditionalHeaders = httpAdditionalHeaders
         self.isUsingAutomaticLogin = usingAutomaticLogin
         self.maxConnectionAttempts = maxConnectionAttempts
+        self.liveQueryConnectionAdditionalProperties = liveQueryConnectionAdditionalProperties
         self.liveQueryMaxConnectionAttempts = liveQueryMaxConnectionAttempts
         self.parseFileTransfer = parseFileTransfer ?? ParseFileDefaultTransfer()
         self.primitiveStore = primitiveStore ?? InMemoryPrimitiveStore()

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -213,6 +213,29 @@ class ParseLiveQueryTests: XCTestCase {
         XCTAssertEqual(decoded, expected)
     }
 
+    func testStandardMessageNotConnectionEncoding() async throws {
+        guard let installationId = await BaseParseInstallation.currentContainer().installationId else {
+            XCTFail("Should have installationId")
+            return
+        }
+        // swiftlint:disable:next line_length
+        let expected = "{\"applicationId\":\"applicationId\",\"clientKey\":\"clientKey\",\"installationId\":\"\(installationId)\",\"masterKey\":\"primaryKey\",\"op\":\"subscribe\"}"
+        let message = await StandardMessage(operation: .subscribe, additionalProperties: true)
+        let encoded = try ParseCoding.jsonEncoder()
+            .encode(message)
+        let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertEqual(decoded, expected)
+    }
+
+    func testStandardMessageNotConnectionNoAddEncoding() async throws {
+        let expected = "{\"op\":\"subscribe\"}"
+        let message = await StandardMessage(operation: .subscribe, additionalProperties: false)
+        let encoded = try ParseCoding.jsonEncoder()
+            .encode(message)
+        let decoded = try XCTUnwrap(String(data: encoded, encoding: .utf8))
+        XCTAssertEqual(decoded, expected)
+    }
+
     func testSubscribeMessageFieldsEncoding() async throws {
         // swiftlint:disable:next line_length
         let expected = "{\"op\":\"subscribe\",\"query\":{\"className\":\"GameScore\",\"fields\":[\"hello\",\"points\"],\"where\":{\"points\":{\"$gt\":9}}},\"requestId\":1}"


### PR DESCRIPTION
…veQuery connections

### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Parse Server < 4.0.0 can't handle certain types of properties during LiveQuery connection #102 

### Approach
<!-- Add a description of the approach in this PR. -->
Provide a SDK config property, `liveQueryConnectionAdditionalProperties` that can be set to `false` to work with old servers. e.g:

```swift
try await ParseSwift.initialize(applicationId: "applicationId",
                                         clientKey: "clientKey",
                                         primaryKey: "primaryKey",
                                         serverURL: url,
                                         liveQueryConnectionAdditionalProperties: false)
```

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
