### PR TITLE
fix: Encode id and className properties for nested non-ParseObjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.10.2...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.10.3...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 5.10.3
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.10.2...5.10.3), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.10.3/documentation/parseswift)
+
+__Fixes__
+* Allow encoding of id and className on nested types that are not ParseObjects ([#176](https://github.com/netreconlab/Parse-Swift/pull/177)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 5.10.2
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.10.1...5.10.2), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.10.2/documentation/parseswift)

--- a/Sources/ParseSwift/Coding/ParseEncoder.swift
+++ b/Sources/ParseSwift/Coding/ParseEncoder.swift
@@ -72,14 +72,17 @@ public struct ParseEncoder: Sendable {
         case custom(Set<String>)
 
         func keys() -> Set<String> {
-            let defaultObjectKeys = Set(["createdAt",
-                                         "updatedAt",
-                                         "objectId",
-                                         "className",
-                                         "emailVerified",
-                                         "id",
-                                         "score",
-                                         "originalData"])
+            let defaultObjectKeys = Set(
+                [
+                    "objectId",
+                    "createdAt",
+                    "updatedAt",
+                    "emailVerified",
+                    "score",
+                    "originalData"
+                ]
+            )
+
             switch self {
 
             case .object:

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.10.2"
+    static let version = "5.10.3"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Tests/ParseSwiftTests/ParseEncoderTests/ParseEncoderExtraTests.swift
+++ b/Tests/ParseSwiftTests/ParseEncoderTests/ParseEncoderExtraTests.swift
@@ -10,6 +10,11 @@ import XCTest
 @testable import ParseSwift
 
 class ParseEncoderTests: XCTestCase {
+
+    struct Dummy: Codable, Hashable {
+        var id: String
+    }
+
     struct GameScore: ParseObject, ParseQueryScorable {
         // These are required by ParseObject
         var objectId: String?
@@ -24,6 +29,7 @@ class ParseEncoderTests: XCTestCase {
 
         // Your own properties
         var points: Int
+        var dummy: Dummy?
 
         // a custom initializer
         init() {

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -11,6 +11,11 @@ import XCTest
 @testable import ParseSwift
 
 class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
+
+    struct Dummy: Codable, Hashable {
+        var id: String
+    }
+
     struct Level: ParseObject {
         var objectId: String?
 
@@ -43,6 +48,7 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         var level: Level?
         var levels: [Level]?
         var nextLevel: Level?
+        var dummy: Dummy?
 
         //: custom initializers
         init() {}
@@ -346,6 +352,29 @@ class ParseObjectTests: XCTestCase { // swiftlint:disable:this type_body_length
         XCTAssertFalse(score1.shouldRestoreKey(\.points, original: score2))
         XCTAssertFalse(score1.shouldRestoreKey(\.level, original: score2))
         XCTAssertTrue(score1.shouldRestoreKey(\.nextLevel, original: score2))
+    }
+
+    func testParseEncoderAllowsIdOnNestedTypesOnParseObject() throws {
+        var score = GameScore(points: 5)
+        score.dummy = Dummy(id: "hello")
+
+        let object = try ParseCoding
+            .parseEncoder()
+            .encode(
+                score,
+                acl: nil,
+                collectChildren: true,
+                objectsSavedBeforeThisOne: nil,
+                filesSavedBeforeThisOne: nil
+            )
+        let decoded = String(
+            decoding: object.encoded,
+            as: UTF8.self
+        )
+        XCTAssertEqual(
+            decoded,
+            #"{"dummy":{"id":"hello"},"player":"Jen","points":5}"#
+        )
     }
 
     func testParseObjectMutable() throws {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Close #140 

### Approach
<!-- Add a description of the approach in this PR. -->
Since `id` and `className` are computed properties, they are not encoded by default and therefore can be removed from the `ParseEncoder` `SkipKeys` enum. Note that these keys should not be encoded manually if a developer decides to add their own custom encoding for ParseObjects or else the server may not handle their objects properly.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
