### PR TITLE
feat: Add support for hook triggers on ParseConfig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     branches: [ main ]
 
 env:
-  CI_XCODE_OLDEST: '/Applications/Xcode_13.3.1.app/Contents/Developer'
+  CI_XCODE_OLDEST: '/Applications/Xcode_14.2.app/Contents/Developer'
   CI_XCODE_14: '/Applications/Xcode_14.3.1.app/Contents/Developer'
   CI_XCODE_LATEST: '/Applications/Xcode_15.4.app/Contents/Developer'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
 
-  xcode-test-5_5:
+  xcode-test-5_7:
     timeout-minutes: 25
     needs: linux
     runs-on: macos-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.10.3...5.11.0), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.11.0/documentation/parseswift)
 
 __New features__
-* Allow hook triggers on ParseConfig and improve SDK ability to throw errors when the developer uses unsupported trigger combinations ([#179](https://github.com/netreconlab/Parse-Swift/pull/179)), thanks to [Corey Baker](https://github.com/cbaker6).
+* Allow hook triggers on ParseConfig and improve SDK ability to throw errors when the developer uses unsupported trigger combinations. Also changes lowest requirements to be Swift 5.7 and Xcode 14.0 which aligns with other Swift Packages ([#179](https://github.com/netreconlab/Parse-Swift/pull/179)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 5.10.3
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.10.2...5.10.3), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.10.3/documentation/parseswift)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.10.3...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.11.0...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 5.11.0
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.10.3...5.11.0), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.11.0/documentation/parseswift)
+
+__New features__
+* Allow hook triggers on ParseConfig and improve SDK ability to throw errors when the developer uses unsupported trigger combinations ([#179](https://github.com/netreconlab/Parse-Swift/pull/179)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 5.10.3
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.10.2...5.10.3), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.10.3/documentation/parseswift)

