### PR TITLE
feat: Attempt to retreive full objects on server during POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,15 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.12.1...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.12.2...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 5.12.2
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.12.1...5.12.2), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.12.2/documentation/parseswift)
+
+__Fixes__
+* When creating objects, if the server does not return the correct full object, attempt to retrieve it before returning to call-site. ([#197](https://github.com/netreconlab/Parse-Swift/pull/197)), thanks to [Corey Baker](https://github.com/cbaker6).
+* Fixes an issue when using `mergeable` on `ParseInstallation`'s' and properties that are automatically computed such as `appVersion` are not sent to the server. ([#197](https://github.com/netreconlab/Parse-Swift/pull/197)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 5.12.1
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.12.0...5.12.1), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.12.1/documentation/parseswift)

--- a/Sources/ParseSwift/Objects/ParseUser.swift
+++ b/Sources/ParseSwift/Objects/ParseUser.swift
@@ -1223,8 +1223,9 @@ extension ParseUser {
 				let savedObject = try ParseCoding.jsonDecoder().decode(
 					CreateResponse.self,
 					from: data
-				).apply(to: updatedUser)
-
+				).apply(
+					to: updatedUser
+				)
 				return savedObject
 			} catch let originalError {
 				do {
@@ -1232,9 +1233,8 @@ extension ParseUser {
 						Pointer<Self>.self,
 						from: data
 					)
-					var objectToUpdate = updatedUser
-					objectToUpdate.objectId = pointer.objectId
-					return objectToUpdate
+					let fetchedObject = try await pointer.fetch()
+					return fetchedObject
 				} catch {
 					throw originalError
 				}

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "5.12.1"
+    static let version = "5.12.2"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -483,6 +483,51 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
         XCTAssertEqual(merged, original)
     }
 
+	@MainActor
+	func testMergeableRetainsAutomaticallyComputedProperties() async throws {
+		var original = try await Installation.current()
+		original.objectId = "yolo"
+		original.createdAt = Date()
+		original.updatedAt = Date()
+		original.badge = 10
+		original.deviceToken = "12345"
+		original.channels = ["halo"]
+		original.customKey = "newKey"
+		var acl = ParseACL()
+		acl.publicRead = true
+		original.ACL = acl
+
+		// These properties should not be nil before merge
+		XCTAssertNotNil(original.customKey)
+		XCTAssertNotNil(original.deviceType)
+		XCTAssertNotNil(original.deviceToken)
+		XCTAssertNotNil(original.channels)
+		XCTAssertNotNil(original.installationId)
+		XCTAssertNotNil(original.ACL)
+		XCTAssertNotNil(original.updatedAt)
+
+		let mergeable = original.mergeable
+
+		// These should always remain in the merge
+		XCTAssertEqual(original.badge, mergeable.badge)
+		XCTAssertEqual(original.timeZone, mergeable.timeZone)
+		XCTAssertEqual(original.appName, mergeable.appName)
+		XCTAssertEqual(original.appVersion, mergeable.appVersion)
+		XCTAssertEqual(original.appIdentifier, mergeable.appIdentifier)
+		XCTAssertEqual(original.parseVersion, mergeable.parseVersion)
+		XCTAssertEqual(original.localeIdentifier, mergeable.localeIdentifier)
+		XCTAssertEqual(original.createdAt, mergeable.createdAt)
+
+		// All other properties should be nil
+		XCTAssertNil(mergeable.customKey)
+		XCTAssertNil(mergeable.deviceType)
+		XCTAssertNil(mergeable.deviceToken)
+		XCTAssertNil(mergeable.channels)
+		XCTAssertNil(mergeable.installationId)
+		XCTAssertNil(mergeable.ACL)
+		XCTAssertNil(mergeable.updatedAt)
+	}
+
     @MainActor
     func testMergeDifferentObjectId() async throws {
         var installation = Installation()

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -528,6 +528,48 @@ class ParseInstallationTests: XCTestCase { // swiftlint:disable:this type_body_l
 		XCTAssertNil(mergeable.updatedAt)
 	}
 
+	@MainActor
+	func testMergeableRetainsAllPropertiesWhenNotSaved() async throws {
+		var original = try await Installation.current()
+		original.badge = 10
+		original.deviceToken = "12345"
+		original.channels = ["halo"]
+		original.customKey = "newKey"
+		var acl = ParseACL()
+		acl.publicRead = true
+		original.ACL = acl
+
+		XCTAssertNil(original.objectId)
+		XCTAssertNil(original.createdAt)
+		XCTAssertNil(original.updatedAt)
+
+		// These properties should not be nil before merge
+		XCTAssertNotNil(original.customKey)
+		XCTAssertNotNil(original.deviceType)
+		XCTAssertNotNil(original.deviceToken)
+		XCTAssertNotNil(original.channels)
+		XCTAssertNotNil(original.installationId)
+		XCTAssertNotNil(original.ACL)
+
+		let mergeable = original.mergeable
+
+		XCTAssertEqual(original.badge, mergeable.badge)
+		XCTAssertEqual(original.timeZone, mergeable.timeZone)
+		XCTAssertEqual(original.appName, mergeable.appName)
+		XCTAssertEqual(original.appVersion, mergeable.appVersion)
+		XCTAssertEqual(original.appIdentifier, mergeable.appIdentifier)
+		XCTAssertEqual(original.parseVersion, mergeable.parseVersion)
+		XCTAssertEqual(original.localeIdentifier, mergeable.localeIdentifier)
+		XCTAssertEqual(original.customKey, mergeable.customKey)
+		XCTAssertEqual(original.deviceType, mergeable.deviceType)
+		XCTAssertEqual(original.deviceToken, mergeable.deviceToken)
+		XCTAssertEqual(original.channels, mergeable.channels)
+		XCTAssertEqual(original.installationId, mergeable.installationId)
+		XCTAssertEqual(original.ACL, mergeable.ACL)
+		XCTAssertEqual(original.createdAt, mergeable.createdAt)
+		XCTAssertEqual(original.updatedAt, mergeable.updatedAt)
+	}
+
     @MainActor
     func testMergeDifferentObjectId() async throws {
         var installation = Installation()

--- a/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
@@ -661,6 +661,36 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         }
     }
 
+	func testCreateServerReturnsPointer() async throws {
+		var score = GameScore(points: 10)
+		score.objectId = "yarr"
+
+		var scoreOnServer = try score.toPointer()
+
+		let encoded: Data!
+		do {
+			encoded = try ParseCoding.jsonEncoder().encode(scoreOnServer)
+			// Get dates in correct format from ParseDecoding strategy
+			scoreOnServer = try score.getDecoder().decode(
+				Pointer<GameScore>.self,
+				from: encoded
+			)
+		} catch {
+			XCTFail("Should encode/decode. Error \(error)")
+			return
+		}
+
+		MockURLProtocol.mockRequests { _ in
+			return MockURLResponse(data: encoded, statusCode: 200)
+		}
+		do {
+			let saved = try await score.create()
+			XCTAssertTrue(saved.objectId == scoreOnServer.objectId)
+		} catch {
+			XCTFail(error.localizedDescription)
+		}
+	}
+
     func testSaveNoObjectId() async throws {
         let score = GameScore(points: 10)
         do {
@@ -1276,6 +1306,37 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
         }
     }
 
+	func testUserCreateServerReturnsPointer() async throws {
+		var user = User()
+		user.objectId = "yarr"
+		user.ACL = nil
+
+		var userOnServer = try user.toPointer()
+
+		let encoded: Data!
+		do {
+			encoded = try ParseCoding.jsonEncoder().encode(userOnServer)
+			// Get dates in correct format from ParseDecoding strategy
+			userOnServer = try user.getDecoder().decode(
+				Pointer<User>.self,
+				from: encoded
+			)
+		} catch {
+			XCTFail("Should encode/decode. Error \(error)")
+			return
+		}
+
+		MockURLProtocol.mockRequests { _ in
+			return MockURLResponse(data: encoded, statusCode: 200)
+		}
+		do {
+			let saved = try await user.create()
+			XCTAssertTrue(saved.objectId == userOnServer.objectId)
+		} catch {
+			XCTFail(error.localizedDescription)
+		}
+	}
+
     func testUserSaveNoObjectId() async throws {
         let score = GameScore(points: 10)
         do {
@@ -1828,6 +1889,37 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
             XCTFail(error.localizedDescription)
         }
     }
+
+	func testInstallationCreateServerReturnsPointer() async throws {
+		var installation = Installation()
+		installation.objectId = "yarr"
+		installation.ACL = nil
+
+		var installationOnServer = try installation.toPointer()
+
+		let encoded: Data!
+		do {
+			encoded = try ParseCoding.jsonEncoder().encode(installationOnServer)
+			// Get dates in correct format from ParseDecoding strategy
+			installationOnServer = try installation.getDecoder().decode(
+				Pointer<Installation>.self,
+				from: encoded
+			)
+		} catch {
+			XCTFail("Should encode/decode. Error \(error)")
+			return
+		}
+
+		MockURLProtocol.mockRequests { _ in
+			return MockURLResponse(data: encoded, statusCode: 200)
+		}
+		do {
+			let saved = try await installation.create()
+			XCTAssertTrue(saved.objectId == installationOnServer.objectId)
+		} catch {
+			XCTFail(error.localizedDescription)
+		}
+	}
 
     func testInstallationSaveNoObjectId() async throws {
         let score = GameScore(points: 10)

--- a/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
@@ -691,6 +691,36 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 		}
 	}
 
