### PR TITLE
fix: ParsePolygon.containsPoint() correctly uses longitude and latitude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,18 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.0...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.1...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 5.7.1
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.0...5.7.1), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.7.1/documentation/parseswift)
+
+__Fixes__
+* ParsePolygon is encoded/decoded incorrectly. The latitude and longitude are swapped and should be 
+(latitude, longitude) instead of (longitude, latitude). If a developer used ParseSwift <= 5.7.0
+to save ParsePolygon's, they will need to update the respective ParseObjects by swapping the latitude 
+and longitude manually ([#116](https://github.com/netreconlab/Parse-Swift/pull/116)), thanks to 
+[Corey Baker](https://github.com/cbaker6).
 
 ### 5.7.0
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.6.0...5.7.0), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.7.0/documentation/parseswift)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,7 @@
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.0...5.7.1), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.7.1/documentation/parseswift)
 
 __Fixes__
-* ParsePolygon is encoded/decoded incorrectly. The latitude and longitude are swapped and should be 
-(latitude, longitude) instead of (longitude, latitude). If a developer used ParseSwift <= 5.7.0
-to save ParsePolygon's, they will need to update the respective ParseObjects by swapping the latitude 
-and longitude manually ([#116](https://github.com/netreconlab/Parse-Swift/pull/116)), thanks to 
+* ParsePolygon containsPoint correctly uses longitude and latitude ([#116](https://github.com/netreconlab/Parse-Swift/pull/116)), thanks to 
 [Corey Baker](https://github.com/cbaker6).
 
 ### 5.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.0...5.7.1), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.7.1/documentation/parseswift)
 
 __Fixes__
-* ParsePolygon containsPoint correctly uses longitude and latitude ([#116](https://github.com/netreconlab/Parse-Swift/pull/116)), thanks to 
+* ParsePolygon.containsPoint() correctly uses longitude and latitude ([#116](https://github.com/netreconlab/Parse-Swift/pull/116)), thanks to 
 [Corey Baker](https://github.com/cbaker6).
 
 ### 5.7.0

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -27,11 +27,12 @@ struct GameScore: ParseObject {
     var createdAt: Date?
     var updatedAt: Date?
     var ACL: ParseACL?
-    var location: ParseGeoPoint?
     var originalData: Data?
 
     //: Your own properties
     var points: Int?
+    var location: ParseGeoPoint?
+    var polygon: ParsePolygon?
 
     /*:
      Optional - implement your own version of merge
@@ -42,6 +43,14 @@ struct GameScore: ParseObject {
         if updated.shouldRestoreKey(\.points,
                                      original: object) {
             updated.points = object.points
+        }
+        if updated.shouldRestoreKey(\.location,
+                                     original: object) {
+            updated.location = object.location
+        }
+        if updated.shouldRestoreKey(\.polygon,
+                                     original: object) {
+            updated.polygon = object.polygon
         }
         return updated
     }
@@ -60,6 +69,12 @@ extension GameScore {
 var score = GameScore(points: 10)
 do {
     try score.location = ParseGeoPoint(latitude: 40.0, longitude: -30.0)
+    let points: [ParseGeoPoint] = [
+        try .init(latitude: 35.0, longitude: -30.0),
+        try .init(latitude: 42.0, longitude: -35.0),
+        try .init(latitude: 42.0, longitude: -20.0)
+    ]
+    score.polygon = try ParsePolygon(points)
 }
 
 /*:
@@ -75,13 +90,22 @@ score.save { result in
         assert(savedScore.updatedAt != nil)
         assert(savedScore.points == 10)
         assert(savedScore.location != nil)
+        assert(savedScore.polygon != nil)
 
         guard let location = savedScore.location else {
             print("Something went wrong")
             return
         }
 
-        print(location)
+        print("Saved location: \(location)")
+
+        guard let polygon = savedScore.polygon else {
+            print("Something went wrong")
+            return
+        }
+
+        print("Saved polygon: \(polygon)")
+        print("Saved polygon geopoints: \(polygon.coordinates)")
 
     case .failure(let error):
         assertionFailure("Error saving: \(error)")

--- a/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/7 - GeoPoint.xcplaygroundpage/Contents.swift
@@ -265,9 +265,9 @@ query8.findAll { result in
 
 do {
     let points: [ParseGeoPoint] = [
-        try .init(latitude: 35.0, longitude: -28.0),
-        try .init(latitude: 45.0, longitude: -28.0),
-        try .init(latitude: 39.0, longitude: -35.0)
+        try .init(latitude: 35.0, longitude: -30.0),
+        try .init(latitude: 42.0, longitude: -35.0),
+        try .init(latitude: 42.0, longitude: -20.0)
     ]
     let query9 = GameScore.query(withinPolygon(key: "location", points: points))
     query9.find { results in
@@ -291,9 +291,9 @@ do {
 
 do {
     let points: [ParseGeoPoint] = [
-        try .init(latitude: 35.0, longitude: -28.0),
-        try .init(latitude: 45.0, longitude: -28.0),
-        try .init(latitude: 39.0, longitude: -35.0)
+        try .init(latitude: 35.0, longitude: -30.0),
+        try .init(latitude: 42.0, longitude: -35.0),
+        try .init(latitude: 42.0, longitude: -20.0)
     ]
     let polygon = try ParsePolygon(points)
     let query10 = GameScore.query(withinPolygon(key: "location", polygon: polygon))

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.7.0"
+    static let version = "5.7.1"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Types/ParsePolygon.swift
+++ b/Sources/ParseSwift/Types/ParsePolygon.swift
@@ -51,25 +51,25 @@ public struct ParsePolygon: ParseTypeable, Hashable {
        - parameter point: The point to check.
      */
     public func containsPoint(_ point: ParseGeoPoint) -> Bool {
-        var minX = coordinates[0].latitude
-        var maxX = coordinates[0].latitude
-        var minY = coordinates[0].longitude
-        var maxY = coordinates[0].longitude
+        var minX = coordinates[0].longitude
+        var maxX = coordinates[0].longitude
+        var minY = coordinates[0].latitude
+        var maxY = coordinates[0].latitude
 
         var modifiedCoordinates = coordinates
         modifiedCoordinates.removeFirst()
         for coordinate in modifiedCoordinates {
-            minX = Swift.min(coordinate.latitude, minX)
-            maxX = Swift.max(coordinate.latitude, maxX)
-            minY = Swift.min(coordinate.longitude, minY)
-            maxY = Swift.max(coordinate.longitude, maxY)
+            minX = Swift.min(coordinate.longitude, minX)
+            maxX = Swift.max(coordinate.longitude, maxX)
+            minY = Swift.min(coordinate.latitude, minY)
+            maxY = Swift.max(coordinate.latitude, maxY)
         }
 
         // Check if outside of the polygon
-        if point.latitude < minX ||
-            point.latitude > maxX ||
-            point.longitude < minY ||
-            point.longitude > maxY {
+        if point.longitude < minX ||
+            point.longitude > maxX ||
+            point.latitude < minY ||
+            point.latitude > maxY {
             return false
         }
 
@@ -78,14 +78,14 @@ public struct ParsePolygon: ParseTypeable, Hashable {
         // Check if intersects polygon
         var otherIndex = coordinates.count - 1
         for (index, coordinate) in coordinates.enumerated() {
-            let startX = coordinate.latitude
-            let startY = coordinate.longitude
-            let endX = coordinates[otherIndex].latitude
-            let endY = coordinates[otherIndex].longitude
-            let startYComparison = startY > point.longitude
-            let endYComparison = endY > point.longitude
+            let startX = coordinate.longitude
+            let startY = coordinate.latitude
+            let endX = coordinates[otherIndex].longitude
+            let endY = coordinates[otherIndex].latitude
+            let startYComparison = startY > point.latitude
+            let endYComparison = endY > point.latitude
             if startYComparison != endYComparison &&
-                point.latitude < ((endX - startX) * (point.longitude - startY)) / (endY - startY) + startX {
+                point.longitude < ((endX - startX) * (point.latitude - startY)) / (endY - startY) + startX {
                 return true
             }
             if index == 0 {
@@ -108,7 +108,7 @@ extension ParsePolygon {
         try container.encode(__type, forKey: .__type)
         var nestedUnkeyedContainer = container.nestedUnkeyedContainer(forKey: .coordinates)
         try coordinates.forEach {
-            try nestedUnkeyedContainer.encode([$0.latitude, $0.longitude])
+            try nestedUnkeyedContainer.encode([$0.longitude, $0.latitude])
         }
     }
 
@@ -124,8 +124,8 @@ extension ParsePolygon {
         let points = try values.decode([[Double]].self, forKey: .coordinates)
         try points.forEach {
             if $0.count == 2 {
-                guard let latitude = $0.first,
-                      let longitude = $0.last else {
+                guard let latitude = $0.last,
+                      let longitude = $0.first else {
                     throw ParseError(code: .otherCause, message: "Could not decode ParsePolygon: \(points)")
                 }
                 decodedCoordinates.append(try ParseGeoPoint(latitude: latitude,

--- a/Tests/ParseSwiftTests/ParsePolygonTests.swift
+++ b/Tests/ParseSwiftTests/ParsePolygonTests.swift
@@ -117,13 +117,13 @@ class ParsePolygonTests: XCTestCase {
 
     func testDebugString() throws {
         let polygon = try ParsePolygon(points)
-        let expected = "{\"__type\":\"Polygon\",\"coordinates\":[[0,0],[1,0],[1,1],[0,1],[0,0]]}"
+        let expected = "{\"__type\":\"Polygon\",\"coordinates\":[[0,0],[0,1],[1,1],[1,0],[0,0]]}"
         XCTAssertEqual(polygon.debugDescription, expected)
     }
 
     func testDescription() throws {
         let polygon = try ParsePolygon(points)
-        let expected = "{\"__type\":\"Polygon\",\"coordinates\":[[0,0],[1,0],[1,1],[0,1],[0,0]]}"
+        let expected = "{\"__type\":\"Polygon\",\"coordinates\":[[0,0],[0,1],[1,1],[1,0],[0,0]]}"
         XCTAssertEqual(polygon.description, expected)
     }
 }

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -2947,7 +2947,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testWhereKeyWithinPolygon() throws {
         // swiftlint:disable:next line_length
-        let expected = "{\"yolo\":{\"$geoWithin\":{\"$polygon\":{\"__type\":\"Polygon\",\"coordinates\":[[20.100000000000001,10.1],[30.100000000000001,20.100000000000001],[40.100000000000001,30.100000000000001]]}}}}"
+        let expected = "{\"yolo\":{\"$geoWithin\":{\"$polygon\":{\"__type\":\"Polygon\",\"coordinates\":[[10.1,20.100000000000001],[20.100000000000001,30.100000000000001],[30.100000000000001,40.100000000000001]]}}}}"
         let geoPoint1 = try ParseGeoPoint(latitude: 10.1, longitude: 20.1)
         let geoPoint2 = try ParseGeoPoint(latitude: 20.1, longitude: 30.1)
         let geoPoint3 = try ParseGeoPoint(latitude: 30.1, longitude: 40.1)

--- a/Tests/ParseSwiftTests/ParseQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryTests.swift
@@ -2947,7 +2947,7 @@ class ParseQueryTests: XCTestCase { // swiftlint:disable:this type_body_length
 
     func testWhereKeyWithinPolygon() throws {
         // swiftlint:disable:next line_length
-        let expected = "{\"yolo\":{\"$geoWithin\":{\"$polygon\":{\"__type\":\"Polygon\",\"coordinates\":[[10.1,20.100000000000001],[20.100000000000001,30.100000000000001],[30.100000000000001,40.100000000000001]]}}}}"
+        let expected = "{\"yolo\":{\"$geoWithin\":{\"$polygon\":{\"__type\":\"Polygon\",\"coordinates\":[[20.100000000000001,10.1],[30.100000000000001,20.100000000000001],[40.100000000000001,30.100000000000001]]}}}}"
         let geoPoint1 = try ParseGeoPoint(latitude: 10.1, longitude: 20.1)
         let geoPoint2 = try ParseGeoPoint(latitude: 20.1, longitude: 30.1)
         let geoPoint3 = try ParseGeoPoint(latitude: 30.1, longitude: 40.1)


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
ParsePolygon is encoded/decoded incorrectly with the latitude and longitude being (latitude, longitude) instead of (longitude, latitude).

### Approach
<!-- Add a description of the approach in this PR. -->
Swap the latitude and longitude from (latitude, longitude) to (longitude, latitude). If a developer used ParseSwift <= 5.7.0 to save ParsePolygon's, they will need to update the respective ParseObjects by swapping the latitude and longitude manually.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