--- a/Package.swift
+++ b/Package.swift
@@ -1,26 +1,31 @@
-// swift-tools-version:5.5.2
+// swift-tools-version:5.7
 
 import PackageDescription
 
 let package = Package(
     name: "ParseSwift",
-    platforms: [.iOS(.v13),
-                .macCatalyst(.v13),
-                .macOS(.v10_15),
-                .tvOS(.v13),
-                .watchOS(.v6)],
+    platforms: [
+        .iOS(.v13),
+        .macCatalyst(.v13),
+        .macOS(.v10_15),
+        .tvOS(.v13),
+        .watchOS(.v6)
+    ],
     products: [
         .library(
             name: "ParseSwift",
-            targets: ["ParseSwift"])
+            targets: ["ParseSwift"]
+        )
     ],
     targets: [
         .target(
             name: "ParseSwift",
-            dependencies: []),
+            dependencies: []
+        ),
         .testTarget(
             name: "ParseSwiftTests",
             dependencies: ["ParseSwift"],
-            exclude: ["Info.plist"])
+            exclude: ["Info.plist"]
+        )
     ]
 )

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -82,7 +82,7 @@ public enum ParseHookTriggerObject: Sendable {
     /// Trigger on `ParseFile`'s.
     case file
     /// Trigger on `ParseConfig` updates.
-    /// - warning: Requires Parse Server 7.4.0+.
+    /// - warning: Requires Parse Server 7.3.0-alpha.6+.
     case config
     /// Trigger on `ParseLiveQuery` connections.
     case liveQueryConnect

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.10.3"
+    static let version = "5.11.0"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"
@@ -51,9 +51,9 @@ public enum ParseHookTriggerType: String, Codable, Sendable {
     case afterLogin
     /// Occurs after logout of a `ParseUser`.
     case afterLogout
-    /// Occurs before saving a `ParseObject` or `ParseFile`.
+    /// Occurs before saving a `ParseObject`, `ParseFile`, or `ParseConfig`.
     case beforeSave
-    /// Occurs after saving a `ParseObject` or `ParseFile`.
+    /// Occurs after saving a `ParseObject`, `ParseFile`, or `ParseConfig`.
     case afterSave
     /// Occurs before deleting a `ParseObject` or `ParseFile`.
     case beforeDelete
@@ -69,4 +69,39 @@ public enum ParseHookTriggerType: String, Codable, Sendable {
     case beforeSubscribe
     /// Occurs after a `ParseLiveQuery` event.
     case afterEvent
+}
+
+/**
+ The objects that Parse Hooks can be triggered on.
+ */
+public enum ParseHookTriggerObject: Sendable {
+    /// The type of `ParseObject` to trigger on.
+    case objectType(any ParseObject.Type)
+    /// An instance of a `ParseObject` to trigger on.
+    case object(any ParseObject)
+    /// Trigger on `ParseFile`'s.
+    case file
+    /// Trigger on `ParseConfig` updates.
+    /// - warning: Requires Parse Server 7.4.0+.
+    case config
+    /// Trigger on `ParseLiveQuery` connections.
+    case liveQueryConnect
+
+    /// The class name of the `ParseObject` to trigger on.
+    var className: String {
+        switch self {
+
+        case .objectType(let object):
+            return object.className
+        case .object(let object):
+            return object.className
+        case .file:
+            return "@File"
+        case .config:
+            return "@Config"
+        case .liveQueryConnect:
+            return "@Connect"
+
+        }
+    }
 }

--- a/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
@@ -121,8 +121,7 @@ public extension ParseHookTriggerable {
         case .objectType(let parseObject):
             switch trigger {
             case .beforeLogin, .afterLogin, .afterLogout:
-                // BAKER: Handled this way to preserve Swift backwards compatability.
-                guard parseObject.className == BaseParseUser.className else {
+                guard parseObject is (any ParseUser.Type) else {
                     throw notSupportedError
                 }
             case .beforeSave, .afterSave, .beforeDelete,
@@ -140,8 +139,7 @@ public extension ParseHookTriggerable {
         case .object(let parseObject):
             switch trigger {
             case .beforeLogin, .afterLogin, .afterLogout:
-                // BAKER: Handled this way to preserve Swift backwards compatability.
-                guard parseObject.className == BaseParseUser.className else {
+                guard parseObject is (any ParseUser) else {
                     throw notSupportedError
                 }
             case .beforeSave, .afterSave, .beforeDelete,

--- a/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
@@ -140,7 +140,7 @@ public extension ParseHookTriggerable {
         case .object(let parseObject):
             switch trigger {
             case .beforeLogin, .afterLogin, .afterLogout:
-                // BAKER: Handled this way to preserve Swifg backwards compatability.
+                // BAKER: Handled this way to preserve Swift backwards compatability.
                 guard parseObject.className == BaseParseUser.className else {
                     throw notSupportedError
                 }

--- a/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
@@ -121,7 +121,8 @@ public extension ParseHookTriggerable {
         case .objectType(let parseObject):
             switch trigger {
             case .beforeLogin, .afterLogin, .afterLogout:
-                guard parseObject is (any ParseUser.Type) else {
+                // BAKER: Handled this way to preserve Swift backwards compatability.
+                guard parseObject.className == BaseParseUser.className else {
                     throw notSupportedError
                 }
             case .beforeSave, .afterSave, .beforeDelete,
@@ -139,7 +140,8 @@ public extension ParseHookTriggerable {
         case .object(let parseObject):
             switch trigger {
             case .beforeLogin, .afterLogin, .afterLogout:
-                guard parseObject is (any ParseUser) else {
+                // BAKER: Handled this way to preserve Swifg backwards compatability.
+                guard parseObject.className == BaseParseUser.className else {
                     throw notSupportedError
                 }
             case .beforeSave, .afterSave, .beforeDelete,

--- a/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
@@ -46,6 +46,26 @@ class ParseHookTriggerTests: XCTestCase {
         }
     }
 
+    struct User: ParseUser {
+
+        //: These are required by ParseObject
+        var objectId: String?
+        var createdAt: Date?
+        var updatedAt: Date?
+        var ACL: ParseACL?
+        var originalData: Data?
+
+        // These are required by ParseUser
+        var username: String?
+        var email: String?
+        var emailVerified: Bool?
+        var password: String?
+        var authData: [String: [String: String]?]?
+
+        // Your custom keys
+        var customKey: String?
+    }
+
     override func setUp() async throws {
         try await super.setUp()
         guard let url = URL(string: "http://localhost:1337/parse") else {
@@ -68,7 +88,124 @@ class ParseHookTriggerTests: XCTestCase {
         try await ParseStorage.shared.deleteAll()
     }
 
+    // swiftlint:disable:next function_body_length
     func testCoding() throws {
+        guard let url = URL(string: "https://api.example.com/foo") else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+
+        let parseObjectType = GameScore.self
+        let object = ParseHookTriggerObject.objectType(parseObjectType)
+        let hookTrigger = try ParseHookTrigger(
+            object: object,
+            trigger: .afterSave,
+            url: url
+        )
+        // swiftlint:disable:next line_length
+        let expected = "{\"className\":\"GameScore\",\"triggerName\":\"afterSave\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
+        XCTAssertEqual(hookTrigger.description, expected)
+
+        let parseObject = GameScore()
+        let object2 = ParseHookTriggerObject.object(parseObject)
+        let hookTrigger2 = try ParseHookTrigger(
+            object: object2,
+            trigger: .afterSave,
+            url: url
+        )
+        // swiftlint:disable:next line_length
+        let expected2 = "{\"className\":\"GameScore\",\"triggerName\":\"afterSave\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
+        XCTAssertEqual(hookTrigger2.description, expected2)
+
+        let hookTrigger3 = try ParseHookTrigger(
+            object: .file,
+            trigger: .afterSave,
+            url: url
+        )
+        // swiftlint:disable:next line_length
+        let expected3 = "{\"className\":\"@File\",\"triggerName\":\"afterSave\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
+        XCTAssertEqual(hookTrigger3.description, expected3)
+
+        let hookTrigger4 = try ParseHookTrigger(
+            object: .liveQueryConnect,
+            trigger: .beforeConnect,
+            url: url
+        )
+        // swiftlint:disable:next line_length
+        let expected4 = "{\"className\":\"@Connect\",\"triggerName\":\"beforeConnect\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
+        XCTAssertEqual(hookTrigger4.description, expected4)
+
+        let hookTrigger5 = try ParseHookTrigger(
+            object: .config,
+            trigger: .afterSave,
+            url: url
+        )
+        // swiftlint:disable:next line_length
+        let expected5 = "{\"className\":\"@Config\",\"triggerName\":\"afterSave\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
+        XCTAssertEqual(hookTrigger5.description, expected5)
+
+        let parseUserType = User.self
+        let parseUser = User()
+
+        let object3 = ParseHookTriggerObject.objectType(parseUserType)
+        let object4 = ParseHookTriggerObject.object(parseUser)
+
+        let hookTrigger6 = try ParseHookTrigger(
+            object: object3,
+            trigger: .beforeLogin,
+            url: url
+        )
+        // swiftlint:disable:next line_length
+        let expected6 = "{\"className\":\"_User\",\"triggerName\":\"beforeLogin\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
+        XCTAssertEqual(hookTrigger6.description, expected6)
+
+        let hookTrigger7 = try ParseHookTrigger(
+            object: object3,
+            trigger: .afterLogin,
+            url: url
+        )
+        // swiftlint:disable:next line_length
+        let expected7 = "{\"className\":\"_User\",\"triggerName\":\"afterLogin\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
+        XCTAssertEqual(hookTrigger7.description, expected7)
+
+        let hookTrigger8 = try ParseHookTrigger(
+            object: object3,
+            trigger: .afterLogout,
+            url: url
+        )
+        // swiftlint:disable:next line_length
+        let expected8 = "{\"className\":\"_User\",\"triggerName\":\"afterLogout\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
+        XCTAssertEqual(hookTrigger8.description, expected8)
+
+        let hookTrigger9 = try ParseHookTrigger(
+            object: object4,
+            trigger: .beforeLogin,
+            url: url
+        )
+        // swiftlint:disable:next line_length
+        let expected9 = "{\"className\":\"_User\",\"triggerName\":\"beforeLogin\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
+        XCTAssertEqual(hookTrigger9.description, expected9)
+
+        let hookTrigger10 = try ParseHookTrigger(
+            object: object4,
+            trigger: .afterLogin,
+            url: url
+        )
+        // swiftlint:disable:next line_length
+        let expected10 = "{\"className\":\"_User\",\"triggerName\":\"afterLogin\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
+        XCTAssertEqual(hookTrigger10.description, expected10)
+
+        let hookTrigger11 = try ParseHookTrigger(
+            object: object4,
+            trigger: .afterLogout,
+            url: url
+        )
+        // swiftlint:disable:next line_length
+        let expected11 = "{\"className\":\"_User\",\"triggerName\":\"afterLogout\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
+        XCTAssertEqual(hookTrigger11.description, expected11)
+    }
+
+    func testCodingDeprecated() throws {
         guard let url = URL(string: "https://api.example.com/foo") else {
             XCTFail("Should have unwrapped")
             return
@@ -81,10 +218,6 @@ class ParseHookTriggerTests: XCTestCase {
         let expected = "{\"className\":\"foo\",\"triggerName\":\"afterSave\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
         XCTAssertEqual(hookTrigger.description, expected)
         let object = GameScore()
-        guard let url = URL(string: "https://api.example.com/foo") else {
-            XCTFail("Should have unwrapped")
-            return
-        }
         let hookTrigger2 = ParseHookTrigger(object: object,
                                             triggerName: .afterSave,
                                             url: url)
@@ -116,6 +249,71 @@ class ParseHookTriggerTests: XCTestCase {
         }
         XCTAssertThrowsError(try ParseHookTrigger(trigger: .afterFind,
                                                   url: url))
+    }
+
+    // swiftlint:disable:next function_body_length
+    func testParseHookTriggerObjectUnsupported() throws {
+        guard let url = URL(string: "https://api.example.com/foo") else {
+            XCTFail("Should have unwrapped")
+            return
+        }
+
+        XCTAssertThrowsError(
+            try ParseHookTrigger(
+                object: ParseHookTriggerObject.objectType(GameScore.self),
+                trigger: .beforeConnect,
+                url: url
+            )
+        )
+        XCTAssertThrowsError(
+            try ParseHookTrigger(
+                object: ParseHookTriggerObject.object(GameScore()),
+                trigger: .beforeConnect,
+                url: url
+            )
+        )
+        XCTAssertThrowsError(
+            try ParseHookTrigger(
+                object: ParseHookTriggerObject.object(GameScore()),
+                trigger: .beforeLogin,
+                url: url
+            )
+        )
+        XCTAssertThrowsError(
+            try ParseHookTrigger(
+                object: ParseHookTriggerObject.object(GameScore()),
+                trigger: .afterLogin,
+                url: url
+            )
+        )
+        XCTAssertThrowsError(
+            try ParseHookTrigger(
+                object: ParseHookTriggerObject.object(GameScore()),
+                trigger: .afterLogout,
+                url: url
+            )
+        )
+        XCTAssertThrowsError(
+            try ParseHookTrigger(
+                object: ParseHookTriggerObject.file,
+                trigger: .beforeConnect,
+                url: url
+            )
+        )
+        XCTAssertThrowsError(
+            try ParseHookTrigger(
+                object: ParseHookTriggerObject.config,
+                trigger: .beforeConnect,
+                url: url
+            )
+        )
+        XCTAssertThrowsError(
+            try ParseHookTrigger(
+                object: ParseHookTriggerObject.liveQueryConnect,
+                trigger: .beforeFind,
+                url: url
+            )
+        )
     }
 
     @MainActor


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
The Parse Server added support for hook triggers in CloudCode for `ParseConfig` in https://github.com/parse-community/parse-server/pull/9232.

### Approach
<!-- Add a description of the approach in this PR. -->
- [x] Add first class support in ParseSwift, the SDK currently already supports it using its default initializer, but the developer can easily make mistakes
- [x] Bump minimum requirements to Swift 5.7 and Xcode 14.2. Note most Swift packages have a minimum of Swift 5.8 

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
