### PR TITLE
fix: Handle pointer on Installation and User creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.12.0...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.12.1...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 5.12.1
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.12.0...5.12.1), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.12.1/documentation/parseswift)
+
+__Fixes__
+* Fix failing to decode a ParseInstallation or ParseUser due to object returning from the server as a pointer ([#196](https://github.com/netreconlab/Parse-Swift/pull/196)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 5.12.0
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.11.5...5.12.0), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.12.0/documentation/parseswift)

--- a/Sources/ParseSwift/API/ParseURLSessionDelegate.swift
+++ b/Sources/ParseSwift/API/ParseURLSessionDelegate.swift
@@ -18,7 +18,7 @@ class ParseURLSessionDelegate: NSObject {
                            URLCredential?) -> Void) -> Void)?
     var streamDelegates = [URLSessionTask: InputStream]()
 
-    actor SessionDelegate: Sendable {
+    actor SessionDelegate {
         var downloadDelegates = [URLSessionDownloadTask: ((URLSessionDownloadTask, Int64, Int64, Int64) -> Void)]()
         var uploadDelegates = [URLSessionTask: ((URLSessionTask, Int64, Int64, Int64) -> Void)]()
         var taskCallbackQueues = [URLSessionTask: DispatchQueue]()

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.12.0"
+    static let version = "5.12.1"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Tests/ParseSwiftTests/APICommandMultipleAttemptsTests.swift
+++ b/Tests/ParseSwiftTests/APICommandMultipleAttemptsTests.swift
@@ -57,7 +57,7 @@ class APICommandMultipleAttemptsTests: XCTestCase {
         try await ParseStorage.shared.deleteAll()
     }
 
-    actor Result: Sendable {
+    actor Result {
         var attempts = 0
 
         func incrementAttempts() {


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- Disclose a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- Link this PR to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Sometimes when using custom objectId's and `create` the Installation or User returns from the server as a pointer upon creation.

Closes: FILL_THIS_OUT

### Approach
<!-- Add a description of the approach in this PR. -->
Try to decode `CreateResponse` first for both Installation and User, if it doesn't succeed, try to decode as Pointer and update the object with the new objectId

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add entry to changelog
