### PR TITLE
fix: Only set default LiveQuery client once

### DIFF
--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -295,7 +295,6 @@ Not attempting to open ParseLiveQuery socket anymore
         try await self.resumeTask()
         if isDefault {
             Self.defaultClient = self
-            Self.isConfiguring = false
         }
     }
 
@@ -329,7 +328,8 @@ Not attempting to open ParseLiveQuery socket anymore
         }
         isConfiguring = true
         try await yieldIfNotInitialized()
-        Self.defaultClient = try await ParseLiveQuery(isDefault: true)
+		_ = try await ParseLiveQuery(isDefault: true)
+		isConfiguring = false
     }
 
     static func client() async throws -> ParseLiveQuery {

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "6.0.0-beta.4"
+    static let version = "6.0.0-beta.5"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- Disclose a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- Link this PR to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
This PR fixes a concurrency issue in the LiveQuery client initialization by ensuring the default client is only set once.

Closes: FILL_THIS_OUT

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
