### PR TITLE
fix: LiveQuery clients should receive messages using a new task

### DIFF
--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -292,10 +292,12 @@ Not attempting to open ParseLiveQuery socket anymore
 			taskDelegate: self
 		)
 		self.task = newTask
-        try await self.resumeTask()
-        if isDefault {
-            Self.defaultClient = self
-        }
+		if isDefault {
+			Self.defaultClient = self
+		}
+		Task {
+			try await self.resumeTask()
+		}
     }
 
     /// Gracefully disconnects from the ParseLiveQuery Server.

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -296,7 +296,7 @@ Not attempting to open ParseLiveQuery socket anymore
 			Self.defaultClient = self
 		}
 		Task {
-			try await self.resumeTask()
+			try? await self.resumeTask()
 		}
     }
 

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "6.0.0-beta.5"
+    static let version = "6.0.0-beta.6"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- Disclose a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- Link this PR to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
LiveQuery should receive on a new task and not block initialization.
 
Closes: FILL_THIS_OU

### Approach
<!-- Add a description of the approach in this PR. -->

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
