### PR TITLE
fix: remove all generic shadow warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,20 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.2...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.3...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 5.7.2
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.2...5.7.3), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.7.3/documentation/parseswift)
+
+__Fixes__
+* Remove all generic shadow warnings in Swift 5.9 ([#120](https://github.com/netreconlab/Parse-Swift/pull/120)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 5.7.2
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.1...5.7.2), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.7.2/documentation/parseswift)
 
 __Fixes__
-* ParsePolygon encoding during a save and decoding resulted in (longitude, latitude) when it should be
- (latitude, longitude). If a developer used ParseSwift <= 5.7.1
- to save/update ParsePolygon's, they will need to update the respective ParseObjects by swapping the latitude 
- and longitude manually. Deprecated withinPolygon() query constraint for geoPoint() and polygonContains() for 
- polygon() ([#118](https://github.com/netreconlab/Parse-Swift/pull/118)), thanks to 
-[Corey Baker](https://github.com/cbaker6).
+* ParsePolygon encoding during a save and decoding resulted in (longitude, latitude) when it should be (latitude, longitude). If a developer used ParseSwift <= 5.7.1 to save/update ParsePolygon's, they will need to update the respective ParseObjects by swapping the latitude and longitude manually. Deprecated withinPolygon() query constraint for geoPoint() and polygonContains() for polygon() ([#118](https://github.com/netreconlab/Parse-Swift/pull/118)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 5.7.1
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.0...5.7.1), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.7.1/documentation/parseswift)

--- a/Sources/ParseSwift/API/API+NonParseBodyCommand.swift
+++ b/Sources/ParseSwift/API/API+NonParseBodyCommand.swift
@@ -113,7 +113,7 @@ internal extension API {
 internal extension API.NonParseBodyCommand {
 
     // MARK: Deleting
-    static func delete<T>(_ object: T) throws -> API.NonParseBodyCommand<NoBody, NoBody> where T: ParseObject {
+    static func delete<V>(_ object: V) throws -> API.NonParseBodyCommand<NoBody, NoBody> where V: ParseObject {
         guard object.isSaved else {
             throw ParseError(code: .otherCause,
                              message: "Cannot delete an object without an objectId")

--- a/Sources/ParseSwift/LiveQuery/LiveQueryConstants.swift
+++ b/Sources/ParseSwift/LiveQuery/LiveQueryConstants.swift
@@ -43,7 +43,7 @@ public enum Event<T: ParseObject>: Equatable {
         }
     }
 
-    public static func == <T>(lhs: Event<T>, rhs: Event<T>) -> Bool {
+    public static func == <U>(lhs: Event<U>, rhs: Event<U>) -> Bool {
         switch (lhs, rhs) {
         case (.entered(let obj1), .entered(let obj2)): return obj1 == obj2
         case (.left(let obj1), .left(let obj2)):       return obj1 == obj2

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -893,7 +893,7 @@ public extension Query {
      - returns: Your subscription handler, for easy chaining.
      - throws: An error of type `ParseError`.
     */
-    static func subscribe<T: QuerySubscribable>(_ handler: T) async throws -> T {
+    static func subscribe<V: QuerySubscribable>(_ handler: V) async throws -> V {
         try await ParseLiveQuery.client().subscribe(handler)
     }
 
@@ -904,7 +904,7 @@ public extension Query {
      - returns: Your subscription handler, for easy chaining.
      - throws: An error of type `ParseError`.
     */
-    static func subscribe<T: QuerySubscribable>(_ handler: T, client: ParseLiveQuery) async throws -> T {
+    static func subscribe<V: QuerySubscribable>(_ handler: V, client: ParseLiveQuery) async throws -> V {
         try await ParseLiveQuery.client().subscribe(handler)
     }
 
@@ -957,7 +957,7 @@ public extension Query {
      - parameter handler: The specific handler to unsubscribe from.
      - throws: An error of type `ParseError`.
      */
-    func unsubscribe<T: QuerySubscribable>(_ handler: T) async throws {
+    func unsubscribe<V: QuerySubscribable>(_ handler: V) async throws {
         try await ParseLiveQuery.client().unsubscribe(handler)
     }
 
@@ -968,7 +968,7 @@ public extension Query {
      - parameter client: A specific client.
      - throws: An error of type `ParseError`.
      */
-    func unsubscribe<T: QuerySubscribable>(_ handler: T, client: ParseLiveQuery) async throws {
+    func unsubscribe<V: QuerySubscribable>(_ handler: V, client: ParseLiveQuery) async throws {
         try await client.unsubscribe(handler)
     }
 }
@@ -981,7 +981,7 @@ public extension Query {
      - parameter handler: The specific handler to update.
      - throws: An error of type `ParseError`.
      */
-    func update<T: QuerySubscribable>(_ handler: T) async throws {
+    func update<V: QuerySubscribable>(_ handler: V) async throws {
         try await ParseLiveQuery.client().update(handler)
     }
 
@@ -992,7 +992,7 @@ public extension Query {
      - parameter client: A specific client.
      - throws: An error of type `ParseError`.
      */
-    func update<T: QuerySubscribable>(_ handler: T, client: ParseLiveQuery) async throws {
+    func update<V: QuerySubscribable>(_ handler: V, client: ParseLiveQuery) async throws {
         try await client.update(handler)
     }
 }

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.7.2"
+    static let version = "5.7.3"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Types/ParseServer+async.swift
+++ b/Sources/ParseSwift/Types/ParseServer+async.swift
@@ -50,6 +50,9 @@ public extension ParseServer {
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: Status of ParseServer.
      - throws: An error of type `ParseError`.
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
+     use the primary key in server-side applications where the key is kept secure and not
+     exposed to the public.
     */
     static func information(options: API.Options = []) async throws -> Information {
         try await withCheckedThrowingContinuation { continuation in

--- a/Sources/ParseSwift/Types/ParseServer+combine.swift
+++ b/Sources/ParseSwift/Types/ParseServer+combine.swift
@@ -49,6 +49,9 @@ public extension ParseServer {
      Retrieves any information provided by the server *asynchronously*. Publishes when complete.
      - parameter options: A set of header options sent to the server. Defaults to an empty set.
      - returns: A publisher that eventually produces a single value and then finishes or fails.
+     - requires: `.usePrimaryKey` has to be available. It is recommended to only
+     use the primary key in server-side applications where the key is kept secure and not
+     exposed to the public.
     */
     static func informationPublisher(options: API.Options = []) -> Future<Information, ParseError> {
         Future { promise in

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -46,13 +46,13 @@ public struct Query<T>: ParseTypeable where T: ParseObject {
         Self.className
     }
 
-    struct AggregateBody<T>: Codable where T: ParseObject {
+    struct AggregateBody<V>: Codable where V: ParseObject {
         let pipeline: [[String: AnyCodable]]?
         let hint: AnyCodable?
         let explain: Bool?
         let includeReadPreference: String?
 
-        init(query: Query<T>) {
+        init(query: Query<V>) {
             pipeline = query.pipeline
             hint = query.hint
             explain = query.explain
@@ -77,13 +77,13 @@ public struct Query<T>: ParseTypeable where T: ParseObject {
         }
     }
 
-    struct DistinctBody<T>: Codable where T: ParseObject {
+    struct DistinctBody<V>: Codable where V: ParseObject {
         let hint: AnyCodable?
         let explain: Bool?
         let includeReadPreference: String?
         let distinct: String?
 
-        init(query: Query<T>) {
+        init(query: Query<V>) {
             distinct = query.distinct
             hint = query.hint
             explain = query.explain


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Compiling the project in Swift 5.9 shows there's a number of generic shadows in the code.

### Approach
<!-- Add a description of the approach in this PR. -->
Remove all shadowing of generic types.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
