### PR TITLE
refactor: Create method for skipping ParseObject keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable -->
 ![parse-swift](https://user-images.githubusercontent.com/8621344/204069535-e1882bb0-bbcb-4178-87e6-58fd1bed96d1.png)
 
-<h3 align="center">iOS · macOS · watchOS · tvOS · Linux · Android · Windows</h3>
+<h3 align="center">iOS · macOS · watchOS · tvOS · visionOS ·Linux · Android · Windows</h3>
 
 <h4 align="center">
 ⭐️ ParseSwift was highlighted in <a href="https://iosdevweekly.com/issues/560#start" target="_blank"> issue #560</a> of <a href="https://iosdevweekly.com" target="_blank"> iOS Dev Weekly</a> and discussed in <a href="https://blog.swiftpackageindex.com/posts/swift-package-indexing-episode-5/" target="_blank"> episode 5</a> of <a href="https://swiftpackageindexing.transistor.fm" target="_blank">Swift Package Index Twitter Spaces</a> </h3>

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -435,60 +435,60 @@ private struct _ParseEncoderKeyedEncodingContainer<Key: CodingKey>: KeyedEncodin
 
     // MARK: - KeyedEncodingContainerProtocol Methods
     mutating func encodeNil(forKey key: Key) throws {
-        if self.encoder.skippedKeys.contains(key.stringValue) && !self.encoder.ignoreSkipKeys { return }
+        guard !shouldSkipKey(key) else { return }
         container[key.stringValue] = NSNull()
     }
     mutating func encode(_ value: Bool, forKey key: Key) throws {
-        if self.encoder.skippedKeys.contains(key.stringValue) && !self.encoder.ignoreSkipKeys { return }
+        guard !shouldSkipKey(key) else { return }
         self.container[key.stringValue] = self.encoder.box(value)
     }
     mutating func encode(_ value: Int, forKey key: Key) throws {
-        if self.encoder.skippedKeys.contains(key.stringValue) && !self.encoder.ignoreSkipKeys { return }
+        guard !shouldSkipKey(key) else { return }
         self.container[key.stringValue] = self.encoder.box(value)
     }
     mutating func encode(_ value: Int8, forKey key: Key) throws {
-        if self.encoder.skippedKeys.contains(key.stringValue) && !self.encoder.ignoreSkipKeys { return }
+        guard !shouldSkipKey(key) else { return }
         self.container[key.stringValue] = self.encoder.box(value)
     }
     mutating func encode(_ value: Int16, forKey key: Key) throws {
-        if self.encoder.skippedKeys.contains(key.stringValue) && !self.encoder.ignoreSkipKeys { return }
+        guard !shouldSkipKey(key) else { return }
         self.container[key.stringValue] = self.encoder.box(value)
     }
     mutating func encode(_ value: Int32, forKey key: Key) throws {
-        if self.encoder.skippedKeys.contains(key.stringValue) && !self.encoder.ignoreSkipKeys { return }
+        guard !shouldSkipKey(key) else { return }
         self.container[key.stringValue] = self.encoder.box(value)
     }
     mutating func encode(_ value: Int64, forKey key: Key) throws {
-        if self.encoder.skippedKeys.contains(key.stringValue) && !self.encoder.ignoreSkipKeys { return }
+        guard !shouldSkipKey(key) else { return }
         self.container[key.stringValue] = self.encoder.box(value)
     }
     mutating func encode(_ value: UInt, forKey key: Key) throws {
-        if self.encoder.skippedKeys.contains(key.stringValue) && !self.encoder.ignoreSkipKeys { return }
+        guard !shouldSkipKey(key) else { return }
         self.container[key.stringValue] = self.encoder.box(value)
     }
     mutating func encode(_ value: UInt8, forKey key: Key) throws {
-        if self.encoder.skippedKeys.contains(key.stringValue) && !self.encoder.ignoreSkipKeys { return }
+        guard !shouldSkipKey(key) else { return }
         self.container[key.stringValue] = self.encoder.box(value)
     }
     mutating func encode(_ value: UInt16, forKey key: Key) throws {
-        if self.encoder.skippedKeys.contains(key.stringValue) && !self.encoder.ignoreSkipKeys { return }
+        guard !shouldSkipKey(key) else { return }
         self.container[key.stringValue] = self.encoder.box(value)
     }
     mutating func encode(_ value: UInt32, forKey key: Key) throws {
-        if self.encoder.skippedKeys.contains(key.stringValue) && !self.encoder.ignoreSkipKeys { return }
+        guard !shouldSkipKey(key) else { return }
         self.container[key.stringValue] = self.encoder.box(value)
     }
     mutating func encode(_ value: UInt64, forKey key: Key) throws {
-        if self.encoder.skippedKeys.contains(key.stringValue) && !self.encoder.ignoreSkipKeys { return }
+        guard !shouldSkipKey(key) else { return }
         self.container[key.stringValue] = self.encoder.box(value)
     }
     mutating func encode(_ value: String, forKey key: Key) throws {
-        if self.encoder.skippedKeys.contains(key.stringValue) && !self.encoder.ignoreSkipKeys { return }
+        guard !shouldSkipKey(key) else { return }
         self.container[key.stringValue] = self.encoder.box(value)
     }
     mutating func encode(_ value: Float, forKey key: Key) throws {
         // Since the float may be invalid and throw, the coding path needs to contain this key.
-        if self.encoder.skippedKeys.contains(key.stringValue) && !self.encoder.ignoreSkipKeys { return }
+        guard !shouldSkipKey(key) else { return }
         self.encoder.codingPath.append(key)
         defer { self.encoder.codingPath.removeLast() }
         self.container[key.stringValue] = try self.encoder.box(value)
@@ -496,14 +496,15 @@ private struct _ParseEncoderKeyedEncodingContainer<Key: CodingKey>: KeyedEncodin
 
     mutating func encode(_ value: Double, forKey key: Key) throws {
         // Since the double may be invalid and throw, the coding path needs to contain this key.
-        if self.encoder.skippedKeys.contains(key.stringValue) && !self.encoder.ignoreSkipKeys { return }
+        guard !shouldSkipKey(key) else { return }
         self.encoder.codingPath.append(key)
         defer { self.encoder.codingPath.removeLast() }
         self.container[key.stringValue] = try self.encoder.box(value)
     }
 
     mutating func encode<T>(_ value: T, forKey key: Key) throws where T: Encodable {
-        if self.encoder.skippedKeys.contains(key.stringValue) && !self.encoder.ignoreSkipKeys { return }
+
+        guard !shouldSkipKey(key) else { return }
 
         var valueToEncode: Encodable = value
         if ((value as? Objectable) != nil)
@@ -540,6 +541,13 @@ private struct _ParseEncoderKeyedEncodingContainer<Key: CodingKey>: KeyedEncodin
         self.encoder.codingPath.append(key)
         defer { self.encoder.codingPath.removeLast() }
         self.container[key.stringValue] = try self.encoder.box(valueToEncode)
+    }
+
+    func shouldSkipKey(_ key: Key) -> Bool {
+        guard self.encoder.skippedKeys.contains(key.stringValue) && !self.encoder.ignoreSkipKeys else {
+            return false
+        }
+        return true
     }
 
     mutating func nestedContainer<NestedKey>(

--- a/Tests/ParseSwiftTests/ParseEncoderTests/ParseEncoderExtraTests.swift
+++ b/Tests/ParseSwiftTests/ParseEncoderTests/ParseEncoderExtraTests.swift
@@ -131,7 +131,7 @@ class ParseEncoderTests: XCTestCase {
         XCTAssertEqual(decodedJSON["uint16"]?.value as? NSNumber, NSNumber(value: object.uint16))
         XCTAssertEqual(decodedJSON["uint32"]?.value as? NSNumber, NSNumber(value: object.uint32))
         XCTAssertEqual(decodedJSON["uint64"]?.value as? NSNumber, NSNumber(value: object.uint64))
-        XCTAssertEqual(decodedJSON["float"]?.value as? NSNumber, NSNumber(value: object.float))
+        XCTAssertEqual(decodedJSON["float"]?.value as? Double, Double(object.float))
     }
 
     func testSkipKeysDefaultCodingKeys() throws {

--- a/Tests/ParseSwiftTests/ParseEncoderTests/ParseEncoderExtraTests.swift
+++ b/Tests/ParseSwiftTests/ParseEncoderTests/ParseEncoderExtraTests.swift
@@ -131,7 +131,9 @@ class ParseEncoderTests: XCTestCase {
         XCTAssertEqual(decodedJSON["uint16"]?.value as? NSNumber, NSNumber(value: object.uint16))
         XCTAssertEqual(decodedJSON["uint32"]?.value as? NSNumber, NSNumber(value: object.uint32))
         XCTAssertEqual(decodedJSON["uint64"]?.value as? NSNumber, NSNumber(value: object.uint64))
+        #if !os(Linux) && !os(Android) && !os(Windows)
         XCTAssertEqual(decodedJSON["float"]?.value as? Double, Double(object.float))
+        #endif
     }
 
     func testSkipKeysDefaultCodingKeys() throws {

--- a/Tests/ParseSwiftTests/ParseEncoderTests/ParseEncoderExtraTests.swift
+++ b/Tests/ParseSwiftTests/ParseEncoderTests/ParseEncoderExtraTests.swift
@@ -74,7 +74,7 @@ class ParseEncoderTests: XCTestCase {
         let parseEncoded = try ParseCoding.jsonEncoder().encode(newACL)
         let parseDecoded = try ParseCoding.jsonDecoder().decode([String: [String: Bool]].self, from: parseEncoded)
 
-        XCTAssertEqual(jsonDecoded.keys.count, parseDecoded.keys.count)
+         XCTAssertEqual(jsonDecoded.keys.count, parseDecoded.keys.count)
         XCTAssertEqual(jsonDecoded.values.count, parseDecoded.values.count)
         XCTAssertEqual(jsonDecoded["*"]?["read"], true)
         XCTAssertEqual(parseDecoded["*"]?["read"], true)

--- a/Tests/ParseSwiftTests/ParseEncoderTests/ParseEncoderExtraTests.swift
+++ b/Tests/ParseSwiftTests/ParseEncoderTests/ParseEncoderExtraTests.swift
@@ -11,7 +11,7 @@ import XCTest
 
 class ParseEncoderTests: XCTestCase {
     struct GameScore: ParseObject, ParseQueryScorable {
-        //: These are required by ParseObject
+        // These are required by ParseObject
         var objectId: String?
         var createdAt: Date?
         var updatedAt: Date?
@@ -19,19 +19,56 @@ class ParseEncoderTests: XCTestCase {
         var score: Double?
         var originalData: Data?
 
-        //: ParseUser property
+        // ParseUser property
         var emailVerified: Bool?
 
-        //: Your own properties
+        // Your own properties
         var points: Int
 
-        //: a custom initializer
+        // a custom initializer
         init() {
             self.points = 5
         }
         init(points: Int) {
             self.points = points
         }
+    }
+
+    struct AdditionalTypes: ParseObject {
+        // These are required by ParseObject
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var score: Double?
+        var originalData: Data?
+
+        // Your own properties
+        var int8: Int8
+        var int16: Int16
+        var int32: Int32
+        var int64: Int64
+        var uint: UInt
+        var uint8: UInt8
+        var uint16: UInt16
+        var uint32: UInt32
+        var uint64: UInt64
+        var float: Float
+
+        // a custom initializer
+        init() {
+            self.int8 = 1
+            self.int16 = 2
+            self.int32 = 3
+            self.int64 = 4
+            self.uint = 5
+            self.uint8 = 1
+            self.uint16 = 2
+            self.uint32 = 3
+            self.uint64 = 4
+            self.float = 1.1
+        }
+
     }
 
     struct Address: Codable {
@@ -74,10 +111,27 @@ class ParseEncoderTests: XCTestCase {
         let parseEncoded = try ParseCoding.jsonEncoder().encode(newACL)
         let parseDecoded = try ParseCoding.jsonDecoder().decode([String: [String: Bool]].self, from: parseEncoded)
 
-         XCTAssertEqual(jsonDecoded.keys.count, parseDecoded.keys.count)
+        XCTAssertEqual(jsonDecoded.keys.count, parseDecoded.keys.count)
         XCTAssertEqual(jsonDecoded.values.count, parseDecoded.values.count)
         XCTAssertEqual(jsonDecoded["*"]?["read"], true)
         XCTAssertEqual(parseDecoded["*"]?["read"], true)
+    }
+
+    func testEncodingAdditionalTypes() throws {
+        let object = AdditionalTypes()
+
+        let encodedJSON = try ParseCoding.parseEncoder().encode(object, skipKeys: .object)
+        let decodedJSON = try ParseCoding.jsonDecoder().decode([String: AnyCodable].self, from: encodedJSON)
+        XCTAssertEqual(decodedJSON["int8"]?.value as? NSNumber, NSNumber(value: object.int8))
+        XCTAssertEqual(decodedJSON["int16"]?.value as? NSNumber, NSNumber(value: object.int16))
+        XCTAssertEqual(decodedJSON["int32"]?.value as? NSNumber, NSNumber(value: object.int32))
+        XCTAssertEqual(decodedJSON["int64"]?.value as? NSNumber, NSNumber(value: object.int64))
+        XCTAssertEqual(decodedJSON["uint"]?.value as? NSNumber, NSNumber(value: object.uint))
+        XCTAssertEqual(decodedJSON["uint8"]?.value as? NSNumber, NSNumber(value: object.uint8))
+        XCTAssertEqual(decodedJSON["uint16"]?.value as? NSNumber, NSNumber(value: object.uint16))
+        XCTAssertEqual(decodedJSON["uint32"]?.value as? NSNumber, NSNumber(value: object.uint32))
+        XCTAssertEqual(decodedJSON["uint64"]?.value as? NSNumber, NSNumber(value: object.uint64))
+        XCTAssertEqual(decodedJSON["float"]?.value as? NSNumber, NSNumber(value: object.float))
     }
 
     func testSkipKeysDefaultCodingKeys() throws {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
