### PR TITLE
fix: Encoding Firebase push notification keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        destination: ['platform=iOS\ Simulator,OS=18.1,name=iPhone\ 15\ Pro\ Max', 'platform\=tvOS\ Simulator,OS=18.`,name\=Apple\ TV', 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 10\ \(41mm\)', 'platform=macOS', 'platform=visionOS\ Simulator,OS=2.1,name=Apple\ Vision\ Pro']
+        destination: ['platform=iOS\ Simulator,OS=18.1,name=iPhone\ 15\ Pro\ Max', 'platform\=tvOS\ Simulator,OS=18.1`,name\=Apple\ TV', 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 10\ \(41mm\)', 'platform=macOS', 'platform=visionOS\ Simulator,OS=2.1,name=Apple\ Vision\ Pro']
         action: ['test', 'build']
         exclude:
           - destination: 'platform=iOS\ Simulator,OS=18.1,name=iPhone\ 15\ Pro\ Max'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build-Test
-      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace Parse.xcworkspace -scheme ParseSwift -destination platform\=iOS\ Simulator,name\=iPhone\ 13\ Pro\ Max -derivedDataPath DerivedData build 2>&1 | xcbeautify --renderer github-actions
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace Parse.xcworkspace -scheme ParseSwift -destination platform\=iOS\ Simulator,name\=iPhone\ 15\ Pro\ Max -derivedDataPath DerivedData build 2>&1 | xcbeautify --renderer github-actions
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE_OLDEST }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   test:
     timeout-minutes: 25
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       matrix:
         destination: ['platform=iOS\ Simulator,OS=17.5,name=iPhone\ 15\ Pro\ Max', 'platform\=tvOS\ Simulator,OS=17.5,name\=Apple\ TV', 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 9\ \(41mm\)', 'platform=macOS', 'platform=visionOS\ Simulator,OS=1.2,name=Apple\ Vision\ Pro']
@@ -68,7 +68,7 @@ jobs:
 
   spm-test:
     timeout-minutes: 25
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
     - name: Create and set the default keychain
@@ -156,7 +156,7 @@ jobs:
   docs:
     timeout-minutes: 10
     needs: linux
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Generate Docs
@@ -166,7 +166,7 @@ jobs:
 
   cocoapods:
     needs: linux
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Update Framework Version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
     - name: Prepare codecov
-      uses: sersoft-gmbh/swift-coverage-action@v5
+      uses: sersoft-gmbh/swift-coverage-action@v4
       id: coverage-files
       with:
         format: lcov
@@ -84,7 +84,7 @@ jobs:
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
     - name: Prepare codecov
-      uses: sersoft-gmbh/swift-coverage-action@v5
+      uses: sersoft-gmbh/swift-coverage-action@v4
       id: coverage-files
       with:
         format: lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,18 +22,18 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        destination: ['platform=iOS\ Simulator,OS=17.5,name=iPhone\ 15\ Pro\ Max', 'platform\=tvOS\ Simulator,OS=17.5,name\=Apple\ TV', 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 9\ \(41mm\)', 'platform=macOS', 'platform=visionOS\ Simulator,OS=1.2,name=Apple\ Vision\ Pro']
+        destination: ['platform=iOS\ Simulator,OS=18.1,name=iPhone\ 15\ Pro\ Max', 'platform\=tvOS\ Simulator,OS=18.`,name\=Apple\ TV', 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 10\ \(41mm\)', 'platform=macOS', 'platform=visionOS\ Simulator,OS=2.1,name=Apple\ Vision\ Pro']
         action: ['test', 'build']
         exclude:
-          - destination: 'platform=iOS\ Simulator,OS=17.5,name=iPhone\ 15\ Pro\ Max'
+          - destination: 'platform=iOS\ Simulator,OS=18.1,name=iPhone\ 15\ Pro\ Max'
             action: 'build'
-          - destination: 'platform\=tvOS\ Simulator,OS=17.5,name\=Apple\ TV'
+          - destination: 'platform\=tvOS\ Simulator,OS=18.`,name\=Apple\ TV'
             action: 'build'
           - destination: 'platform=macOS'
             action: 'build'
-          - destination: 'platform=visionOS\ Simulator,OS=1.2,name=Apple\ Vision\ Pro'
+          - destination: 'platform=visionOS\ Simulator,OS=2.1,name=Apple\ Vision\ Pro'
             action: 'test'
-          - destination: 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 9\ \(41mm\)'
+          - destination: 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 10\ \(41mm\)'
             action: 'test'
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
       with:
         format: lcov
         search-paths: ./DerivedData
+        ignore-conversion-failures: true
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
     - name: Upload coverage to Codecov
@@ -89,6 +90,7 @@ jobs:
       with:
         format: lcov
         search-paths: ./.build
+        ignore-conversion-failures: true
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
     - name: Upload coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        destination: ['platform=iOS\ Simulator,OS=18.2,name=iPhone\ 16\ Pro\ Max', 'platform\=tvOS\ Simulator,OS=18.2,name\=Apple\ TV', 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 10\ \(42mm\)', 'platform=macOS', 'platform=visionOS\ Simulator,OS=2.1,name=Apple\ Vision\ Pro']
+        destination: ['platform=iOS\ Simulator,OS=18.2,name=iPhone\ 16\ Pro\ Max', 'platform\=tvOS\ Simulator,OS=18.2,name\=Apple\ TV', 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 10\ \(42mm\)', 'platform=macOS', 'platform=visionOS\ Simulator,OS=2.2,name=Apple\ Vision\ Pro']
         action: ['test', 'build']
         exclude:
           - destination: 'platform=iOS\ Simulator,OS=18.2,name=iPhone\ 16\ Pro\ Max'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        destination: ['platform=iOS\ Simulator,OS=18.1,name=iPhone\ 15\ Pro\ Max', 'platform\=tvOS\ Simulator,OS=18.1,name\=Apple\ TV', 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 10\ \(41mm\)', 'platform=macOS', 'platform=visionOS\ Simulator,OS=2.1,name=Apple\ Vision\ Pro']
+        destination: ['platform=iOS\ Simulator,OS=18.1,name=iPhone\ 16\ Pro\ Max', 'platform\=tvOS\ Simulator,OS=18.1,name\=Apple\ TV', 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 10\ \(41mm\)', 'platform=macOS', 'platform=visionOS\ Simulator,OS=2.1,name=Apple\ Vision\ Pro']
         action: ['test', 'build']
         exclude:
-          - destination: 'platform=iOS\ Simulator,OS=18.1,name=iPhone\ 15\ Pro\ Max'
+          - destination: 'platform=iOS\ Simulator,OS=18.1,name=iPhone\ 16\ Pro\ Max'
             action: 'build'
           - destination: 'platform\=tvOS\ Simulator,OS=18.1,name\=Apple\ TV'
             action: 'build'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        destination: ['platform=iOS\ Simulator,OS=18.1,name=iPhone\ 16\ Pro\ Max', 'platform\=tvOS\ Simulator,OS=18.1,name\=Apple\ TV', 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 10\ \(41mm\)', 'platform=macOS', 'platform=visionOS\ Simulator,OS=2.1,name=Apple\ Vision\ Pro']
+        destination: ['platform=iOS\ Simulator,OS=18.1,name=iPhone\ 16\ Pro\ Max', 'platform\=tvOS\ Simulator,OS=18.1,name\=Apple\ TV', 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 10\ \(42mm\)', 'platform=macOS', 'platform=visionOS\ Simulator,OS=2.1,name=Apple\ Vision\ Pro']
         action: ['test', 'build']
         exclude:
           - destination: 'platform=iOS\ Simulator,OS=18.1,name=iPhone\ 16\ Pro\ Max'
@@ -33,7 +33,7 @@ jobs:
             action: 'build'
           - destination: 'platform=visionOS\ Simulator,OS=2.1,name=Apple\ Vision\ Pro'
             action: 'test'
-          - destination: 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 10\ \(41mm\)'
+          - destination: 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 10\ \(42mm\)'
             action: 'test'
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: sersoft-gmbh/swifty-linux-action@v3
         with:
-          release-version: "6"
+          release-version: "5"
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Test
         run: swift test --enable-test-discovery --enable-code-coverage -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         exclude:
           - destination: 'platform=iOS\ Simulator,OS=18.1,name=iPhone\ 15\ Pro\ Max'
             action: 'build'
-          - destination: 'platform\=tvOS\ Simulator,OS=18.`,name\=Apple\ TV'
+          - destination: 'platform\=tvOS\ Simulator,OS=18.1,name\=Apple\ TV'
             action: 'build'
           - destination: 'platform=macOS'
             action: 'build'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        destination: ['platform=iOS\ Simulator,OS=18.1,name=iPhone\ 15\ Pro\ Max', 'platform\=tvOS\ Simulator,OS=18.1`,name\=Apple\ TV', 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 10\ \(41mm\)', 'platform=macOS', 'platform=visionOS\ Simulator,OS=2.1,name=Apple\ Vision\ Pro']
+        destination: ['platform=iOS\ Simulator,OS=18.1,name=iPhone\ 15\ Pro\ Max', 'platform\=tvOS\ Simulator,OS=18.1,name\=Apple\ TV', 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 10\ \(41mm\)', 'platform=macOS', 'platform=visionOS\ Simulator,OS=2.1,name=Apple\ Vision\ Pro']
         action: ['test', 'build']
         exclude:
           - destination: 'platform=iOS\ Simulator,OS=18.1,name=iPhone\ 15\ Pro\ Max'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 env:
   CI_XCODE_OLDEST: '/Applications/Xcode_14.2.app/Contents/Developer'
   CI_XCODE_14: '/Applications/Xcode_14.3.1.app/Contents/Developer'
-  CI_XCODE_LATEST: '/Applications/Xcode_16.1.app/Contents/Developer'
+  CI_XCODE_LATEST: '/Applications/Xcode_16.2.app/Contents/Developer'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,16 +22,16 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        destination: ['platform=iOS\ Simulator,OS=18.1,name=iPhone\ 16\ Pro\ Max', 'platform\=tvOS\ Simulator,OS=18.1,name\=Apple\ TV', 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 10\ \(42mm\)', 'platform=macOS', 'platform=visionOS\ Simulator,OS=2.1,name=Apple\ Vision\ Pro']
+        destination: ['platform=iOS\ Simulator,OS=18.2,name=iPhone\ 16\ Pro\ Max', 'platform\=tvOS\ Simulator,OS=18.2,name\=Apple\ TV', 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 10\ \(42mm\)', 'platform=macOS', 'platform=visionOS\ Simulator,OS=2.1,name=Apple\ Vision\ Pro']
         action: ['test', 'build']
         exclude:
-          - destination: 'platform=iOS\ Simulator,OS=18.1,name=iPhone\ 16\ Pro\ Max'
+          - destination: 'platform=iOS\ Simulator,OS=18.2,name=iPhone\ 16\ Pro\ Max'
             action: 'build'
-          - destination: 'platform\=tvOS\ Simulator,OS=18.1,name\=Apple\ TV'
+          - destination: 'platform\=tvOS\ Simulator,OS=18.2,name\=Apple\ TV'
             action: 'build'
           - destination: 'platform=macOS'
             action: 'build'
-          - destination: 'platform=visionOS\ Simulator,OS=2.1,name=Apple\ Vision\ Pro'
+          - destination: 'platform=visionOS\ Simulator,OS=2.2,name=Apple\ Vision\ Pro'
             action: 'test'
           - destination: 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 10\ \(42mm\)'
             action: 'test'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
     - name: Prepare codecov
-      uses: sersoft-gmbh/swift-coverage-action@v4
+      uses: sersoft-gmbh/swift-coverage-action@v5
       id: coverage-files
       with:
         format: lcov
@@ -58,7 +58,7 @@ jobs:
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         files: ${{join(fromJSON(steps.coverage-files.outputs.files), ',')}}
         fail_ci_if_error: false
@@ -84,7 +84,7 @@ jobs:
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
     - name: Prepare codecov
-      uses: sersoft-gmbh/swift-coverage-action@v4
+      uses: sersoft-gmbh/swift-coverage-action@v5
       id: coverage-files
       with:
         format: lcov
@@ -92,7 +92,7 @@ jobs:
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         files: ${{join(fromJSON(steps.coverage-files.outputs.files), ',')}}
         env_vars: SPM
@@ -128,7 +128,7 @@ jobs:
           cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
           llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/debug/ParseSwiftPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata > info_linux.lcov
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           env_vars: LINUX
           fail_ci_if_error: true
@@ -147,7 +147,7 @@ jobs:
         run: |
           swift build --enable-test-discovery -v
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           env_vars: WINDOWSLATEST
           fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 env:
   CI_XCODE_OLDEST: '/Applications/Xcode_14.2.app/Contents/Developer'
   CI_XCODE_14: '/Applications/Xcode_14.3.1.app/Contents/Developer'
-  CI_XCODE_LATEST: '/Applications/Xcode_15.4.app/Contents/Developer'
+  CI_XCODE_LATEST: '/Applications/Xcode_16.1.app/Contents/Developer'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: sersoft-gmbh/swifty-linux-action@v3
         with:
-          release-version: "5"
+          release-version: "6"
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Test
         run: swift test --enable-test-discovery --enable-code-coverage -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build-Test
-      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace Parse.xcworkspace -scheme ParseSwift -destination platform\=iOS\ Simulator,name\=iPhone\ 15\ Pro\ Max -derivedDataPath DerivedData build 2>&1 | xcbeautify --renderer github-actions
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace Parse.xcworkspace -scheme ParseSwift -destination platform\=iOS\ Simulator,name\=iPhone\ 14\ Pro\ Max -derivedDataPath DerivedData build 2>&1 | xcbeautify --renderer github-actions
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE_OLDEST }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
   xcode-test-5_7:
     timeout-minutes: 25
     needs: linux
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
     - name: Build-Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   cocoapods:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Get release version
@@ -24,7 +24,7 @@ jobs:
           DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
 
   docs:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - name: Get release version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
     types: [published]
 env:
   CI_XCODE_14: '/Applications/Xcode_14.3.1.app/Contents/Developer'
-  CI_XCODE_LATEST: '/Applications/Xcode_15.4.app/Contents/Developer'
+  CI_XCODE_LATEST: '/Applications/Xcode_16.1.app/Contents/Developer'
 
 jobs:
   cocoapods:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,6 +3,7 @@ disabled_rules:
   - identifier_name
   - blanket_disable_command
   - non_optional_string_data_conversion
+  - optional_data_string_conversion
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Tests/ParseSwiftTests/ParseEncoderTests
   - DerivedData

--- a/Package.swift
+++ b/Package.swift
@@ -27,5 +27,6 @@ let package = Package(
             dependencies: ["ParseSwift"],
             exclude: ["Info.plist"]
         )
-    ]
+    ],
+    swiftLanguageModes: [.v5]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,5 @@ let package = Package(
             dependencies: ["ParseSwift"],
             exclude: ["Info.plist"]
         )
-    ],
-    swiftLanguageModes: [.v5]
+    ]
 )

--- a/Sources/ParseSwift/API/API+Command.swift
+++ b/Sources/ParseSwift/API/API+Command.swift
@@ -100,7 +100,7 @@ internal extension API {
                      allowIntermediateResponses: Bool = false,
                      uploadProgress: ((URLSessionTask, Int64, Int64, Int64) -> Void)? = nil,
                      downloadProgress: ((URLSessionDownloadTask, Int64, Int64, Int64) -> Void)? = nil,
-                     completion: @escaping(Result<U, ParseError>) -> Void) async {
+                     completion: @escaping (Result<U, ParseError>) -> Void) async {
             let currentNotificationQueue: DispatchQueue!
             if let notificationQueue = notificationQueue {
                 currentNotificationQueue = notificationQueue
@@ -257,7 +257,7 @@ internal extension API {
                                batching: Bool = false,
                                childObjects: [String: PointerType]? = nil,
                                childFiles: [String: ParseFile]? = nil,
-                               completion: @escaping(Result<URLRequest, ParseError>) -> Void) {
+                               completion: @escaping (Result<URLRequest, ParseError>) -> Void) {
             let params = self.params?.getURLQueryItems()
             Task {
                 do {

--- a/Sources/ParseSwift/API/API+NonParseBodyCommand.swift
+++ b/Sources/ParseSwift/API/API+NonParseBodyCommand.swift
@@ -37,7 +37,7 @@ internal extension API {
         func execute(options: API.Options,
                      callbackQueue: DispatchQueue,
                      allowIntermediateResponses: Bool = false,
-                     completion: @escaping(Result<U, ParseError>) -> Void) async {
+                     completion: @escaping (Result<U, ParseError>) -> Void) async {
 
             switch await self.prepareURLRequest(options: options) {
             case .success(let urlRequest):

--- a/Sources/ParseSwift/Extensions/URLSession.swift
+++ b/Sources/ParseSwift/Extensions/URLSession.swift
@@ -143,7 +143,7 @@ internal extension URLSession {
         attempts: Int = 1,
         allowIntermediateResponses: Bool,
         mapper: @escaping (Data) async throws -> U,
-        completion: @escaping(Result<U, ParseError>) -> Void
+        completion: @escaping (Result<U, ParseError>) -> Void
     ) async {
         do {
             let (responseData, urlResponse) = try await dataTask(for: request)
@@ -288,7 +288,7 @@ internal extension URLSession {
         from file: URL?,
         progress: ((URLSessionTask, Int64, Int64, Int64) -> Void)?,
         mapper: @escaping (Data) async throws -> U,
-        completion: @escaping(Result<U, ParseError>) -> Void
+        completion: @escaping (Result<U, ParseError>) -> Void
     ) {
         var task: URLSessionTask?
         if let data = data {
@@ -354,7 +354,7 @@ internal extension URLSession {
         with request: URLRequest,
         progress: ((URLSessionDownloadTask, Int64, Int64, Int64) -> Void)?,
         mapper: @escaping (Data) async throws -> U,
-        completion: @escaping(Result<U, ParseError>) -> Void
+        completion: @escaping (Result<U, ParseError>) -> Void
     ) async {
         let task = downloadTask(with: request) { (location, urlResponse, responseError) in
             Task {
@@ -374,7 +374,7 @@ internal extension URLSession {
     func downloadTask<U>(
         with request: URLRequest,
         mapper: @escaping (Data) async throws -> U,
-        completion: @escaping(Result<U, ParseError>) -> Void
+        completion: @escaping (Result<U, ParseError>) -> Void
     ) {
         Task {
             do {

--- a/Sources/ParseSwift/Storage/ParseFileManager.swift
+++ b/Sources/ParseSwift/Storage/ParseFileManager.swift
@@ -112,7 +112,7 @@ extension ParseFileManager {
         }
     }
 
-    func writeString(_ string: String, filePath: URL, completion: @escaping(Error?) -> Void) {
+    func writeString(_ string: String, filePath: URL, completion: @escaping (Error?) -> Void) {
         synchronizationQueue.async {
             do {
                 guard let data = string.data(using: .utf8) else {
@@ -127,7 +127,7 @@ extension ParseFileManager {
         }
     }
 
-    func writeData(_ data: Data, filePath: URL, completion: @escaping(Error?) -> Void) {
+    func writeData(_ data: Data, filePath: URL, completion: @escaping (Error?) -> Void) {
         synchronizationQueue.async {
             do {
                 try data.write(to: filePath, options: self.defaultDataWritingOptions)
@@ -138,7 +138,7 @@ extension ParseFileManager {
         }
     }
 
-    func copyItem(_ fromPath: URL, toPath: URL, completion: @escaping(Error?) -> Void) {
+    func copyItem(_ fromPath: URL, toPath: URL, completion: @escaping (Error?) -> Void) {
         synchronizationQueue.async {
             do {
                 try FileManager.default.copyItem(at: fromPath, to: toPath)
@@ -149,7 +149,7 @@ extension ParseFileManager {
         }
     }
 
-    func moveItem(_ fromPath: URL, toPath: URL, completion: @escaping(Error?) -> Void) {
+    func moveItem(_ fromPath: URL, toPath: URL, completion: @escaping (Error?) -> Void) {
         synchronizationQueue.async {
             if fromPath != toPath {
                 do {
@@ -164,7 +164,7 @@ extension ParseFileManager {
         }
     }
 
-    func moveContentsOfDirectory(_ fromPath: URL, toPath: URL, completion: @escaping(Error?) -> Void) {
+    func moveContentsOfDirectory(_ fromPath: URL, toPath: URL, completion: @escaping (Error?) -> Void) {
         synchronizationQueue.async {
             do {
                 if fromPath == toPath {

--- a/Sources/ParseSwift/Types/ParsePushPayload/Firebase/ParsePushFirebaseNotification.swift
+++ b/Sources/ParseSwift/Types/ParsePushPayload/Firebase/ParsePushFirebaseNotification.swift
@@ -128,8 +128,8 @@ public struct ParsePushFirebaseNotification: ParseTypeable {
     enum CodingKeys: String, CodingKey {
         case titleLocKey = "title_loc_key"
         case titleLocArgs = "title_loc_args"
-        case bodyLocKey = "body_loc-key"
-        case bodyLocArgs = "body-loc-args"
+        case bodyLocKey = "body_loc_key"
+        case bodyLocArgs = "body_loc_args"
         case clickAction = "click_action"
         case androidChannelId = "android_channel_id"
         case title, icon, body, sound, badge, tag,

--- a/Tests/ParseSwiftTests/ParsePushPayloadAnyTests.swift
+++ b/Tests/ParseSwiftTests/ParsePushPayloadAnyTests.swift
@@ -115,7 +115,7 @@ class ParsePushPayloadAnyTests: XCTestCase {
         XCTAssertEqual(decodedAny2, applePayload)
         #if !os(Linux) && !os(Android) && !os(Windows)
         XCTAssertEqual(fcmPayload.description,
-                       "{\"collapseKey\":\"nope\",\"data\":{\"help\":\"you\"},\"delayWhileIdle\":false,\"dryRun\":false,\"notification\":{\"android_channel_id\":\"you\",\"badge\":\"no\",\"body\":\"android\",\"body-loc-args\":[\"mother\"],\"body_loc-key\":\"cousin\",\"click_action\":\"to\",\"color\":\"blue\",\"icon\":\"world\",\"image\":\"icon\",\"sound\":\"yes\",\"subtitle\":\"trip\",\"tag\":\"it\",\"title\":\"hello\",\"title_loc_args\":[\"arg\"],\"title_loc_key\":\"it\"},\"restrictedPackageName\":\"geez\",\"title\":\"peace\",\"uri\":\"https:\\/\\/parse.org\"}")
+                       "{\"collapseKey\":\"nope\",\"data\":{\"help\":\"you\"},\"delayWhileIdle\":false,\"dryRun\":false,\"notification\":{\"android_channel_id\":\"you\",\"badge\":\"no\",\"body\":\"android\",\"body_loc_args\":[\"mother\"],\"body_loc_key\":\"cousin\",\"click_action\":\"to\",\"color\":\"blue\",\"icon\":\"world\",\"image\":\"icon\",\"sound\":\"yes\",\"subtitle\":\"trip\",\"tag\":\"it\",\"title\":\"hello\",\"title_loc_args\":[\"arg\"],\"title_loc_key\":\"it\"},\"restrictedPackageName\":\"geez\",\"title\":\"peace\",\"uri\":\"https:\\/\\/parse.org\"}")
         #endif
     }
 
@@ -230,7 +230,7 @@ class ParsePushPayloadAnyTests: XCTestCase {
         XCTAssertEqual(decoded2, fcmPayload)
         #if !os(Linux) && !os(Android) && !os(Windows)
         XCTAssertEqual(fcmPayload.description,
-                       "{\"collapseKey\":\"nope\",\"contentAvailable\":true,\"data\":{\"help\":\"you\"},\"delayWhileIdle\":false,\"dryRun\":false,\"mutableContent\":true,\"notification\":{\"android_channel_id\":\"you\",\"badge\":\"no\",\"body\":\"android\",\"body-loc-args\":[\"mother\"],\"body_loc-key\":\"cousin\",\"click_action\":\"to\",\"color\":\"blue\",\"icon\":\"world\",\"image\":\"icon\",\"sound\":\"yes\",\"subtitle\":\"trip\",\"tag\":\"it\",\"title\":\"hello\",\"title_loc_args\":[\"arg\"],\"title_loc_key\":\"it\"},\"priority\":\"high\",\"restrictedPackageName\":\"geez\",\"title\":\"peace\",\"uri\":\"https:\\/\\/parse.org\"}")
+                       "{\"collapseKey\":\"nope\",\"contentAvailable\":true,\"data\":{\"help\":\"you\"},\"delayWhileIdle\":false,\"dryRun\":false,\"mutableContent\":true,\"notification\":{\"android_channel_id\":\"you\",\"badge\":\"no\",\"body\":\"android\",\"body_loc_args\":[\"mother\"],\"body_loc_key\":\"cousin\",\"click_action\":\"to\",\"color\":\"blue\",\"icon\":\"world\",\"image\":\"icon\",\"sound\":\"yes\",\"subtitle\":\"trip\",\"tag\":\"it\",\"title\":\"hello\",\"title_loc_args\":[\"arg\"],\"title_loc_key\":\"it\"},\"priority\":\"high\",\"restrictedPackageName\":\"geez\",\"title\":\"peace\",\"uri\":\"https:\\/\\/parse.org\"}")
         #endif
     }
 }

--- a/Tests/ParseSwiftTests/ParsePushPayloadAnyTests.swift
+++ b/Tests/ParseSwiftTests/ParsePushPayloadAnyTests.swift
@@ -115,7 +115,7 @@ class ParsePushPayloadAnyTests: XCTestCase {
         XCTAssertEqual(decodedAny2, applePayload)
         #if !os(Linux) && !os(Android) && !os(Windows)
         XCTAssertEqual(fcmPayload.description,
-                       "{\"collapseKey\":\"nope\",\"data\":{\"help\":\"you\"},\"delayWhileIdle\":false,\"dryRun\":false,\"notification\":{\"android_channel_id\":\"you\",\"badge\":\"no\",\"body\":\"android\",\"body_loc-key\":\"cousin\",\"body-loc-args\":[\"mother\"],\"click_action\":\"to\",\"color\":\"blue\",\"icon\":\"world\",\"image\":\"icon\",\"sound\":\"yes\",\"subtitle\":\"trip\",\"tag\":\"it\",\"title\":\"hello\",\"title_loc_args\":[\"arg\"],\"title_loc_key\":\"it\"},\"restrictedPackageName\":\"geez\",\"title\":\"peace\",\"uri\":\"https:\\/\\/parse.org\"}")
+                       "{\"collapseKey\":\"nope\",\"data\":{\"help\":\"you\"},\"delayWhileIdle\":false,\"dryRun\":false,\"notification\":{\"android_channel_id\":\"you\",\"badge\":\"no\",\"body\":\"android\",\"body-loc-args\":[\"mother\"],\"body_loc-key\":\"cousin\",\"click_action\":\"to\",\"color\":\"blue\",\"icon\":\"world\",\"image\":\"icon\",\"sound\":\"yes\",\"subtitle\":\"trip\",\"tag\":\"it\",\"title\":\"hello\",\"title_loc_args\":[\"arg\"],\"title_loc_key\":\"it\"},\"restrictedPackageName\":\"geez\",\"title\":\"peace\",\"uri\":\"https:\\/\\/parse.org\"}")
         #endif
     }
 
@@ -230,7 +230,7 @@ class ParsePushPayloadAnyTests: XCTestCase {
         XCTAssertEqual(decoded2, fcmPayload)
         #if !os(Linux) && !os(Android) && !os(Windows)
         XCTAssertEqual(fcmPayload.description,
-                       "{\"collapseKey\":\"nope\",\"contentAvailable\":true,\"data\":{\"help\":\"you\"},\"delayWhileIdle\":false,\"dryRun\":false,\"mutableContent\":true,\"notification\":{\"android_channel_id\":\"you\",\"badge\":\"no\",\"body\":\"android\",\"body_loc-key\":\"cousin\",\"body-loc-args\":[\"mother\"],\"click_action\":\"to\",\"color\":\"blue\",\"icon\":\"world\",\"image\":\"icon\",\"sound\":\"yes\",\"subtitle\":\"trip\",\"tag\":\"it\",\"title\":\"hello\",\"title_loc_args\":[\"arg\"],\"title_loc_key\":\"it\"},\"priority\":\"high\",\"restrictedPackageName\":\"geez\",\"title\":\"peace\",\"uri\":\"https:\\/\\/parse.org\"}")
+                       "{\"collapseKey\":\"nope\",\"contentAvailable\":true,\"data\":{\"help\":\"you\"},\"delayWhileIdle\":false,\"dryRun\":false,\"mutableContent\":true,\"notification\":{\"android_channel_id\":\"you\",\"badge\":\"no\",\"body\":\"android\",\"body-loc-args\":[\"mother\"],\"body_loc-key\":\"cousin\",\"click_action\":\"to\",\"color\":\"blue\",\"icon\":\"world\",\"image\":\"icon\",\"sound\":\"yes\",\"subtitle\":\"trip\",\"tag\":\"it\",\"title\":\"hello\",\"title_loc_args\":[\"arg\"],\"title_loc_key\":\"it\"},\"priority\":\"high\",\"restrictedPackageName\":\"geez\",\"title\":\"peace\",\"uri\":\"https:\\/\\/parse.org\"}")
         #endif
     }
 }

--- a/Tests/ParseSwiftTests/ParsePushPayloadFirebaseTests.swift
+++ b/Tests/ParseSwiftTests/ParsePushPayloadFirebaseTests.swift
@@ -73,7 +73,7 @@ class ParsePushPayloadFirebaseTests: XCTestCase {
         XCTAssertEqual(fcmPayload, decoded)
         #if !os(Linux) && !os(Android) && !os(Windows)
         XCTAssertEqual(fcmPayload.description,
-                       "{\"collapseKey\":\"nope\",\"contentAvailable\":true,\"data\":{\"help\":\"you\"},\"delayWhileIdle\":false,\"dryRun\":false,\"mutableContent\":true,\"notification\":{\"android_channel_id\":\"you\",\"badge\":\"no\",\"body\":\"android\",\"body_loc-key\":\"cousin\",\"body-loc-args\":[\"mother\"],\"click_action\":\"to\",\"color\":\"blue\",\"icon\":\"world\",\"image\":\"icon\",\"sound\":\"yes\",\"subtitle\":\"trip\",\"tag\":\"it\",\"title\":\"hello\",\"title_loc_args\":[\"arg\"],\"title_loc_key\":\"it\"},\"priority\":\"high\",\"restrictedPackageName\":\"geez\",\"title\":\"peace\",\"uri\":\"https:\\/\\/parse.org\"}")
+                       "{\"collapseKey\":\"nope\",\"contentAvailable\":true,\"data\":{\"help\":\"you\"},\"delayWhileIdle\":false,\"dryRun\":false,\"mutableContent\":true,\"notification\":{\"android_channel_id\":\"you\",\"badge\":\"no\",\"body\":\"android\",\"body-loc-args\":[\"mother\"],\"body_loc-key\":\"cousin\",\"click_action\":\"to\",\"color\":\"blue\",\"icon\":\"world\",\"image\":\"icon\",\"sound\":\"yes\",\"subtitle\":\"trip\",\"tag\":\"it\",\"title\":\"hello\",\"title_loc_args\":[\"arg\"],\"title_loc_key\":\"it\"},\"priority\":\"high\",\"restrictedPackageName\":\"geez\",\"title\":\"peace\",\"uri\":\"https:\\/\\/parse.org\"}")
         #endif
     }
 }

--- a/Tests/ParseSwiftTests/ParsePushPayloadFirebaseTests.swift
+++ b/Tests/ParseSwiftTests/ParsePushPayloadFirebaseTests.swift
@@ -73,7 +73,7 @@ class ParsePushPayloadFirebaseTests: XCTestCase {
         XCTAssertEqual(fcmPayload, decoded)
         #if !os(Linux) && !os(Android) && !os(Windows)
         XCTAssertEqual(fcmPayload.description,
-                       "{\"collapseKey\":\"nope\",\"contentAvailable\":true,\"data\":{\"help\":\"you\"},\"delayWhileIdle\":false,\"dryRun\":false,\"mutableContent\":true,\"notification\":{\"android_channel_id\":\"you\",\"badge\":\"no\",\"body\":\"android\",\"body-loc-args\":[\"mother\"],\"body_loc-key\":\"cousin\",\"click_action\":\"to\",\"color\":\"blue\",\"icon\":\"world\",\"image\":\"icon\",\"sound\":\"yes\",\"subtitle\":\"trip\",\"tag\":\"it\",\"title\":\"hello\",\"title_loc_args\":[\"arg\"],\"title_loc_key\":\"it\"},\"priority\":\"high\",\"restrictedPackageName\":\"geez\",\"title\":\"peace\",\"uri\":\"https:\\/\\/parse.org\"}")
+                       "{\"collapseKey\":\"nope\",\"contentAvailable\":true,\"data\":{\"help\":\"you\"},\"delayWhileIdle\":false,\"dryRun\":false,\"mutableContent\":true,\"notification\":{\"android_channel_id\":\"you\",\"badge\":\"no\",\"body\":\"android\",\"body_loc_args\":[\"mother\"],\"body_loc_key\":\"cousin\",\"click_action\":\"to\",\"color\":\"blue\",\"icon\":\"world\",\"image\":\"icon\",\"sound\":\"yes\",\"subtitle\":\"trip\",\"tag\":\"it\",\"title\":\"hello\",\"title_loc_args\":[\"arg\"],\"title_loc_key\":\"it\"},\"priority\":\"high\",\"restrictedPackageName\":\"geez\",\"title\":\"peace\",\"uri\":\"https:\\/\\/parse.org\"}")
         #endif
     }
 }


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [ ] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

### Approach
<!-- Add a description of the approach in this PR. -->
- [x] Firebase encoding keys should use underscores instead of dashes
- [x] Bump to latest Xcode
- [x] Only build linux for latest 5.x as 6.x forces Swift 6 conversion 

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
