### PR TITLE
fix: Encoding plus symbol in URI's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.11.3...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.11.4...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 5.11.4
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.11.3...5.11.4), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.11.4/documentation/parseswift)
+
+__Fixes__
+* Encode plus symbol in query parameter URI's to server ([#191](https://github.com/netreconlab/Parse-Swift/pull/191)), thanks to [Corey Baker](https://github.com/cbaker6).
+* Encode Firebase notification keys correctly ([#187](https://github.com/netreconlab/Parse-Swift/pull/187)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 5.11.3
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.11.2...5.11.3), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.11.3/documentation/parseswift)

--- a/Sources/ParseSwift/API/API+Command.swift
+++ b/Sources/ParseSwift/API/API+Command.swift
@@ -276,6 +276,11 @@ internal extension API {
                         return
                     }
                     components.queryItems = params
+                    components.percentEncodedQuery = components.percentEncodedQuery?
+                        .replacingOccurrences(
+                            of: "+",
+                            with: "%2B"
+                        )
 
                     guard let urlComponents = components.url else {
                         let error = ParseError(code: .otherCause,

--- a/Sources/ParseSwift/API/API+NonParseBodyCommand.swift
+++ b/Sources/ParseSwift/API/API+NonParseBodyCommand.swift
@@ -78,6 +78,11 @@ internal extension API {
                                                message: "Could not unwrap url components for \(url)"))
                 }
                 components.queryItems = params
+                components.percentEncodedQuery = components.percentEncodedQuery?
+                    .replacingOccurrences(
+                        of: "+",
+                        with: "%2B"
+                    )
 
                 guard let urlComponents = components.url else {
                     return .failure(ParseError(code: .otherCause,

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -154,6 +154,11 @@ Not attempting to open ParseLiveQuery socket anymore
             throw error
         }
         components.scheme = (components.scheme == "https" || components.scheme == "wss") ? "wss" : "ws"
+        components.percentEncodedQuery = components.percentEncodedQuery?
+            .replacingOccurrences(
+                of: "+",
+                with: "%2B"
+            )
         url = components.url
         self.task = await URLSession.liveQuery.createTask(self.url,
                                                           taskDelegate: self)

--- a/Tests/ParseSwiftTests/APICommandTests.swift
+++ b/Tests/ParseSwiftTests/APICommandTests.swift
@@ -407,6 +407,55 @@ class APICommandTests: XCTestCase {
         }
     }
 
+    func testQueryWhereEncoding() async throws {
+        let query = Level.query("name" == "test@parse.com")
+        let parameters = try query.getQueryParameters()
+
+        let queryCommand = API.NonParseBodyCommand<Query<Level>, Level?>(
+            method: .GET,
+            path: query.endpoint,
+            params: parameters
+        ) { _ in
+            return nil
+        }
+
+        switch await queryCommand.prepareURLRequest(options: []) {
+
+        case .success(let request):
+            XCTAssertEqual(
+                request.url?.absoluteString,
+                "http://localhost:1337/parse/classes/Level?limit=100&skip=0&where=%7B%22name%22:%22test@parse.com%22%7D"
+            )
+        case .failure(let error):
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    func testQueryWhereEncodingPlus() async throws {
+        let query = Level.query("name" == "test+1@parse.com")
+        let parameters = try query.getQueryParameters()
+
+        let queryCommand = API.NonParseBodyCommand<Query<Level>, Level?>(
+            method: .GET,
+            path: query.endpoint,
+            params: parameters
+        ) { _ in
+            return nil
+        }
+
+        switch await queryCommand.prepareURLRequest(options: []) {
+
+        case .success(let request):
+            XCTAssertEqual(
+                request.url?.absoluteString,
+                // swiftlint:disable:next line_length
+                "http://localhost:1337/parse/classes/Level?limit=100&skip=0&where=%7B%22name%22:%22test%2B1@parse.com%22%7D"
+            )
+        case .failure(let error):
+            XCTFail(error.localizedDescription)
+        }
+    }
+
     func testClientKeyHeader() async throws {
         guard let clientKey = ParseSwift.configuration.clientKey else {
             throw ParseError(code: .otherCause, message: "Parse configuration should contain key")


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- [x] I am not disclosing a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- [x] I am creating this PR in reference to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Close #189

### Approach
<!-- Add a description of the approach in this PR. -->
Encode all plus values in query parameters.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog
- [x] Add changes to documentation (guides, repository pages, in-code descriptions)
