### PR TITLE
fix: Save and decode ParsePolygon correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,19 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.1...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.2...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 5.7.2
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.1...5.7.2), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.7.2/documentation/parseswift)
+
+__Fixes__
+* ParsePolygon encoding during a save and decoding resulted in (longitude, latitude) when it should be
+ (latitude, longitude). If a developer used ParseSwift <= 5.7.1
+ to save/update ParsePolygon's, they will need to update the respective ParseObjects by swapping the latitude 
+ and longitude manually. Deprecated withinPolygon() query constraint for geoPoint() and polygonContains() for 
+ polygon() ([#118](https://github.com/netreconlab/Parse-Swift/pull/118)), thanks to 
+[Corey Baker](https://github.com/cbaker6).
 
 ### 5.7.1
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.0...5.7.1), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.7.1/documentation/parseswift)

--- a/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/1 - Your first Object.xcplaygroundpage/Contents.swift
@@ -81,7 +81,7 @@ struct GameData: ParseObject {
     var originalData: Data?
 
     //: Your own properties.
-    var polygon: ParsePolygon?
+    var fence: ParsePolygon?
     //: `ParseBytes` needs to be a part of the original schema
     //: or else you will need your primaryKey to force an upgrade.
     var bytes: ParseBytes?
@@ -92,9 +92,9 @@ struct GameData: ParseObject {
      */
     func merge(with object: Self) throws -> Self {
         var updated = try mergeParse(with: object)
-        if shouldRestoreKey(\.polygon,
+        if shouldRestoreKey(\.fence,
                              original: object) {
-            updated.polygon = object.polygon
+            updated.fence = object.fence
         }
         if shouldRestoreKey(\.bytes,
                              original: object) {
@@ -108,9 +108,9 @@ struct GameData: ParseObject {
 //: to preserve the memberwise initializer.
 extension GameData {
 
-    init (bytes: ParseBytes?, polygon: ParsePolygon) {
+    init (bytes: ParseBytes?, fence: ParsePolygon) {
         self.bytes = bytes
-        self.polygon = polygon
+        self.fence = fence
     }
 }
 
@@ -396,18 +396,18 @@ Task {
 
 Task {
     //: How to add `ParseBytes` and `ParsePolygon` to objects.
-    let points = [
-        try ParseGeoPoint(latitude: 0, longitude: 0),
-        try ParseGeoPoint(latitude: 0, longitude: 1),
-        try ParseGeoPoint(latitude: 1, longitude: 1),
-        try ParseGeoPoint(latitude: 1, longitude: 0),
-        try ParseGeoPoint(latitude: 0, longitude: 0)
+    let detroitPoints = [
+        try ParseGeoPoint(latitude: 42.631655189280224, longitude: -83.78406753121705),
+        try ParseGeoPoint(latitude: 42.633047793854814, longitude: -83.75333640366955),
+        try ParseGeoPoint(latitude: 42.61625254348911, longitude: -83.75149921669944),
+        try ParseGeoPoint(latitude: 42.61526926650296, longitude: -83.78161794858735),
+        try ParseGeoPoint(latitude: 42.631655189280224, longitude: -83.78406753121705)
     ]
 
     do {
-        let polygon = try ParsePolygon(points)
+        let detroit = try ParsePolygon(detroitPoints)
         let bytes = ParseBytes(data: "hello world".data(using: .utf8)!)
-        var gameData = GameData(bytes: bytes, polygon: polygon)
+        var gameData = GameData(bytes: bytes, fence: detroit)
         gameData = try await gameData.save()
         print("Successfully saved: \(gameData)")
     } catch {

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.7.1"
+    static let version = "5.7.2"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Types/ParsePolygon.swift
+++ b/Sources/ParseSwift/Types/ParsePolygon.swift
@@ -14,7 +14,7 @@
 public struct ParsePolygon: ParseTypeable, Hashable {
     private let __type: String = "Polygon" // swiftlint:disable:this identifier_name
     public let coordinates: [ParseGeoPoint]
-    var flipEncodingCoordinates = false
+    var isSwappingCoordinates = false
 
     enum CodingKeys: String, CodingKey {
         case __type // swiftlint:disable:this identifier_name
@@ -109,7 +109,7 @@ extension ParsePolygon {
         try container.encode(__type, forKey: .__type)
         var nestedUnkeyedContainer = container.nestedUnkeyedContainer(forKey: .coordinates)
         try coordinates.forEach {
-            guard flipEncodingCoordinates else {
+            guard isSwappingCoordinates else {
                 try nestedUnkeyedContainer.encode([$0.latitude, $0.longitude])
                 return
             }

--- a/Sources/ParseSwift/Types/QueryConstraint.swift
+++ b/Sources/ParseSwift/Types/QueryConstraint.swift
@@ -621,7 +621,7 @@ public func withinPolygon(key: String, points: [ParseGeoPoint]) -> QueryConstrai
  */
 public func geoPoint(_ key: String, within polygon: ParsePolygon) -> QueryConstraint {
     var polygon = polygon
-    polygon.flipEncodingCoordinates = true
+    polygon.isSwappingCoordinates = true
     let dictionary = [QueryConstraint.Comparator.polygon.rawValue: polygon]
     return .init(key: key, value: dictionary, comparator: .geoWithin)
 }

--- a/Sources/ParseSwift/Types/QueryConstraint.swift
+++ b/Sources/ParseSwift/Types/QueryConstraint.swift
@@ -587,8 +587,42 @@ public func withinGeoBox(key: String, fromSouthWest southwest: ParseGeoPoint,
  - warning: Requires Parse Server 2.5.0+.
  - returns: The same instance of `QueryConstraint` as the receiver.
  */
-public func withinPolygon(key: String, points: [ParseGeoPoint]) -> QueryConstraint {
+public func geoPoint(_ key: String, within points: [ParseGeoPoint]) -> QueryConstraint {
     let dictionary = [QueryConstraint.Comparator.polygon.rawValue: points]
+    return .init(key: key, value: dictionary, comparator: .geoWithin)
+}
+
+/**
+ Add a constraint to the query that requires a particular key's
+ coordinates be contained within and on the bounds of a given polygon
+ Supports closed and open (last point is connected to first) paths.
+
+ Polygon must have at least 3 points.
+
+ - parameter key: The key to be constrained.
+ - parameter points: The polygon points as an Array of `ParseGeoPoint`'s.
+ - warning: Requires Parse Server 2.5.0+.
+ - returns: The same instance of `QueryConstraint` as the receiver.
+ */
+@available(*, deprecated, renamed: "geoPoint")
+public func withinPolygon(key: String, points: [ParseGeoPoint]) -> QueryConstraint {
+    geoPoint(key, within: points)
+}
+
+/**
+ Add a constraint to the query that requires a particular key's
+ coordinates be contained within and on the bounds of a given polygon
+ Supports closed and open (last point is connected to first) paths.
+
+ - parameter key: The key to be constrained.
+ - parameter polygon: The `ParsePolygon`.
+ - warning: Requires Parse Server 2.5.0+.
+ - returns: The same instance of `QueryConstraint` as the receiver.
+ */
+public func geoPoint(_ key: String, within polygon: ParsePolygon) -> QueryConstraint {
+    var polygon = polygon
+    polygon.flipEncodingCoordinates = true
+    let dictionary = [QueryConstraint.Comparator.polygon.rawValue: polygon]
     return .init(key: key, value: dictionary, comparator: .geoWithin)
 }
 
@@ -602,9 +636,9 @@ public func withinPolygon(key: String, points: [ParseGeoPoint]) -> QueryConstrai
  - warning: Requires Parse Server 2.5.0+.
  - returns: The same instance of `QueryConstraint` as the receiver.
  */
+@available(*, deprecated, renamed: "geoPoint")
 public func withinPolygon(key: String, polygon: ParsePolygon) -> QueryConstraint {
-    let dictionary = [QueryConstraint.Comparator.polygon.rawValue: polygon]
-    return .init(key: key, value: dictionary, comparator: .geoWithin)
+    geoPoint(key, within: polygon)
 }
 
 /**
@@ -616,9 +650,23 @@ public func withinPolygon(key: String, polygon: ParsePolygon) -> QueryConstraint
  - warning: Requires Parse Server 2.6.0+.
  - returns: The same instance of `QueryConstraint` as the receiver.
  */
-public func polygonContains(key: String, point: ParseGeoPoint) -> QueryConstraint {
+public func polygon(_ key: String, contains point: ParseGeoPoint) -> QueryConstraint {
     let dictionary = [QueryConstraint.Comparator.point.rawValue: point]
     return .init(key: key, value: dictionary, comparator: .geoIntersects)
+}
+
+/**
+ Add a constraint to the query that requires a particular key's
+ coordinates contains a `ParseGeoPoint`.
+
+ - parameter key: The key of the `ParsePolygon`.
+ - parameter point: The `ParseGeoPoint` to check for containment.
+ - warning: Requires Parse Server 2.6.0+.
+ - returns: The same instance of `QueryConstraint` as the receiver.
+ */
+@available(*, deprecated, renamed: "polygon")
+public func polygonContains(key: String, point: ParseGeoPoint) -> QueryConstraint {
+    polygon(key, contains: point)
 }
 
 /**

--- a/Tests/ParseSwiftTests/ParsePolygonTests.swift
+++ b/Tests/ParseSwiftTests/ParsePolygonTests.swift
@@ -89,7 +89,7 @@ class ParsePolygonTests: XCTestCase {
 
     func testDecode() throws {
         var polygon = try ParsePolygon(points)
-        polygon.flipEncodingCoordinates = false
+        polygon.isSwappingCoordinates = false
         let encoded = try ParseCoding.jsonEncoder().encode(polygon)
         let decoded = try ParseCoding.jsonDecoder().decode(ParsePolygon.self, from: encoded)
         XCTAssertEqual(decoded, polygon)

--- a/Tests/ParseSwiftTests/ParsePolygonTests.swift
+++ b/Tests/ParseSwiftTests/ParsePolygonTests.swift
@@ -76,7 +76,7 @@ class ParsePolygonTests: XCTestCase {
 
     func testEncode() throws {
         let polygon = try ParsePolygon(points)
-        let expected = "{\"__type\":\"Polygon\",\"coordinates\":[[0,0],[1,0],[1,1],[0,1],[0,0]]}"
+        let expected = "{\"__type\":\"Polygon\",\"coordinates\":[[0,0],[0,1],[1,1],[1,0],[0,0]]}"
         XCTAssertEqual(polygon.debugDescription, expected)
         guard polygon.coordinates.count == points.count else {
             XCTAssertEqual(polygon.coordinates.count, points.count)
@@ -88,7 +88,8 @@ class ParsePolygonTests: XCTestCase {
     }
 
     func testDecode() throws {
-        let polygon = try ParsePolygon(points)
+        var polygon = try ParsePolygon(points)
+        polygon.flipEncodingCoordinates = false
         let encoded = try ParseCoding.jsonEncoder().encode(polygon)
         let decoded = try ParseCoding.jsonDecoder().decode(ParsePolygon.self, from: encoded)
         XCTAssertEqual(decoded, polygon)
@@ -141,7 +142,7 @@ class ParsePolygonTests: XCTestCase {
 
     func testDescription() throws {
         let polygon = try ParsePolygon(points)
-        let expected = "{\"__type\":\"Polygon\",\"coordinates\":[[0,0],[1,0],[1,1],[0,1],[0,0]]}"
+        let expected = "{\"__type\":\"Polygon\",\"coordinates\":[[0,0],[0,1],[1,1],[1,0],[0,0]]}"
         XCTAssertEqual(polygon.description, expected)
     }
 }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
`ParsePolygon` encoding during a save and decoding resulted in `(longitude, latitude)` when it should be
 `(latitude, longitude)`.

### Approach
<!-- Add a description of the approach in this PR. -->
When a `ParsePolygon` is saved, encode it as `(latitude, longitude)`. If querying with a `ParsePolygon` as a constraint, encode it as `(longitude, latitude)`. Always decode a `ParsePolygon` as `(latitude, longitude)`.

If a developer used ParseSwift <= 5.7.1 to save/update ParsePolygon's, they will need to update the respective `ParseObject`'s by swapping the latitude and longitude manually. 

Deprecated `withinPolygon()` query constraint for `geoPoint()` and `polygonContains()` for `polygon()`

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
