### PR TITLE
fix: Improve ParseObject conformance to Hashable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.10.1...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.10.2...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
+### 5.10.2
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.10.1...5.10.2), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.10.2/documentation/parseswift)
+
+__Fixes__
+* Improve ParseObject conformance to Hashable to prevent collision attacks ([#176](https://github.com/netreconlab/Parse-Swift/pull/176)), thanks to [Corey Baker](https://github.com/cbaker6).
+
 ### 5.10.1
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.10.0...5.10.1), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.10.0/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.10.0...5.10.1), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.10.1/documentation/parseswift)
 
 __Fixes__
 * Make ParseEncoder sendable ([#175](https://github.com/netreconlab/Parse-Swift/pull/175)), thanks to [Corey Baker](https://github.com/cbaker6).

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -245,15 +245,6 @@ extension ParseObject {
     }
 }
 
-// MARK: Hashable
-public extension ParseObject {
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(self.id)
-        hasher.combine(createdAt)
-        hasher.combine(updatedAt)
-    }
-}
-
 // MARK: Helper Methods
 public extension ParseObject {
     /**

--- a/Sources/ParseSwift/Objects/ParseObject.swift
+++ b/Sources/ParseSwift/Objects/ParseObject.swift
@@ -172,16 +172,6 @@ public protocol ParseObject: ParseTypeable,
 // MARK: Default Implementations
 public extension ParseObject {
 
-    /**
-     A computed property that is a unique identifier and makes it easy to use `ParseObject`'s
-     as models in MVVM and SwiftUI.
-     - note: `id` allows `ParseObject`'s to be used even if they have not been saved and/or missing an `objectId`.
-     - important: `id` will have the same value as `objectId` when a `ParseObject` contains an `objectId`.
-    */
-    var id: String {
-        objectId ?? UUID().uuidString
-    }
-
     var mergeable: Self {
         guard isSaved,
             originalData == nil else {
@@ -243,6 +233,20 @@ extension ParseObject {
                             original: Self) -> Bool where W: Equatable {
         original[keyPath: keyPath] != self[keyPath: keyPath]
     }
+}
+
+// MARK: Identifiable
+public extension ParseObject {
+
+    /**
+     A computed property that ensures `ParseObject`'s can be uniquely identified across instances.
+     - note: `id` allows `ParseObject`'s to be uniquely identified even if they have not been saved and/or missing an `objectId`.
+     - important: `id` will have the same value as `objectId` when a `ParseObject` contains an `objectId`.
+     */
+    var id: String {
+        objectId ?? UUID().uuidString
+    }
+
 }
 
 // MARK: Helper Methods

--- a/Sources/ParseSwift/Objects/ParseRole.swift
+++ b/Sources/ParseSwift/Objects/ParseRole.swift
@@ -104,13 +104,6 @@ public extension ParseRole {
         self.ACL = acl
     }
 
-    func hash(into hasher: inout Hasher) {
-        let name = self.name ?? self.objectId
-        hasher.combine(name)
-        hasher.combine(createdAt)
-        hasher.combine(updatedAt)
-    }
-
     func mergeParse(with object: Self) throws -> Self {
         guard hasSameObjectId(as: object) else {
             throw ParseError(code: .otherCause,

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.10.1"
+    static let version = "5.10.2"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Protocols/Fileable.swift
+++ b/Sources/ParseSwift/Protocols/Fileable.swift
@@ -18,12 +18,4 @@ extension Fileable {
     var isSaved: Bool {
         return url != nil
     }
-
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        guard let lURL = lhs.url,
-              let rURL = rhs.url else {
-            return lhs.id == rhs.id
-        }
-        return lURL == rURL
-    }
 }

--- a/Sources/ParseSwift/Protocols/ParseHookParametable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookParametable.swift
@@ -12,4 +12,4 @@ import Foundation
  Conforming to `ParseHookParametable` allows types that can be created
  to decode parameters in `ParseHookFunctionRequest`'s.
  */
-public protocol ParseHookParametable: Codable, Equatable, Sendable {}
+public protocol ParseHookParametable: ParseTypeable {}

--- a/Sources/ParseSwift/Protocols/ParseTypeable.swift
+++ b/Sources/ParseSwift/Protocols/ParseTypeable.swift
@@ -13,7 +13,7 @@ import Foundation
  */
 public protocol ParseTypeable: Codable,
                                Sendable,
-                               Equatable,
+                               Hashable,
                                CustomDebugStringConvertible,
                                CustomStringConvertible {}
 

--- a/Sources/ParseSwift/Types/ParseError.swift
+++ b/Sources/ParseSwift/Types/ParseError.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
  An object with a Parse code and message.
  */
-public struct ParseError: ParseTypeable, Swift.Error {
+public struct ParseError: ParseTypeable, Hashable, Swift.Error {
     /// The value representing the error from the Parse Server.
     public let code: Code
     /// The text representing the error from the Parse Server.
@@ -537,6 +537,17 @@ extension ParseError: CustomDebugStringConvertible {
 extension ParseError: LocalizedError {
     public var errorDescription: String? {
         debugDescription
+    }
+}
+
+// MARK: Hashable
+extension ParseError {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(code)
+        hasher.combine(message)
+        hasher.combine(error)
+        hasher.combine(otherCode)
+        hasher.combine(swift?.localizedDescription)
     }
 }
 

--- a/Sources/ParseSwift/Types/ParseError.swift
+++ b/Sources/ParseSwift/Types/ParseError.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
  An object with a Parse code and message.
  */
-public struct ParseError: ParseTypeable, Hashable, Swift.Error {
+public struct ParseError: ParseTypeable, Swift.Error {
     /// The value representing the error from the Parse Server.
     public let code: Code
     /// The text representing the error from the Parse Server.

--- a/Sources/ParseSwift/Types/ParseFile.swift
+++ b/Sources/ParseSwift/Types/ParseFile.swift
@@ -159,10 +159,6 @@ public struct ParseFile: Fileable, Savable, Deletable, Hashable, Identifiable {
         self.options = options
     }
 
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(self.id)
-    }
-
     public func isSaved() async throws -> Bool {
         isSaved
     }

--- a/Sources/ParseSwift/Types/ParseFile.swift
+++ b/Sources/ParseSwift/Types/ParseFile.swift
@@ -23,28 +23,6 @@ public struct ParseFile: Fileable, Savable, Deletable, Hashable, Identifiable {
     }
 
     /**
-     A computed property that is a unique identifier and makes it easy to use `ParseFile`'s
-     as models in MVVM and SwiftUI.
-     - note: `id` allows `ParseFile`'s to be used even when they are  not saved.
-     - important: `id` will have the same value as `name` when a `ParseFile` is saved.
-    */
-    public var id: String {
-        guard isSaved else {
-            guard let cloudURL = cloudURL else {
-                guard let localURL = localURL else {
-                    guard let data = data else {
-                        return name
-                    }
-                    return "\(name)_\(data)"
-                }
-                return combineName(with: localURL)
-            }
-            return combineName(with: cloudURL)
-        }
-        return name
-    }
-
-    /**
       The name of the file.
       Before the file is saved, this is the filename given by the user.
       After the file is saved, that name gets prefixed with a unique identifier.
@@ -167,6 +145,30 @@ public struct ParseFile: Fileable, Savable, Deletable, Hashable, Identifiable {
         case url
         case name
         case type = "__type"
+    }
+}
+
+// MARK: Identifiable
+extension ParseFile {
+    /**
+     A computed property that ensures `ParseFile`'s can be uniquely identified across instances.
+     - note: `id` allows `ParseFile`'s to be uniquely identified even if they have not been saved.
+     - important: `id` will have the same value as `objectId` when a `ParseObject` contains an `objectId`.
+    */
+    public var id: String {
+        guard isSaved else {
+            guard let cloudURL = cloudURL else {
+                guard let localURL = localURL else {
+                    guard let data = data else {
+                        return name
+                    }
+                    return "\(name)_\(data)"
+                }
+                return combineName(with: localURL)
+            }
+            return combineName(with: cloudURL)
+        }
+        return name
     }
 }
 

--- a/Sources/ParseSwift/Types/ParseHookResponse.swift
+++ b/Sources/ParseSwift/Types/ParseHookResponse.swift
@@ -12,7 +12,7 @@ import Foundation
  Build a response after processing a `ParseHookFunctionRequest`
  or `ParseHookTriggerRequest`.
  */
-public struct ParseHookResponse<R: Codable & Equatable & Sendable>: ParseTypeable {
+public struct ParseHookResponse<R: Codable & Hashable & Sendable>: ParseTypeable {
     /// The data to return in the response.
     public var success: R?
     /// An object with a Parse code and message.

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -132,7 +132,7 @@ public struct Query<T>: ParseTypeable where T: ParseObject {
 
       - parameter key: The key to order by.
     */
-    public enum Order: Codable, Equatable, Sendable {
+    public enum Order: Codable, Hashable, Sendable {
         /// Sort in ascending order based on `key`.
         case ascending(String)
         /// Sort in descending order based on `key`.

--- a/Sources/ParseSwift/Types/Query.swift
+++ b/Sources/ParseSwift/Types/Query.swift
@@ -132,7 +132,7 @@ public struct Query<T>: ParseTypeable where T: ParseObject {
 
       - parameter key: The key to order by.
     */
-    public enum Order: Codable, Hashable, Sendable {
+    public enum Order: ParseTypeable {
         /// Sort in ascending order based on `key`.
         case ascending(String)
         /// Sort in descending order based on `key`.

--- a/Tests/ParseSwiftTests/ParseErrorTests.swift
+++ b/Tests/ParseSwiftTests/ParseErrorTests.swift
@@ -159,6 +159,23 @@ class ParseErrorTests: XCTestCase {
         XCTAssertNil(error.containedIn([.operationForbidden, .invalidQuery]))
     }
 
+    func testHashing() throws {
+        let error1 = ParseError(code: .accountAlreadyLinked, message: "Hello")
+        let error2 = ParseError(code: .accountAlreadyLinked, message: "World")
+        let error3 = error1
+
+        var setOfSameErrors = Set([error1, error1, error3])
+        XCTAssertEqual(setOfSameErrors.count, 1)
+        XCTAssertEqual(setOfSameErrors.first, error1)
+        XCTAssertEqual(setOfSameErrors.first, error3)
+        XCTAssertNotEqual(setOfSameErrors.first, error2)
+        setOfSameErrors.insert(error2)
+        XCTAssertEqual(setOfSameErrors.count, 2)
+        XCTAssertTrue(setOfSameErrors.contains(error1))
+        XCTAssertTrue(setOfSameErrors.contains(error2))
+        XCTAssertTrue(setOfSameErrors.contains(error3))
+    }
+
     func testErrorCount() throws {
         let errorCodes = ParseError.Code.allCases
         XCTAssertGreaterThan(errorCodes.count, 50)

--- a/Tests/ParseSwiftTests/ParseObjectAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectAsyncTests.swift
@@ -1801,7 +1801,7 @@ class ParseObjectAsyncTests: XCTestCase { // swiftlint:disable:this type_body_le
         XCTAssertEqual(savedGame.objectId, gameOnServer.objectId)
         XCTAssertEqual(savedGame.createdAt, gameOnServer.createdAt)
         XCTAssertEqual(savedGame.updatedAt, gameOnServer.createdAt)
-        XCTAssertEqual(savedGame.profilePicture, gameOnServer.profilePicture)
+        XCTAssertEqual(savedGame.profilePicture?.url, gameOnServer.profilePicture?.url)
     }
     #endif
 }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
`ParseObjects` are using a custom hashing method that depended on `objectId`, `createdAt`, and `updatedAt` to determine if a hash was equal. This was a fairly weak implementation and only protected against values provided from the server. If a property on a `ParseObject` that wasn't `objectId`, `createdAt`, and `updatedAt` was changed locally, it would still hash to the same value.

For ParseFile, the type currently uses a custom function for `Equatable`.

### Approach
<!-- Add a description of the approach in this PR. -->
Remove all custom hashing methods for `ParseObjects` and use the compiler level hasher which will hash all properties on an ParseObject assuming all of those objects are `Hashable` (which they should be). This moves in the direction of guaranteeing that collision attacks won't be possible (see [discussion](https://forums.swift.org/t/is-this-a-good-idea-protocol-identifiablehashable-hashable-identifiable/47496) for details).

If a developer decides to add their own implementation of the hashing function they are doing so at their own risk and risking collision attacks. In addition, if their `ParseObjects` are used in SwiftUI views they may see unexpected behavior as SwiftUI heavily depends on `Identifiable`, `Hashable`, and `Equatable` to determine when a view should be updated.

For ParseFile, conforming to `Equatable` is improved by checking all properties are equal.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
