### PR TITLE
feat: Add concrete types ParseHookTrigger and ParseHookFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.4...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.8.0...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 5.8.0
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.4...5.8.0), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.8.0/documentation/parseswift)
+
+__Fixes__
+* Add concrete types: ParseHookTrigger and ParseHookFunction to reduce code developers need to create. Deprecate triggerName in favor of trigger where possible ([#122](https://github.com/netreconlab/Parse-Swift/pull/122)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 5.7.4
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.3...5.7.4), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.7.4/documentation/parseswift)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 __New features__
 * Add concrete types: ParseHookTrigger and ParseHookFunction to reduce code developers need to create. Deprecate triggerName in favor of trigger where possible. The SDK also yields for 0.5 second as oppose to 1 second, which can lead to faster app starts ([#122](https://github.com/netreconlab/Parse-Swift/pull/122)), thanks to [Corey Baker](https://github.com/cbaker6).
 
+__Fixes__
+* A problem when the developer did not impement merge() on a ParseObject and depended on the internal mergeAutomatically() to merge. If the developer used mergeAutomatically() indirectly for objects with different objectId's, the method allowed the merge. Now the method throws an error ([#122](https://github.com/netreconlab/Parse-Swift/pull/122)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 5.7.4
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.3...5.7.4), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.7.4/documentation/parseswift)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.4...5.8.0), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.8.0/documentation/parseswift)
 
 __New features__
-* Add concrete types: ParseHookTrigger and ParseHookFunction to reduce code developers need to create. Deprecate triggerName in favor of trigger where possible. The SDK also yields for 0.5 second as oppose to 1 second, which can lead to faster app starts ([#122](https://github.com/netreconlab/Parse-Swift/pull/122)), thanks to [Corey Baker](https://github.com/cbaker6).
+* Add concrete types: ParseHookTrigger and ParseHookFunction to reduce code developers need to write. Deprecate triggerName in favor of trigger where possible. The SDK also yields for 0.5 second as oppose to 1 second, which can lead to faster app starts ([#122](https://github.com/netreconlab/Parse-Swift/pull/122)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __Fixes__
-* A problem when the developer did not impement merge() on a ParseObject and depended on the internal mergeAutomatically() to merge. If the developer used mergeAutomatically() indirectly for objects with different objectId's, the method allowed the merge. Now the method throws an error ([#122](https://github.com/netreconlab/Parse-Swift/pull/122)), thanks to [Corey Baker](https://github.com/cbaker6).
+* There was a problem when the developer did not implement merge() on a ParseObject and depended on the internal mergeAutomatically() to merge. If the developer used mergeAutomatically() indirectly for objects with different objectId's, the method allowed the merge. Now the method now throws the proper error ([#122](https://github.com/netreconlab/Parse-Swift/pull/122)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 5.7.4
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.3...5.7.4), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.7.4/documentation/parseswift)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
 ### 5.8.0
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.4...5.8.0), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.8.0/documentation/parseswift)
 
