### PR TITLE
fix: Expose isSaved method on ParseFile and ParseOperation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.8.1...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+### 5.8.2
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.8.1...5.8.2), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.8.2/documentation/parseswift)
+
+__Fixes__
+* Expose isSaved method on ParseFile and ParseOperation ([#135](https://github.com/netreconlab/Parse-Swift/pull/135)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 5.8.1
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.8.0...5.8.1), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.8.1/documentation/parseswift)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.8.1...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.8.2...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
 ### 5.8.2

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.8.1"
+    static let version = "5.8.2"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Protocols/Savable.swift
+++ b/Sources/ParseSwift/Protocols/Savable.swift
@@ -11,6 +11,7 @@ public protocol Savable: Encodable {
 
     func save(options: API.Options) async throws -> SavingType
     func save() async throws -> SavingType
+    func isSaved() async throws -> Bool
 }
 
 extension Savable {

--- a/Sources/ParseSwift/Types/ParseFile.swift
+++ b/Sources/ParseSwift/Types/ParseFile.swift
@@ -17,7 +17,7 @@ public struct ParseFile: Fileable, Savable, Deletable, Hashable, Identifiable {
 
     internal var isDownloadNeeded: Bool {
         return cloudURL != nil
-            && url == nil
+            && !isSaved
             && localURL == nil
             && data == nil
     }
@@ -161,6 +161,10 @@ public struct ParseFile: Fileable, Savable, Deletable, Hashable, Identifiable {
 
     public func hash(into hasher: inout Hasher) {
         hasher.combine(self.id)
+    }
+
+    public func isSaved() async throws -> Bool {
+        isSaved
     }
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/ParseSwift/Types/ParseOperation.swift
+++ b/Sources/ParseSwift/Types/ParseOperation.swift
@@ -29,6 +29,15 @@ public struct ParseOperation<T>: Savable,
     }
 
     /**
+     Specifies if this object related to the operation has been saved.
+     - returns: Returns **true** if this object is saved, **false** otherwise.
+     - throws: An error of `ParseError` type.
+     */
+    public func isSaved() async throws -> Bool {
+        try await target.isSaved()
+    }
+
+    /**
      An operation that sets a field's value.
      - Parameters:
         - keyPath: The respective `KeyPath` of the object.

--- a/Tests/ParseSwiftTests/ParseFileTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileTests.swift
@@ -258,6 +258,10 @@ class ParseFileTests: XCTestCase { // swiftlint:disable:this type_body_length
         let savedFile = try await parseFile.save()
         XCTAssertEqual(savedFile.name, response.name)
         XCTAssertEqual(savedFile.url, response.url)
+        let isSavedBefore = try await parseFile.isSaved()
+        XCTAssertFalse(isSavedBefore)
+        let isSavedAfter = try await savedFile.isSaved()
+        XCTAssertTrue(isSavedAfter)
     }
 
     @MainActor

--- a/Tests/ParseSwiftTests/ParseOperationTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationTests.swift
@@ -155,7 +155,7 @@ class ParseOperationTests: XCTestCase {
             XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
             XCTAssertEqual(saved.ACL, scoreOnServer.ACL)
             XCTAssertEqual(saved.points, originalPoints-1)
-            let isSavedAfter = try await saved.isSaved()
+            let isSavedAfter = try await operations.isSaved()
             XCTAssertTrue(isSavedAfter)
         } catch {
             XCTFail(error.localizedDescription)

--- a/Tests/ParseSwiftTests/ParseOperationTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationTests.swift
@@ -155,6 +155,8 @@ class ParseOperationTests: XCTestCase {
             XCTAssertEqual(savedUpdatedAt, originalUpdatedAt)
             XCTAssertEqual(saved.ACL, scoreOnServer.ACL)
             XCTAssertEqual(saved.points, originalPoints-1)
+            let isSavedAfter = try await saved.isSaved()
+            XCTAssertTrue(isSavedAfter)
         } catch {
             XCTFail(error.localizedDescription)
         }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [ ] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