+	func testCreateServerReturnsIncorrectJSON() async throws {
+		var score = GameScore(points: 10)
+		score.objectId = "yarr"
+
+		var scoreOnServer = GameScore()
+
+		let encoded: Data!
+		do {
+			encoded = try ParseCoding.jsonEncoder().encode(scoreOnServer)
+			// Get dates in correct format from ParseDecoding strategy
+			scoreOnServer = try score.getDecoder().decode(
+				GameScore.self,
+				from: encoded
+			)
+		} catch {
+			XCTFail("Should encode/decode. Error \(error)")
+			return
+		}
+
+		MockURLProtocol.mockRequests { _ in
+			return MockURLResponse(data: encoded, statusCode: 200)
+		}
+		do {
+			_ = try await score.create()
+			XCTFail("Should have failed to decode")
+		} catch {
+			XCTAssertTrue(error.equalsTo(.otherCause))
+		}
+	}
+
     func testSaveNoObjectId() async throws {
         let score = GameScore(points: 10)
         do {
@@ -1337,6 +1367,37 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 		}
 	}
 
+	func testUserCreateServerReturnsIncorrectJSON() async throws {
+		var user = User()
+		user.objectId = "yarr"
+		user.ACL = nil
+
+		var userOnServer = User()
+
+		let encoded: Data!
+		do {
+			encoded = try ParseCoding.jsonEncoder().encode(userOnServer)
+			// Get dates in correct format from ParseDecoding strategy
+			userOnServer = try user.getDecoder().decode(
+				User.self,
+				from: encoded
+			)
+		} catch {
+			XCTFail("Should encode/decode. Error \(error)")
+			return
+		}
+
+		MockURLProtocol.mockRequests { _ in
+			return MockURLResponse(data: encoded, statusCode: 200)
+		}
+		do {
+			_ = try await user.create()
+			XCTFail("Should have failed to decode")
+		} catch {
+			XCTAssertTrue(error.equalsTo(.otherCause))
+		}
+	}
+
     func testUserSaveNoObjectId() async throws {
         let score = GameScore(points: 10)
         do {
@@ -1918,6 +1979,37 @@ class ParseObjectCustomObjectIdTests: XCTestCase { // swiftlint:disable:this typ
 			XCTAssertTrue(saved.objectId == installationOnServer.objectId)
 		} catch {
 			XCTFail(error.localizedDescription)
+		}
+	}
+
+	func testInstallationCreateServerReturnsIncorrectJSON() async throws {
+		var installation = Installation()
+		installation.objectId = "yarr"
+		installation.ACL = nil
+
+		var installationOnServer = Installation()
+
+		let encoded: Data!
+		do {
+			encoded = try ParseCoding.jsonEncoder().encode(installationOnServer)
+			// Get dates in correct format from ParseDecoding strategy
+			installationOnServer = try installation.getDecoder().decode(
+				Installation.self,
+				from: encoded
+			)
+		} catch {
+			XCTFail("Should encode/decode. Error \(error)")
+			return
+		}
+
+		MockURLProtocol.mockRequests { _ in
+			return MockURLResponse(data: encoded, statusCode: 200)
+		}
+		do {
+			_ = try await installation.create()
+			XCTFail("Should have failed to decode")
+		} catch {
+			XCTAssertTrue(error.equalsTo(.otherCause))
 		}
 	}
 


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- Disclose a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- Link this PR to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
- Sometimes, when creating objects, the server may return a `ParsePointer` instead of the realized object.
- There's an issue when using `mergeable` on `ParseInstallation`'s' and properties that are automatically computed, such as `appVersion` are not sent to the server

Closes: FILL_THIS_OUT

### Approach
<!-- Add a description of the approach in this PR. -->
- Attempt to retrieve the realized object before returning to the function call-site
- When using `mergeable` on `ParseInstallation`, always retain all automatically computed properties so the server always receives the latest update of a `ParseInstallation`.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [x] Add entry to changelog