### PR TITLE
feat: Add failedLoginCount and accountLockoutExpiresAt to ParseCloudUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.6.0...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.0...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 5.7.0
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.6.0...5.7.0), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.7.0/documentation/parseswift)
+
+__New features__
+* Add failedLoginCount and accountLockoutExpiresAt to ParseCloudUser protocol for better access ([#109](https://github.com/netreconlab/Parse-Swift/pull/109)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 5.6.0
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.5.1...5.6.0), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.6.0/documentation/parseswift)
@@ -172,7 +178,7 @@ __Fixes__
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/4.15.1...4.15.2), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/4.15.2/documentation/parseswift)
 
 __Fixes__
-- Fixed an issue that prevented nested ParseObjects and ParsFiles from saving correctly in some cases ([#8](https://github.com/netreconlab/Parse-Swift/pull/8)), thanks to [Corey Baker](https://github.com/cbaker6).
+- Fixed an issue that prevented nested ParseObjects and ParseFiles from saving correctly in some cases ([#8](https://github.com/netreconlab/Parse-Swift/pull/8)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 4.15.1
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/4.15.0...4.15.1), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/4.15.1/documentation/parseswift)

--- a/Sources/ParseSwift/Objects/ParseCloudUser.swift
+++ b/Sources/ParseSwift/Objects/ParseCloudUser.swift
@@ -13,11 +13,39 @@ import Foundation
  needed for Parse hook calls.
  */
 public protocol ParseCloudUser: ParseUser {
+
     /// The session token of the `ParseUser`.
     var sessionToken: String? { get set }
+
     /// The number of unsuccessful login attempts.
+    var failedLoginCount: Int? { get }
+
+    /// The number of unsuccessful login attempts.
+    /// - Important: This property is required for decoding purposes.
+    /// You should use `failedLoginCount` to access this value.
     var _failed_login_count: Int? { get }
+
     /// The date the lockout expires. After this date, the `ParseUser`
     /// can attempt to login again.
+    var accountLockoutExpiresAt: Date? { get }
+
+    /// The date the lockout expires. After this date, the `ParseUser`
+    /// can attempt to login again.
+    /// - Important: This property is required for decoding purposes.
+    /// You should use `accountLockoutExpiresAt` to access this value.
     var _account_lockout_expires_at: Date? { get }
+
+}
+
+// MARK: Convenience Implementations
+public extension ParseCloudUser {
+
+    var failedLoginCount: Int? {
+        _failed_login_count
+    }
+
+    var accountLockoutExpiresAt: Date? {
+        _account_lockout_expires_at
+    }
+
 }

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.6.0"
+    static let version = "5.7.0"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Tests/ParseSwiftTests/ParseHookFunctionRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionRequestTests.swift
@@ -13,6 +13,7 @@ import FoundationNetworking
 import XCTest
 @testable import ParseSwift
 
+// swiftlint:disable:next type_body_length
 class ParseHookFunctionRequestTests: XCTestCase {
 
     struct Parameters: ParseHookParametable {
@@ -74,6 +75,28 @@ class ParseHookFunctionRequestTests: XCTestCase {
         try await KeychainStore.shared.deleteAll()
         #endif
         try await ParseStorage.shared.deleteAll()
+    }
+
+    func testCloudUserCoding() async throws {
+        let sessionToken = "heel"
+        let failedLoginCount = 3
+        var accountLockoutExpiresAt = Date()
+        let encodedDate = try ParseCoding.jsonEncoder().encode(accountLockoutExpiresAt)
+        guard let encodeedDateString = String(data: encodedDate, encoding: .utf8) else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+        accountLockoutExpiresAt = try ParseCoding.jsonDecoder().decode(Date.self, from: encodedDate)
+        // swiftlint:disable:next line_length
+        let encodedString = "{\"className\":\"_User\",\"sessionToken\":\"\(sessionToken)\",\"_failed_login_count\":\(failedLoginCount),\"_account_lockout_expires_at\":\(encodeedDateString)}"
+        guard let encoded = encodedString.data(using: .utf8) else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+        let decoded = try ParseCoding.jsonDecoder().decode(User.self, from: encoded)
+        XCTAssertEqual(decoded.sessionToken, sessionToken)
+        XCTAssertEqual(decoded.failedLoginCount, failedLoginCount)
+        XCTAssertEqual(decoded.accountLockoutExpiresAt, accountLockoutExpiresAt)
     }
 
     func testCoding() async throws {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Currently `ParseCloudUser` requires developers to access properties `_failed_login_count` and `_account_lockout_expires_at` which would typically be unaccessible due to the underscore.

### Approach
<!-- Add a description of the approach in this PR. -->

Add properties `failedLoginCount` and `accountLockoutExpiresAt` to access private properties.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
