### PR TITLE
fix: includeKeys when fetching pointer

### DIFF
--- a/Sources/ParseSwift/API/API+NonParseBodyCommand.swift
+++ b/Sources/ParseSwift/API/API+NonParseBodyCommand.swift
@@ -74,7 +74,7 @@ internal extension API {
 
                 guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
                     return .failure(ParseError(code: .otherCause,
-                                               message: "Could not unrwrap url components for \(url)"))
+                                               message: "Could not unwrap url components for \(url)"))
                 }
                 components.queryItems = params
 

--- a/Sources/ParseSwift/Coding/ParseCoding.swift
+++ b/Sources/ParseSwift/Coding/ParseCoding.swift
@@ -53,7 +53,7 @@ public extension ParseObject {
     }
 
     /// The Parse encoder is used to JSON encode all `ParseObject`s and
-    /// types in a way meaninful for a Parse Server to consume.
+    /// types in a way meaningful for a Parse Server to consume.
     func getEncoder() -> ParseEncoder {
         return Self.getEncoder()
     }

--- a/Sources/ParseSwift/Types/Pointer.swift
+++ b/Sources/ParseSwift/Types/Pointer.swift
@@ -115,13 +115,20 @@ public extension Pointer {
         Task {
             var options = options
             options.insert(.cachePolicy(.reloadIgnoringLocalCacheData))
+            
+            let method = API.Method.GET
             let path = API.Endpoint.object(className: className, objectId: objectId)
-            await API.NonParseBodyCommand<NoBody, T>(method: .GET,
-                                               path: path) { (data) -> T in
+            let params: [String: String]? = {
+                guard let includeKeys else { return nil }
+                return ["include": "\(Set(includeKeys))"]
+            }()
+            let mapper = { (data) -> T in
                 try ParseCoding.jsonDecoder().decode(T.self, from: data)
-            }.execute(options: options,
-                      callbackQueue: callbackQueue,
-                      completion: completion)
+            }
+            await API.NonParseBodyCommand<NoBody, T>(method: method, path: path, params: params, mapper: mapper)
+                .execute(options: options,
+                         callbackQueue: callbackQueue,
+                         completion: completion)
         }
     }
 }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to a [discussion](https://github.com/netreconlab/Parse-Swift/discussions/128).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
This is a bug fix for the `fetch(includeKeys...)` function in `Pointer`.
[Related discussion](https://github.com/netreconlab/Parse-Swift/discussions/128)

### Approach
<!-- Add a description of the approach in this PR. -->
Account for the params.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