-__Fixes__
-* Add concrete types: ParseHookTrigger and ParseHookFunction to reduce code developers need to create. Deprecate triggerName in favor of trigger where possible ([#122](https://github.com/netreconlab/Parse-Swift/pull/122)), thanks to [Corey Baker](https://github.com/cbaker6).
+__New features__
+* Add concrete types: ParseHookTrigger and ParseHookFunction to reduce code developers need to create. Deprecate triggerName in favor of trigger where possible. The SDK also yields for 0.5 second as oppose to 1 second, which can lead to faster app starts ([#122](https://github.com/netreconlab/Parse-Swift/pull/122)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 5.7.4
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.7.3...5.7.4), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.7.4/documentation/parseswift)

--- a/ParseSwift.playground/Pages/12 - Roles and Relations.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/12 - Roles and Relations.xcplaygroundpage/Contents.swift
@@ -373,7 +373,7 @@ Task {
 Task {
     let score1 = GameScore(points: 53)
     //: You can also do
-    // let specificRelation = try await User.current().relation("scores", className: "GameScore")
+    // let specificRelation = try await User.current().relation("scores", object: GameScore.self)
     do {
         let currentUser = try await User.current()
         let specificRelation = try currentUser.relation("scores", child: score1)

--- a/ParseSwift.playground/Pages/22 - Cloud Hook Functions.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/22 - Cloud Hook Functions.xcplaygroundpage/Contents.swift
@@ -21,20 +21,11 @@ Task {
 }
 
 /*:
- Parse Hook Functions can be created by conforming to
- `ParseHookFunctionable`.
- */
-struct HookFunction: ParseHookFunctionable {
-    var functionName: String?
-    var url: URL?
-}
-
-/*:
  Lets create our first Hook function by first creating an instance
  with the name of the function and url for the hook.
  */
-var myFunction = HookFunction(name: "foo",
-                              url: URL(string: "https://api.example.com/foo"))
+var myFunction = ParseHookFunction(name: "foo",
+                                   url: URL(string: "https://api.example.com/foo"))
 
 //: Then, create the function on the server.
 myFunction.create { result in
@@ -101,7 +92,7 @@ myFunction.delete { result in
  You can also use the fetchAll type method to fetch all of
  the current Hook functions.
  */
-HookFunction.fetchAll { result in
+ParseHookFunction.fetchAll { result in
     switch result {
     case .success(let functions):
         print("Current: \"\(functions)\"")

--- a/ParseSwift.playground/Pages/23 - Cloud Hook Triggers.xcplaygroundpage/Contents.swift
+++ b/ParseSwift.playground/Pages/23 - Cloud Hook Triggers.xcplaygroundpage/Contents.swift
@@ -47,23 +47,13 @@ struct GameScore: ParseObject {
 }
 
 /*:
- Parse Hook Triggers can be created by conforming to
- `ParseHookFunctionable`.
- */
-struct HookTrigger: ParseHookTriggerable {
-    var className: String?
-    var triggerName: ParseHookTriggerType?
-    var url: URL?
-}
-
-/*:
  Lets create our first Hook trigger by first creating an instance
  with the name of the trigger and url for the hook.
  */
 let gameScore = GameScore()
-var myTrigger = HookTrigger(object: gameScore,
-                            triggerName: .afterSave,
-                            url: URL(string: "https://api.example.com/bar")!)
+var myTrigger = ParseHookTrigger(object: gameScore,
+                                 trigger: .afterSave,
+                                 url: URL(string: "https://api.example.com/bar")!)
 
 //: Then, create the trigger on the server.
 myTrigger.create { result in
@@ -130,7 +120,7 @@ myTrigger.delete { result in
  You can also use the fetchAll type method to fetch all of
  the current Hook triggers.
  */
-HookTrigger.fetchAll { result in
+ParseHookTrigger.fetchAll { result in
     switch result {
     case .success(let triggers):
         print("Current: \"\(triggers)\"")

--- a/ParseSwift.xcodeproj/project.pbxproj
+++ b/ParseSwift.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		7030E09029BBBFFA0021970D /* ParseConfigCodable+combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7030E08F29BBBFFA0021970D /* ParseConfigCodable+combine.swift */; };
 		7030E09529BBC5740021970D /* ParseConfigCodableCombineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7030E09429BBC5740021970D /* ParseConfigCodableCombineTests.swift */; };
 		7031F356296F553200E077CC /* APICommandMultipleAttemptsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7031F355296F553200E077CC /* APICommandMultipleAttemptsTests.swift */; };
+		7034B9FD2A46380B00395CBC /* ParseHookTrigger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7034B9FC2A46380B00395CBC /* ParseHookTrigger.swift */; };
+		7034B9FF2A46391200395CBC /* ParseHookFunction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7034B9FE2A46391200395CBC /* ParseHookFunction.swift */; };
 		7037DAB226384DE1005D7E62 /* TestParseEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7037DAB126384DE1005D7E62 /* TestParseEncoder.swift */; };
 		70385E6428563FD10084D306 /* ParsePushPayloadFirebaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70385E6328563FD10084D306 /* ParsePushPayloadFirebaseTests.swift */; };
 		70385E68285640A30084D306 /* ParsePushPayloadAnyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70385E67285640A30084D306 /* ParsePushPayloadAnyTests.swift */; };
@@ -394,6 +396,8 @@
 		7030E08F29BBBFFA0021970D /* ParseConfigCodable+combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ParseConfigCodable+combine.swift"; sourceTree = "<group>"; };
 		7030E09429BBC5740021970D /* ParseConfigCodableCombineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseConfigCodableCombineTests.swift; sourceTree = "<group>"; };
 		7031F355296F553200E077CC /* APICommandMultipleAttemptsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APICommandMultipleAttemptsTests.swift; sourceTree = "<group>"; };
+		7034B9FC2A46380B00395CBC /* ParseHookTrigger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseHookTrigger.swift; sourceTree = "<group>"; };
+		7034B9FE2A46391200395CBC /* ParseHookFunction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParseHookFunction.swift; sourceTree = "<group>"; };
 		7037DAB126384DE1005D7E62 /* TestParseEncoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestParseEncoder.swift; sourceTree = "<group>"; };
 		70385E6328563FD10084D306 /* ParsePushPayloadFirebaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParsePushPayloadFirebaseTests.swift; sourceTree = "<group>"; };
 		70385E67285640A30084D306 /* ParsePushPayloadAnyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParsePushPayloadAnyTests.swift; sourceTree = "<group>"; };
@@ -1226,8 +1230,10 @@
 				7044C19025C4F5B60011F6E7 /* ParseFile+combine.swift */,
 				704E781B28CFFAF80075F952 /* ParseFileDefaultTransfer.swift */,
 				F97B45BC24D9C6F200F4A88B /* ParseGeoPoint.swift */,
+				7034B9FE2A46391200395CBC /* ParseHookFunction.swift */,
 				70385E7F2858EAA90084D306 /* ParseHookFunctionRequest.swift */,
 				70CE0A9328590A0A00DAEA86 /* ParseHookResponse.swift */,
+				7034B9FC2A46380B00395CBC /* ParseHookTrigger.swift */,
 				70CE0AB1285963A300DAEA86 /* ParseHookTriggerObjectRequest.swift */,
 				70B412B329801AFB00F706EA /* ParseHookTriggerRequest.swift */,
 				70D41D7F28B520E200613510 /* ParseKeychainAccessGroup.swift */,
@@ -1530,6 +1536,7 @@
 				70385E712858D2DD0084D306 /* ParseHookTriggerable.swift in Sources */,
 				91679D64268E596300F71809 /* ParseVersion.swift in Sources */,
 				91285B1C26990D7F0051B544 /* ParsePolygon.swift in Sources */,
+				7034B9FD2A46380B00395CBC /* ParseHookTrigger.swift in Sources */,
 				91BB8FCA2690AC99005A6BA5 /* QueryViewModel.swift in Sources */,
 				70B412B429801AFB00F706EA /* ParseHookTriggerRequest.swift in Sources */,
 				7085DD9426CBF3A70033B977 /* Documentation.docc in Sources */,
@@ -1595,6 +1602,7 @@
 				F97B465A24D9C78C00F4A88B /* ParseOperationIncrement.swift in Sources */,
 				7045769326BD8F8100F86F71 /* ParseInstallation+async.swift in Sources */,
 				7C55F9E72860CD6B002A352D /* ParseSpotify.swift in Sources */,
+				7034B9FF2A46391200395CBC /* ParseHookFunction.swift in Sources */,
 				7003960925A184EF0052CB31 /* ParseLiveQuery.swift in Sources */,
 				7044C17525C4ECFF0011F6E7 /* ParseCloudable+combine.swift in Sources */,
 				705025B32845C302008D6624 /* ParsePushStatus.swift in Sources */,

--- a/Sources/ParseSwift/API/API.swift
+++ b/Sources/ParseSwift/API/API.swift
@@ -121,7 +121,7 @@ public struct API {
             case .hookTriggers:
                 return "/hooks/triggers/"
             case .hookTrigger(let request):
-                return "/hooks/triggers/\(request.className)/\(request.triggerName)"
+                return "/hooks/triggers/\(request.className)/\(request.trigger)"
             case .serverInfo:
                 return "/serverInfo"
             case .any(let path):

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -357,6 +357,10 @@ public extension ParseObject {
 extension ParseObject {
 
     func mergeAutomatically(_ originalObject: Self) throws -> Self {
+        guard hasSameObjectId(as: originalObject) else {
+            throw ParseError(code: .otherCause,
+                             message: "objectId's of objects do not match")
+        }
         let updatedEncoded = try ParseCoding.jsonEncoder().encode(self)
         let originalData = try ParseCoding.jsonEncoder().encode(originalObject)
         guard let updated = try JSONSerialization.jsonObject(with: updatedEncoded) as? [String: AnyObject],

--- a/Sources/ParseSwift/Objects/ParseRole.swift
+++ b/Sources/ParseSwift/Objects/ParseRole.swift
@@ -84,11 +84,11 @@ public extension ParseRole {
     }
 
     var users: ParseRelation<Self>? {
-        try? ParseRelation(parent: self, key: "users", className: RoleUser.className)
+        try? ParseRelation(parent: self, key: "users", object: RoleUser.self)
     }
 
     var roles: ParseRelation<Self>? {
-        try? ParseRelation(parent: self, key: "roles", className: Self.className)
+        try? ParseRelation(parent: self, key: "roles", object: Self.self)
     }
 
     init(name: String) throws {

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -70,11 +70,11 @@ internal func initialize(applicationId: String,
 
 internal func yieldIfNotInitialized(_ iteration: Int = 0) async throws {
     guard ParseConfiguration.checkIfConfigured() else {
-        guard iteration < 5 else {
+        guard iteration < 10 else {
             throw ParseError(code: .otherCause,
                              message: "The SDK needs to be initialized")
         }
-        let nanoSeconds = UInt64(1 * 1_000_000_000)
+        let nanoSeconds = UInt64(1 * 500_000_000)
         try await Task.sleep(nanoseconds: nanoSeconds)
         try await yieldIfNotInitialized(iteration + 1)
         return

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.7.4"
+    static let version = "5.8.0"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Protocols/ParseHookFunctionable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookFunctionable.swift
@@ -36,11 +36,17 @@ public extension ParseHookFunctionable {
     }
 }
 
+/// A type of request for Parse Hook Functions.
 public struct FunctionRequest: Encodable {
     let functionName: String
     let url: URL?
 
-    init<F>(hookFunction: F) throws where F: ParseHookFunctionable {
+    /**
+     Creates an instance.
+     - parameter hookFunction: A type that conforms to `ParseHookFunctionable`.
+     - throws: An error of `ParseError` type.
+     */
+    public init<F>(hookFunction: F) throws where F: ParseHookFunctionable {
         guard let functionName = hookFunction.functionName else {
             throw ParseError(code: .otherCause,
                              message: "The \"functionName\" needs to be set: \(hookFunction)")

--- a/Sources/ParseSwift/Protocols/ParseHookTriggerRequestable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookTriggerRequestable.swift
@@ -16,7 +16,7 @@ import Foundation
  exposed to the public.
  */
 public protocol ParseHookTriggerRequestable: ParseHookRequestable {
-    /// The types of Parse Hook Trigger.
+    /// The type of Parse Hook Trigger.
     var triggerName: String? { get }
     /// The number of clients connected.
     var clients: Int? { get }

--- a/Sources/ParseSwift/Protocols/ParseHookTriggerRequestable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookTriggerRequestable.swift
@@ -16,7 +16,7 @@ import Foundation
  exposed to the public.
  */
 public protocol ParseHookTriggerRequestable: ParseHookRequestable {
-    /// The type of Parse Hook Trigger.
+    /// The name of the Parse Hook Trigger.
     var triggerName: String? { get }
     /// The number of clients connected.
     var clients: Int? { get }

--- a/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
@@ -112,12 +112,18 @@ public extension ParseHookTriggerable {
 
 }
 
+/// A type of request for Parse Hook Triggers.
 public struct TriggerRequest: Encodable {
     let className: String
     let trigger: ParseHookTriggerType
     let url: URL?
 
-    init<T>(trigger: T) throws where T: ParseHookTriggerable {
+    /**
+     Creates an instance.
+     - parameter trigger: A type that conforms to `ParseHookTriggerable`.
+     - throws: An error of `ParseError` type.
+     */
+    public init<T>(trigger: T) throws where T: ParseHookTriggerable {
         guard let className = trigger.className,
               let triggerType = trigger.triggerName else {
             throw ParseError(code: .otherCause,

--- a/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
@@ -24,17 +24,49 @@ public protocol ParseHookTriggerable: ParseHookable {
 
 // MARK: Default Implementation
 public extension ParseHookTriggerable {
+
+    /**
+     Creates a new Parse hook trigger.
+     - parameter className: The name of the `ParseObject` the trigger should act on.
+     - parameter trigger: The `ParseHookTriggerType` type.
+     - parameter url: The endpoint of the hook.
+     */
+    init(className: String, trigger: ParseHookTriggerType, url: URL) {
+        self.init()
+        self.className = className
+        self.triggerName = trigger
+        self.url = url
+    }
+
     /**
      Creates a new Parse hook trigger.
      - parameter className: The name of the `ParseObject` the trigger should act on.
      - parameter triggerName: The `ParseHookTriggerType` type.
      - parameter url: The endpoint of the hook.
      */
+    @available(*, deprecated, message: "Change \"triggerName\" to \"trigger\"")
     init(className: String, triggerName: ParseHookTriggerType, url: URL) {
-        self.init()
-        self.className = className
-        self.triggerName = triggerName
-        self.url = url
+        self.init(className: className, trigger: triggerName, url: url)
+    }
+
+    /**
+     Creates a new Parse hook trigger.
+     - parameter object: The `ParseObject` the trigger should act on.
+     - parameter trigger: The `ParseHookTriggerType` type.
+     - parameter url: The endpoint of the hook.
+     */
+    init<T>(object: T.Type, trigger: ParseHookTriggerType, url: URL) where T: ParseObject {
+        self.init(className: object.className, trigger: trigger, url: url)
+    }
+
+    /**
+     Creates a new Parse hook trigger.
+     - parameter object: The `ParseObject` the trigger should act on.
+     - parameter trigger: The `ParseHookTriggerType` type.
+     - parameter url: The endpoint of the hook.
+     */
+    init<T>(object: T, trigger: ParseHookTriggerType, url: URL) where T: ParseObject {
+        self.init(className: T.className, trigger: trigger, url: url)
     }
 
     /**
@@ -43,18 +75,19 @@ public extension ParseHookTriggerable {
      - parameter triggerName: The `ParseHookTriggerType` type.
      - parameter url: The endpoint of the hook.
      */
+    @available(*, deprecated, message: "Change \"triggerName\" to \"trigger\"")
     init<T>(object: T, triggerName: ParseHookTriggerType, url: URL) where T: ParseObject {
-        self.init(className: T.className, triggerName: triggerName, url: url)
+        self.init(object: object, trigger: triggerName, url: url)
     }
 
     /**
      Creates a new `ParseFile` or `ParseHookTriggerType.beforeConnect` hook trigger.
-     - parameter triggerName: The `ParseHookTriggerType` type.
+     - parameter trigger: The `ParseHookTriggerType` type.
      - parameter url: The endpoint of the hook.
      */
-    init(triggerName: ParseHookTriggerType, url: URL) throws {
+    init(trigger: ParseHookTriggerType, url: URL) throws {
         self.init()
-        self.triggerName = triggerName
+        self.triggerName = trigger
         self.url = url
         switch triggerName {
         case .beforeSave, .afterSave, .beforeDelete, .afterDelete:
@@ -66,11 +99,22 @@ public extension ParseHookTriggerable {
                              message: "This initializer should only be used for \"ParseFile\" and \"beforeConnect\"")
         }
     }
+
+    /**
+     Creates a new `ParseFile` or `ParseHookTriggerType.beforeConnect` hook trigger.
+     - parameter triggerName: The `ParseHookTriggerType` type.
+     - parameter url: The endpoint of the hook.
+     */
+    @available(*, deprecated, message: "Change \"triggerName\" to \"trigger\"")
+    init(triggerName: ParseHookTriggerType, url: URL) throws {
+        try self.init(trigger: triggerName, url: url)
+    }
+
 }
 
 public struct TriggerRequest: Encodable {
     let className: String
-    let triggerName: ParseHookTriggerType
+    let trigger: ParseHookTriggerType
     let url: URL?
 
     init<T>(trigger: T) throws where T: ParseHookTriggerable {
@@ -80,8 +124,14 @@ public struct TriggerRequest: Encodable {
                              message: "The \"className\" and \"triggerName\" needs to be set: \(trigger)")
         }
         self.className = className
-        self.triggerName = triggerName
+        self.trigger = triggerName
         self.url = trigger.url
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case className
+        case trigger = "triggerName"
+        case url
     }
 }
 

--- a/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
@@ -119,12 +119,12 @@ public struct TriggerRequest: Encodable {
 
     init<T>(trigger: T) throws where T: ParseHookTriggerable {
         guard let className = trigger.className,
-              let triggerName = trigger.triggerName else {
+              let triggerType = trigger.triggerName else {
             throw ParseError(code: .otherCause,
                              message: "The \"className\" and \"triggerName\" needs to be set: \(trigger)")
         }
         self.className = className
-        self.trigger = triggerName
+        self.trigger = triggerType
         self.url = trigger.url
     }
 

--- a/Sources/ParseSwift/Types/ParseHookFunction.swift
+++ b/Sources/ParseSwift/Types/ParseHookFunction.swift
@@ -1,0 +1,19 @@
+//
+//  ParseHookFunction.swift
+//  ParseSwift
+//
+//  Created by Corey Baker on 6/23/23.
+//  Copyright © 2023 Network Reconnaissance Lab. All rights reserved.
+//
+
+import Foundation
+
+/**
+ A generic Parse Hook Function type that can be used to create any Parse Hook Function.
+ */
+public struct ParseHookFunction: ParseHookFunctionable {
+    public var functionName: String?
+    public var url: URL?
+
+    public init() {}
+}

--- a/Sources/ParseSwift/Types/ParseHookTrigger.swift
+++ b/Sources/ParseSwift/Types/ParseHookTrigger.swift
@@ -1,0 +1,20 @@
+//
+//  ParseHookTrigger.swift
+//  ParseSwift
+//
+//  Created by Corey Baker on 6/23/23.
+//  Copyright © 2023 Network Reconnaissance Lab. All rights reserved.
+//
+
+import Foundation
+
+/**
+ A generic Parse Hook Trigger type that can be used to create any Hook Trigger.
+ */
+public struct ParseHookTrigger: ParseHookTriggerable {
+    public var className: String?
+    public var triggerName: ParseHookTriggerType?
+    public var url: URL?
+
+    public init() {}
+}

--- a/Sources/ParseSwift/Types/ParseHookTriggerObjectRequest.swift
+++ b/Sources/ParseSwift/Types/ParseHookTriggerObjectRequest.swift
@@ -21,7 +21,12 @@ public struct ParseHookTriggerObjectRequest<U: ParseCloudUser, T: ParseObject>: 
     public var installationId: String?
     public var ipAddress: String?
     public var headers: [String: String]?
-    public var triggerName: String?
+    /// The type of Parse Hook Trigger.
+    public var trigger: ParseHookTriggerType?
+    @available(*, deprecated, message: "Use \"trigger\" instead.")
+    public var triggerName: String? {
+        trigger?.rawValue
+    }
     public var clients: Int?
     /// An object from the hook call.
     public var object: T?
@@ -48,11 +53,11 @@ public struct ParseHookTriggerObjectRequest<U: ParseCloudUser, T: ParseObject>: 
     enum CodingKeys: String, CodingKey {
         case primaryKey = "master"
         case ipAddress = "ip"
+        case trigger = "triggerName"
         case user, installationId, headers,
-             log, context, triggerName,
-             object, objects, original, query,
-             isGet, clients, subscriptions,
-             sendEvent
+             log, context, object, objects,
+             original, query, isGet,
+             clients, subscriptions, sendEvent
     }
 }
 

--- a/Sources/ParseSwift/Types/ParseHookTriggerRequest.swift
+++ b/Sources/ParseSwift/Types/ParseHookTriggerRequest.swift
@@ -21,7 +21,12 @@ public struct ParseHookTriggerRequest<U: ParseCloudUser>: ParseHookTriggerReques
     public var installationId: String?
     public var ipAddress: String?
     public var headers: [String: String]?
-    public var triggerName: String?
+    /// The type of Parse Hook Trigger.
+    public var trigger: ParseHookTriggerType?
+    @available(*, deprecated, message: "Use \"trigger\" instead.")
+    public var triggerName: String? {
+        trigger?.rawValue
+    }
     public var clients: Int?
     /// The  from the hook call.
     public var file: ParseFile?
@@ -33,9 +38,10 @@ public struct ParseHookTriggerRequest<U: ParseCloudUser>: ParseHookTriggerReques
     enum CodingKeys: String, CodingKey {
         case primaryKey = "master"
         case ipAddress = "ip"
+        case trigger = "triggerName"
         case user, installationId, headers,
              log, context, file, fileSize,
-             clients, triggerName
+             clients
     }
 }
 

--- a/Sources/ParseSwift/Types/ParseRelation.swift
+++ b/Sources/ParseSwift/Types/ParseRelation.swift
@@ -50,6 +50,17 @@ public struct ParseRelation<T>: ParseTypeable, Hashable where T: ParseObject {
     }
 
     /**
+     Create a `ParseRelation` with a specific parent, key, and object.
+     - parameters:
+        - parent: The parent `ParseObject` Pointer.
+        - key: The key for the relation.
+        - object: The type of child for the relation.
+     */
+    public init<V: ParseObject>(parent: Pointer<T>, key: String? = nil, object: V.Type) {
+        self.init(parent: parent, key: key, className: object.className)
+    }
+
+    /**
      Create a `ParseRelation` with a specific parent, key, and child object.
      - parameters:
         - parent: The parent `ParseObject` Pointer.
@@ -92,6 +103,17 @@ public struct ParseRelation<T>: ParseTypeable, Hashable where T: ParseObject {
      */
     public init(parent: T, key: String? = nil, className: String) throws {
         self.init(parent: try parent.toPointer(), key: key, className: className)
+    }
+
+    /**
+     Create a `ParseRelation` with a specific parent, key, and object.
+     - parameters:
+        - parent: The parent `ParseObject`.
+        - key: The key for the relation.
+        - object: The type of child for the relation.
+     */
+    public init<V: ParseObject>(parent: T, key: String? = nil, object: V.Type) throws {
+        self.init(parent: try parent.toPointer(), key: key, className: object.className)
     }
 
     /**
@@ -420,6 +442,16 @@ public extension ParseObject {
      */
     func relation(_ key: String, className: String) throws -> ParseRelation<Self> {
         try ParseRelation(parent: self, key: key, className: className)
+    }
+
+    /**
+     Create a new relation with a specific key.
+     - parameter key: The key for the relation.
+     - parameter className: The name of the child class for the relation.
+     - returns: A new `ParseRelation`.
+     */
+    func relation<V: ParseObject>(_ key: String, object: V.Type) throws -> ParseRelation<Self> {
+        try ParseRelation(parent: self, key: key, className: object.className)
     }
 
     /**

--- a/Sources/ParseSwift/Types/ParseSchema.swift
+++ b/Sources/ParseSwift/Types/ParseSchema.swift
@@ -348,16 +348,16 @@ extension ParseSchema {
 
     func createCommand() -> API.NonParseBodyCommand<Self, Self> {
         API.NonParseBodyCommand(method: .POST,
-                                       path: endpoint,
-                                       body: self) { (data) -> Self in
+                                path: endpoint,
+                                body: self) { (data) -> Self in
             try ParseCoding.jsonDecoder().decode(Self.self, from: data)
         }
     }
 
     func updateCommand() -> API.NonParseBodyCommand<Self, Self> {
         API.NonParseBodyCommand(method: .PUT,
-                    path: endpoint,
-                    body: self) { (data) -> Self in
+                                path: endpoint,
+                                body: self) { (data) -> Self in
             try ParseCoding.jsonDecoder().decode(Self.self, from: data)
         }
     }

--- a/Tests/ParseSwiftTests/APICommandTests.swift
+++ b/Tests/ParseSwiftTests/APICommandTests.swift
@@ -136,6 +136,10 @@ class APICommandTests: XCTestCase {
         XCTAssertEqual(serverURL4, serverURL1)
     }
 
+    func testAPISchemasURL() throws {
+        XCTAssertEqual(API.Endpoint.schemas.urlComponent, "/schemas")
+    }
+
     func testOptionCacheHasher() throws {
         var options = API.Options()
         options.insert(.cachePolicy(.returnCacheDataDontLoad))

--- a/Tests/ParseSwiftTests/ParseHookFunctionCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionCombineTests.swift
@@ -14,10 +14,6 @@ import Combine
 @testable import ParseSwift
 
 class ParseHookFunctionCombineTests: XCTestCase {
-    struct TestFunction: ParseHookFunctionable {
-        var functionName: String?
-        var url: URL?
-    }
 
     override func setUp() async throws {
         try await super.setUp()
@@ -45,8 +41,8 @@ class ParseHookFunctionCombineTests: XCTestCase {
         var current = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Create hook")
 
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
 
         let server = hookFunction
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -74,8 +70,8 @@ class ParseHookFunctionCombineTests: XCTestCase {
         var current = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Create hook")
 
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
 
         let server = ParseError(code: .commandUnavailable, message: "no delete")
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -104,8 +100,8 @@ class ParseHookFunctionCombineTests: XCTestCase {
         var current = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Update hook")
 
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
 
         let server = hookFunction
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -133,8 +129,8 @@ class ParseHookFunctionCombineTests: XCTestCase {
         var current = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Update hook")
 
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
 
         let server = ParseError(code: .commandUnavailable, message: "no delete")
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -163,8 +159,8 @@ class ParseHookFunctionCombineTests: XCTestCase {
         var current = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Fetch hook")
 
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
 
         let server = hookFunction
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -192,8 +188,8 @@ class ParseHookFunctionCombineTests: XCTestCase {
         var current = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Fetch hook")
 
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
 
         let server = ParseError(code: .commandUnavailable, message: "no delete")
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -222,8 +218,8 @@ class ParseHookFunctionCombineTests: XCTestCase {
         var current = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "FetchAll hook")
 
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
 
         let server = [hookFunction]
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -251,8 +247,8 @@ class ParseHookFunctionCombineTests: XCTestCase {
         var current = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "FetchAll hook")
 
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
 
         let server = ParseError(code: .commandUnavailable, message: "no delete")
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -281,8 +277,8 @@ class ParseHookFunctionCombineTests: XCTestCase {
         var current = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Delete hook")
 
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
 
         let server = hookFunction
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -308,8 +304,8 @@ class ParseHookFunctionCombineTests: XCTestCase {
         var current = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Delete hook")
 
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
 
         let server = ParseError(code: .commandUnavailable, message: "no delete")
         let encoded = try ParseCoding.jsonEncoder().encode(server)

--- a/Tests/ParseSwiftTests/ParseHookFunctionTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionTests.swift
@@ -14,10 +14,6 @@ import XCTest
 @testable import ParseSwift
 
 class ParseHookFunctionTests: XCTestCase {
-    struct TestFunction: ParseHookFunctionable {
-        var functionName: String?
-        var url: URL?
-    }
 
     override func setUp() async throws {
         try await super.setUp()
@@ -42,8 +38,8 @@ class ParseHookFunctionTests: XCTestCase {
     }
 
     func testCoding() throws {
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
         let expected = "{\"functionName\":\"foo\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
         XCTAssertEqual(hookFunction.description, expected)
     }
@@ -51,8 +47,8 @@ class ParseHookFunctionTests: XCTestCase {
     @MainActor
     func testCreate() async throws {
 
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
 
         let server = hookFunction
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -74,8 +70,8 @@ class ParseHookFunctionTests: XCTestCase {
             return MockURLResponse(data: encoded, statusCode: 200)
         }
 
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
         do {
             _ = try await hookFunction.create()
             XCTFail("Should have thrown error")
@@ -87,7 +83,9 @@ class ParseHookFunctionTests: XCTestCase {
     @MainActor
     func testCreateError2() async throws {
 
-        let hookFunction = TestFunction(url: URL(string: "https://api.example.com/foo"))
+        var hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
+        hookFunction.functionName = nil
         do {
             _ = try await hookFunction.create()
             XCTFail("Should have thrown error")
@@ -99,8 +97,8 @@ class ParseHookFunctionTests: XCTestCase {
     @MainActor
     func testUpdate() async throws {
 
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
 
         let server = hookFunction
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -122,8 +120,8 @@ class ParseHookFunctionTests: XCTestCase {
             return MockURLResponse(data: encoded, statusCode: 200)
         }
 
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
         do {
             _ = try await hookFunction.update()
             XCTFail("Should have thrown error")
@@ -135,7 +133,9 @@ class ParseHookFunctionTests: XCTestCase {
     @MainActor
     func testUpdateError2() async throws {
 
-        let hookFunction = TestFunction(url: URL(string: "https://api.example.com/foo"))
+        var hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
+        hookFunction.functionName = nil
         do {
             _ = try await hookFunction.update()
             XCTFail("Should have thrown error")
@@ -147,8 +147,8 @@ class ParseHookFunctionTests: XCTestCase {
     @MainActor
     func testFetch() async throws {
 
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
 
         let server = hookFunction
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -170,8 +170,8 @@ class ParseHookFunctionTests: XCTestCase {
             return MockURLResponse(data: encoded, statusCode: 200)
         }
 
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
         do {
             _ = try await hookFunction.fetch()
             XCTFail("Should have thrown error")
@@ -183,7 +183,9 @@ class ParseHookFunctionTests: XCTestCase {
     @MainActor
     func testFetchError2() async throws {
 
-        let hookFunction = TestFunction(url: URL(string: "https://api.example.com/foo"))
+        var hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
+        hookFunction.functionName = nil
         do {
             _ = try await hookFunction.fetch()
             XCTFail("Should have thrown error")
@@ -195,8 +197,8 @@ class ParseHookFunctionTests: XCTestCase {
     @MainActor
     func testFetchAll() async throws {
 
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
 
         let server = [hookFunction]
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -218,8 +220,8 @@ class ParseHookFunctionTests: XCTestCase {
             return MockURLResponse(data: encoded, statusCode: 200)
         }
 
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
         do {
             _ = try await hookFunction.fetchAll()
             XCTFail("Should have thrown error")
@@ -237,8 +239,8 @@ class ParseHookFunctionTests: XCTestCase {
             return MockURLResponse(data: encoded, statusCode: 200)
         }
 
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
         try await hookFunction.delete()
     }
 
@@ -251,8 +253,8 @@ class ParseHookFunctionTests: XCTestCase {
             return MockURLResponse(data: encoded, statusCode: 200)
         }
 
-        let hookFunction = TestFunction(name: "foo",
-                                        url: URL(string: "https://api.example.com/foo"))
+        let hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
         do {
             try await hookFunction.delete()
             XCTFail("Should have thrown error")
@@ -264,7 +266,9 @@ class ParseHookFunctionTests: XCTestCase {
     @MainActor
     func testDeleteError2() async throws {
 
-        let hookFunction = TestFunction(url: URL(string: "https://api.example.com/foo"))
+        var hookFunction = ParseHookFunction(name: "foo",
+                                             url: URL(string: "https://api.example.com/foo"))
+        hookFunction.functionName = nil
         do {
             _ = try await hookFunction.delete()
             XCTFail("Should have thrown error")

--- a/Tests/ParseSwiftTests/ParseHookTriggerCombineTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerCombineTests.swift
@@ -16,11 +16,6 @@ import Combine
 // swiftlint:disable type_body_length
 
 class ParseHookTriggerCombineTests: XCTestCase {
-    struct TestTrigger: ParseHookTriggerable {
-        var className: String?
-        var triggerName: ParseHookTriggerType?
-        var url: URL?
-    }
 
     override func setUp() async throws {
         try await super.setUp()
@@ -48,9 +43,14 @@ class ParseHookTriggerCombineTests: XCTestCase {
         var current = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Create hook")
 
-        let hookTrigger = TestTrigger(className: "foo",
-                                      triggerName: .afterSave,
-                                      url: URL(string: "https://api.example.com/foo"))
+        guard let url = URL(string: "https://api.example.com/foo") else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+
+        let hookTrigger = ParseHookTrigger(className: "foo",
+                                           trigger: .afterSave,
+                                           url: url)
 
         let server = hookTrigger
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -78,9 +78,14 @@ class ParseHookTriggerCombineTests: XCTestCase {
         var current = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Create hook")
 
-        let hookTrigger = TestTrigger(className: "foo",
-                                      triggerName: .afterSave,
-                                      url: URL(string: "https://api.example.com/foo"))
+        guard let url = URL(string: "https://api.example.com/foo") else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+
+        let hookTrigger = ParseHookTrigger(className: "foo",
+                                           trigger: .afterSave,
+                                           url: url)
 
         let server = ParseError(code: .commandUnavailable, message: "no delete")
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -109,9 +114,14 @@ class ParseHookTriggerCombineTests: XCTestCase {
         var current = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Update hook")
 
-        let hookTrigger = TestTrigger(className: "foo",
-                                      triggerName: .afterSave,
-                                      url: URL(string: "https://api.example.com/foo"))
+        guard let url = URL(string: "https://api.example.com/foo") else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+
+        let hookTrigger = ParseHookTrigger(className: "foo",
+                                           trigger: .afterSave,
+                                           url: url)
 
         let server = hookTrigger
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -139,9 +149,14 @@ class ParseHookTriggerCombineTests: XCTestCase {
         var current = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Update hook")
 
-        let hookTrigger = TestTrigger(className: "foo",
-                                      triggerName: .afterSave,
-                                      url: URL(string: "https://api.example.com/foo"))
+        guard let url = URL(string: "https://api.example.com/foo") else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+
+        let hookTrigger = ParseHookTrigger(className: "foo",
+                                           trigger: .afterSave,
+                                           url: url)
 
         let server = ParseError(code: .commandUnavailable, message: "no delete")
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -170,9 +185,14 @@ class ParseHookTriggerCombineTests: XCTestCase {
         var current = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Fetch hook")
 
-        let hookTrigger = TestTrigger(className: "foo",
-                                      triggerName: .afterSave,
-                                      url: URL(string: "https://api.example.com/foo"))
+        guard let url = URL(string: "https://api.example.com/foo") else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+
+        let hookTrigger = ParseHookTrigger(className: "foo",
+                                           trigger: .afterSave,
+                                           url: url)
 
         let server = hookTrigger
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -200,9 +220,14 @@ class ParseHookTriggerCombineTests: XCTestCase {
         var current = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Fetch hook")
 
-        let hookTrigger = TestTrigger(className: "foo",
-                                      triggerName: .afterSave,
-                                      url: URL(string: "https://api.example.com/foo"))
+        guard let url = URL(string: "https://api.example.com/foo") else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+
+        let hookTrigger = ParseHookTrigger(className: "foo",
+                                           trigger: .afterSave,
+                                           url: url)
 
         let server = ParseError(code: .commandUnavailable, message: "no delete")
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -231,9 +256,14 @@ class ParseHookTriggerCombineTests: XCTestCase {
         var current = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "FetchAll hook")
 
-        let hookTrigger = TestTrigger(className: "foo",
-                                      triggerName: .afterSave,
-                                      url: URL(string: "https://api.example.com/foo"))
+        guard let url = URL(string: "https://api.example.com/foo") else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+
+        let hookTrigger = ParseHookTrigger(className: "foo",
+                                           trigger: .afterSave,
+                                           url: url)
 
         let server = [hookTrigger]
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -261,9 +291,14 @@ class ParseHookTriggerCombineTests: XCTestCase {
         var current = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "FetchAll hook")
 
-        let hookTrigger = TestTrigger(className: "foo",
-                                      triggerName: .afterSave,
-                                      url: URL(string: "https://api.example.com/foo"))
+        guard let url = URL(string: "https://api.example.com/foo") else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+
+        let hookTrigger = ParseHookTrigger(className: "foo",
+                                           trigger: .afterSave,
+                                           url: url)
 
         let server = ParseError(code: .commandUnavailable, message: "no delete")
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -292,9 +327,14 @@ class ParseHookTriggerCombineTests: XCTestCase {
         var current = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Delete hook")
 
-        let hookTrigger = TestTrigger(className: "foo",
-                                      triggerName: .afterSave,
-                                      url: URL(string: "https://api.example.com/foo"))
+        guard let url = URL(string: "https://api.example.com/foo") else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+
+        let hookTrigger = ParseHookTrigger(className: "foo",
+                                           trigger: .afterSave,
+                                           url: url)
 
         let server = hookTrigger
         let encoded = try ParseCoding.jsonEncoder().encode(server)
@@ -320,9 +360,14 @@ class ParseHookTriggerCombineTests: XCTestCase {
         var current = Set<AnyCancellable>()
         let expectation1 = XCTestExpectation(description: "Delete hook")
 
-        let hookTrigger = TestTrigger(className: "foo",
-                                      triggerName: .afterSave,
-                                      url: URL(string: "https://api.example.com/foo"))
+        guard let url = URL(string: "https://api.example.com/foo") else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+
+        let hookTrigger = ParseHookTrigger(className: "foo",
+                                           trigger: .afterSave,
+                                           url: url)
 
         let server = ParseError(code: .commandUnavailable, message: "no delete")
         let encoded = try ParseCoding.jsonEncoder().encode(server)

--- a/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
@@ -90,7 +90,7 @@ class ParseHookTriggerRequestTests: XCTestCase {
         let triggerRequest = ParseHookTriggerObjectRequest<User, User>(primaryKey: true,
                                                                        ipAddress: "1.1.1.1",
                                                                        headers: ["yolo": "me"],
-                                                                       triggerName: "beforeDelete",
+                                                                       trigger: ParseHookTriggerType.beforeDelete,
                                                                        object: object)
         // swiftlint:disable:next line_length
         let expected = "{\"headers\":{\"yolo\":\"me\"},\"ip\":\"1.1.1.1\",\"master\":true,\"object\":{\"objectId\":\"geez\"},\"triggerName\":\"beforeDelete\"}"

--- a/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
@@ -77,12 +77,13 @@ class ParseHookTriggerRequestTests: XCTestCase {
         let triggerRequest = ParseHookTriggerRequest<User>(primaryKey: true,
                                                            ipAddress: "1.1.1.1",
                                                            headers: ["yolo": "me"],
-                                                           triggerName: "beforeDelete",
+                                                           trigger: .beforeDelete,
                                                            file: ParseFile(data: Data()),
                                                            fileSize: 0)
         // swiftlint:disable:next line_length
         let expected = "{\"file\":{\"__type\":\"File\",\"name\":\"file\"},\"fileSize\":0,\"headers\":{\"yolo\":\"me\"},\"ip\":\"1.1.1.1\",\"master\":true,\"triggerName\":\"beforeDelete\"}"
         XCTAssertEqual(triggerRequest.description, expected)
+        XCTAssertEqual(triggerRequest.triggerName, triggerRequest.trigger?.rawValue)
     }
 
     func testCodingObject() async throws {
@@ -90,11 +91,12 @@ class ParseHookTriggerRequestTests: XCTestCase {
         let triggerRequest = ParseHookTriggerObjectRequest<User, User>(primaryKey: true,
                                                                        ipAddress: "1.1.1.1",
                                                                        headers: ["yolo": "me"],
-                                                                       trigger: ParseHookTriggerType.beforeDelete,
+                                                                       trigger: .beforeDelete,
                                                                        object: object)
         // swiftlint:disable:next line_length
         let expected = "{\"headers\":{\"yolo\":\"me\"},\"ip\":\"1.1.1.1\",\"master\":true,\"object\":{\"objectId\":\"geez\"},\"triggerName\":\"beforeDelete\"}"
         XCTAssertEqual(triggerRequest.description, expected)
+        XCTAssertEqual(triggerRequest.triggerName, triggerRequest.trigger?.rawValue)
         let triggerRequest2 = ParseHookTriggerObjectRequest<User, User>(ipAddress: "1.1.1.1",
                                                                         headers: ["yolo": "me"],
                                                                         object: object)

--- a/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
@@ -74,9 +74,9 @@ class ParseHookTriggerTests: XCTestCase {
             return
         }
 
-        let hookTrigger = try ParseHookTrigger(className: "foo",
-                                               triggerName: .afterSave,
-                                               url: url)
+        let hookTrigger = ParseHookTrigger(className: "foo",
+                                           triggerName: .afterSave,
+                                           url: url)
         // swiftlint:disable:next line_length
         let expected = "{\"className\":\"foo\",\"triggerName\":\"afterSave\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
         XCTAssertEqual(hookTrigger.description, expected)
@@ -170,12 +170,15 @@ class ParseHookTriggerTests: XCTestCase {
             XCTFail("Should have unwrapped")
             return
         }
-        let hookTrigger = try ParseHookTrigger(trigger: .afterSave,
-                                               url: url)
+        var hookTrigger = ParseHookTrigger(className: "foo",
+                                           trigger: .afterSave,
+                                           url: url)
+        hookTrigger.className = nil
         do {
             _ = try await hookTrigger.create()
             XCTFail("Should have thrown error")
         } catch {
+            print(error)
             XCTAssertTrue(error.equalsTo(.otherCause))
         }
     }
@@ -231,8 +234,10 @@ class ParseHookTriggerTests: XCTestCase {
             XCTFail("Should have unwrapped")
             return
         }
-        let hookTrigger = try ParseHookTrigger(trigger: .afterSave,
-                                               url: url)
+        var hookTrigger = ParseHookTrigger(className: "foo",
+                                           trigger: .afterSave,
+                                           url: url)
+        hookTrigger.className = nil
         do {
             _ = try await hookTrigger.update()
             XCTFail("Should have thrown error")
@@ -310,8 +315,10 @@ class ParseHookTriggerTests: XCTestCase {
             XCTFail("Should have unwrapped")
             return
         }
-        let hookTrigger = try ParseHookTrigger(trigger: .afterSave,
-                                               url: url)
+        var hookTrigger = ParseHookTrigger(className: "foo",
+                                           trigger: .afterSave,
+                                           url: url)
+        hookTrigger.className = nil
         do {
             _ = try await hookTrigger.fetch()
             XCTFail("Should have thrown error")
@@ -414,8 +421,10 @@ class ParseHookTriggerTests: XCTestCase {
             XCTFail("Should have unwrapped")
             return
         }
-        let hookTrigger = try ParseHookTrigger(trigger: .afterSave,
-                                               url: url)
+        var hookTrigger = ParseHookTrigger(className: "foo",
+                                           trigger: .afterSave,
+                                           url: url)
+        hookTrigger.className = nil
         do {
             _ = try await hookTrigger.delete()
             XCTFail("Should have thrown error")

--- a/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
@@ -86,12 +86,12 @@ class ParseHookTriggerTests: XCTestCase {
             return
         }
         let hookTrigger2 = ParseHookTrigger(object: object,
-                                            trigger: .afterSave,
+                                            triggerName: .afterSave,
                                             url: url)
         // swiftlint:disable:next line_length
         let expected2 = "{\"className\":\"GameScore\",\"triggerName\":\"afterSave\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
         XCTAssertEqual(hookTrigger2.description, expected2)
-        let hookTrigger3 = try ParseHookTrigger(trigger: .afterSave,
+        let hookTrigger3 = try ParseHookTrigger(triggerName: .afterSave,
                                                 url: url)
         // swiftlint:disable:next line_length
         let expected3 = "{\"className\":\"@File\",\"triggerName\":\"afterSave\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"

--- a/Tests/ParseSwiftTests/ParseRelationTests.swift
+++ b/Tests/ParseSwiftTests/ParseRelationTests.swift
@@ -133,6 +133,7 @@ class ParseRelationTests: XCTestCase {
 
         // Should not produce a relation without an objectId.
         XCTAssertThrowsError(try score.relation("yolo", child: level))
+        XCTAssertThrowsError(try score.relation("yolo", object: Level.self))
 
         let objectId = "hello"
         score.objectId = objectId
@@ -161,6 +162,11 @@ class ParseRelationTests: XCTestCase {
         let encoded4 = try ParseCoding.jsonEncoder().encode(relation2)
         let decoded4 = try XCTUnwrap(String(data: encoded4, encoding: .utf8))
         XCTAssertEqual(decoded4, expected4)
+
+        let relation4 = try score.relation("yolo", object: Level.self)
+        let encoded5 = try ParseCoding.jsonEncoder().encode(relation4)
+        let decoded5 = try XCTUnwrap(String(data: encoded5, encoding: .utf8))
+        XCTAssertEqual(decoded5, expected)
     }
 
     func testInitWithChild() throws {

--- a/Tests/ParseSwiftTests/ParseRelationTests.swift
+++ b/Tests/ParseSwiftTests/ParseRelationTests.swift
@@ -192,6 +192,13 @@ class ParseRelationTests: XCTestCase {
         _ = try ParseRelation<GameScore>(parent: score,
                                          key: "yolo",
                                          child: try level.toPointer())
+
+        var relation2 = try ParseRelation<GameScore>(parent: score.toPointer(), object: Level.self)
+
+        let expected3 = "{\"__type\":\"Relation\",\"className\":\"Level\"}"
+        let encoded3 = try ParseCoding.jsonEncoder().encode(relation2)
+        let decoded3 = try XCTUnwrap(String(data: encoded3, encoding: .utf8))
+        XCTAssertEqual(decoded3, expected3)
     }
 
     func testAddIncorrectClassError() throws {

--- a/Tests/ParseSwiftTests/ParseRelationTests.swift
+++ b/Tests/ParseSwiftTests/ParseRelationTests.swift
@@ -193,7 +193,7 @@ class ParseRelationTests: XCTestCase {
                                          key: "yolo",
                                          child: try level.toPointer())
 
-        var relation2 = try ParseRelation<GameScore>(parent: score.toPointer(), object: Level.self)
+        let relation2 = try ParseRelation<GameScore>(parent: score.toPointer(), object: Level.self)
 
         let expected3 = "{\"__type\":\"Relation\",\"className\":\"Level\"}"
         let encoded3 = try ParseCoding.jsonEncoder().encode(relation2)
@@ -490,6 +490,16 @@ class ParseRelationTests: XCTestCase {
             let encoded3 = try ParseCoding.jsonEncoder().encode(query3)
             let decoded3 = try XCTUnwrap(String(data: encoded3, encoding: .utf8))
             XCTAssertEqual(decoded3, expected3)
+
+            guard let query4 = try level.relation?.query("levels", parent: score.toPointer()) else {
+                XCTFail("Should have unwrapped")
+                return
+            }
+            // swiftlint:disable:next line_length
+            let expected4 = "{\"_method\":\"GET\",\"limit\":100,\"skip\":0,\"where\":{\"$relatedTo\":{\"key\":\"levels\",\"object\":{\"__type\":\"Pointer\",\"className\":\"GameScore\",\"objectId\":\"hello\"}}}}"
+            let encoded4 = try ParseCoding.jsonEncoder().encode(query4)
+            let decoded4 = try XCTUnwrap(String(data: encoded4, encoding: .utf8))
+            XCTAssertEqual(decoded4, expected4)
         } catch {
             XCTFail("Should not have thrown error")
         }

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -138,6 +138,15 @@ class ParseRoleTests: XCTestCase {
         XCTAssertThrowsError(try Role<User>(name: "Hello10!", acl: ParseACL()))
     }
 
+    func testMergeError() throws {
+        var role1 = try Role<User>(name: "Hello9_- ")
+        role1.objectId = "hello"
+        var role2 = try Role<User>(name: "Hello9_- ")
+        role2.objectId = "world"
+        XCTAssertThrowsError(try role1.merge(with: role2))
+        XCTAssertThrowsError(try role1.mergeParse(with: role2))
+    }
+
     func testEndPoint() throws {
         var role = try Role<User>(name: "Administrator")
         XCTAssertEqual(role.endpoint.urlComponent, "/roles")

--- a/Tests/ParseSwiftTests/ParseRoleTests.swift
+++ b/Tests/ParseSwiftTests/ParseRoleTests.swift
@@ -81,6 +81,22 @@ class ParseRoleTests: XCTestCase {
         }
     }
 
+    struct Role2<RoleUser: ParseUser>: ParseRole {
+
+        // required by ParseObject
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // provided by Role
+        var name: String?
+
+        // custom
+        var title: String?
+    }
+
     struct Level: ParseObject {
         //: These are required by ParseObject
         var objectId: String?
@@ -145,6 +161,12 @@ class ParseRoleTests: XCTestCase {
         role2.objectId = "world"
         XCTAssertThrowsError(try role1.merge(with: role2))
         XCTAssertThrowsError(try role1.mergeParse(with: role2))
+        var role3 = try Role2<User>(name: "Hello9_- ")
+        role3.objectId = "hello"
+        var role4 = try Role2<User>(name: "Hello9_- ")
+        role4.objectId = "world"
+        XCTAssertThrowsError(try role3.merge(with: role4))
+        XCTAssertThrowsError(try role3.mergeParse(with: role4))
     }
 
     func testEndPoint() throws {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
- Developers currently need to create unnecessary types for `ParseHookTrigger` and `ParseHookFunction` that conform to respective protocols
- There is a problem when the developer did not implement merge() on a ParseObject and depended on the internal mergeAutomatically() to merge. If the developer used mergeAutomatically() indirectly for objects with different objectId's, the method allowed the merge. Now the method now throws the proper error

### Approach
<!-- Add a description of the approach in this PR. -->
- [x] Provide concrete types: ParseHookTrigger and ParseHookFunction to reduce code developers need to write
- [x] Deprecate `triggerName` in favor of `trigger` where applicable
- [x] The SDK also yields for 0.5 second as oppose to 1 second, which can lead to faster app starts 
- [x] Increase overall codecov 

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
