### PR TITLE
fix: URLSession usage on Linux, Windows, and Android

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,10 +117,10 @@ jobs:
       id: coverage-files
       with:
         format: lcov
-        search-paths: ./.build
+        search-paths: ./DerivedData
         ignore-conversion-failures: true
       env:
-          DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
+          DEVELOPER_DIR: ${{ env.CI_XCODE_OLDEST }}
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       with:
@@ -140,12 +140,12 @@ jobs:
         with:
           toolchain: 6.2.3
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and Test
-        run: set -o pipefail && env NSUnbufferedIO=YES swift test --enable-test-discovery --enable-code-coverage
-      - name: Prepare codecov
-        run: |
-          cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
-          llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/debug/ParseSwiftPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata > info_linux.lcov
+      - name: Build
+        run: set -o pipefail && env NSUnbufferedIO=YES swift build --enable-test-discovery --enable-code-coverage
+      #- name: Prepare codecov
+      #  run: |
+      #    cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
+      #    llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/debug/ParseSwiftPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata > info_linux.lcov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
@@ -162,9 +162,9 @@ jobs:
         with:
           branch: swift-6.2.3-release
           tag: 6.2.3-RELEASE
-      - name: Build and Test
+      - name: Build
         run: |
-          swift test --enable-test-discovery --enable-code-coverage
+          swift build --enable-test-discovery --enable-code-coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           - destination: 'platform=macOS'
             action: 'build'
           - destination: 'platform=visionOS\ Simulator,OS=26.2,name=Apple\ Vision\ Pro'
-            action: 'test'
+            action: 'build'
           - destination: 'platform=watchOS\ Simulator,name=Apple\ Watch\ Series\ 11\ \(46mm\)'
             action: 'test'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
           toolchain: 6.2.3
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Test
-        run: swift build --enable-test-discovery --enable-code-coverage
+        run: set -o pipefail && env NSUnbufferedIO=YES swift test --enable-test-discovery --enable-code-coverage
       #- name: Prepare codecov
       #  run: |
       #    cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
@@ -146,7 +146,7 @@ jobs:
           tag: 6.2.3-RELEASE
       - name: Build
         run: |
-          swift build --enable-test-discovery
+          set -o pipefail && env NSUnbufferedIO=YES swift test --enable-test-discovery
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
 
   xcode-test-oldest:
     timeout-minutes: 25
-    needs: linux
+    needs: spm-test
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v6
@@ -174,7 +174,7 @@ jobs:
   
   docs:
     timeout-minutes: 10
-    needs: linux
+    needs: spm-test
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
@@ -184,7 +184,7 @@ jobs:
           DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
 
   cocoapods:
-    needs: linux
+    needs: spm-test
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,15 +124,15 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Test
         run: set -o pipefail && env NSUnbufferedIO=YES swift test --enable-test-discovery --enable-code-coverage
-      #- name: Prepare codecov
-      #  run: |
-      #    cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
-      #    llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/debug/ParseSwiftPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata > info_linux.lcov
+      - name: Prepare codecov
+        run: |
+          cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
+          llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/debug/ParseSwiftPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata > info_linux.lcov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           env_vars: LINUX
-          fail_ci_if_error: false
+          fail_ci_if_error: test
           token: ${{ secrets.CODECOV_TOKEN }}
 
   windows:
@@ -144,14 +144,14 @@ jobs:
         with:
           branch: swift-6.2.3-release
           tag: 6.2.3-RELEASE
-      - name: Build
+      - name: Build and Test
         run: |
-          set -o pipefail && env NSUnbufferedIO=YES swift test --enable-test-discovery
+          swift test --enable-test-discovery --enable-code-coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
           env_vars: WINDOWSLATEST
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
   
   docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
           toolchain: 6.2.3
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and Test
-        run: set -o pipefail && env NSUnbufferedIO=YES swift test -v --enable-test-discovery --enable-code-coverage
+        run: set -o pipefail && env NSUnbufferedIO=YES swift test --enable-test-discovery --enable-code-coverage
       - name: Prepare codecov
         run: |
           cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
@@ -164,7 +164,7 @@ jobs:
           tag: 6.2.3-RELEASE
       - name: Build and Test
         run: |
-          swift test -v --enable-test-discovery --enable-code-coverage
+          swift test --enable-test-discovery --enable-code-coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,24 @@ jobs:
       run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace Parse.xcworkspace -scheme ParseSwift -destination platform\=iOS\ Simulator,name\=iPhone\ 16\ Pro\ Max -derivedDataPath DerivedData test 2>&1 | xcbeautify --renderer github-actions
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE_OLDEST }}
+    - name: Prepare codecov
+      uses: sersoft-gmbh/swift-coverage-action@v5
+      id: coverage-files
+      with:
+        format: lcov
+        search-paths: ./.build
+        ignore-conversion-failures: true
+      env:
+          DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        files: ${{join(fromJSON(steps.coverage-files.outputs.files), ',')}}
+        env_vars: XCODEOLDEST
+        fail_ci_if_error: false
+        token: ${{ secrets.CODECOV_TOKEN }}
+      env:
+          DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
 
   linux:
     timeout-minutes: 10
@@ -132,7 +150,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           env_vars: LINUX
-          fail_ci_if_error: test
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
   windows:
@@ -151,7 +169,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           env_vars: WINDOWSLATEST
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
   
   docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,8 +140,8 @@ jobs:
         with:
           toolchain: 6.2.3
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build
-        run: set -o pipefail && env NSUnbufferedIO=YES swift test --enable-test-discovery --enable-code-coverage
+      - name: Build and Test
+        run: set -o pipefail && env NSUnbufferedIO=YES swift test -v --enable-test-discovery --enable-code-coverage
       - name: Prepare codecov
         run: |
           cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
@@ -162,9 +162,9 @@ jobs:
         with:
           branch: swift-6.2.3-release
           tag: 6.2.3-RELEASE
-      - name: Build
+      - name: Build and Test
         run: |
-          swift test --enable-test-discovery --enable-code-coverage
+          swift test -v --enable-test-discovery --enable-code-coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}
       env:
-          DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
+          DEVELOPER_DIR: ${{ env.CI_XCODE_OLDEST }}
 
   linux:
     timeout-minutes: 10
@@ -141,11 +141,11 @@ jobs:
           toolchain: 6.2.3
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
-        run: set -o pipefail && env NSUnbufferedIO=YES swift build --enable-test-discovery --enable-code-coverage
-      #- name: Prepare codecov
-      #  run: |
-      #    cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
-      #    llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/debug/ParseSwiftPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata > info_linux.lcov
+        run: set -o pipefail && env NSUnbufferedIO=YES swift test --enable-test-discovery --enable-code-coverage
+      - name: Prepare codecov
+        run: |
+          cat .codecov.yml | curl --data-binary @- https://codecov.io/validate
+          llvm-cov export -format="lcov" .build/x86_64-unknown-linux-gnu/debug/ParseSwiftPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata > info_linux.lcov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
@@ -164,7 +164,7 @@ jobs:
           tag: 6.2.3-RELEASE
       - name: Build
         run: |
-          swift build --enable-test-discovery --enable-code-coverage
+          swift test --enable-test-discovery --enable-code-coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
 
   xcode-test-oldest:
     timeout-minutes: 25
-    needs: spm-test
+    needs: linux
     runs-on: macos-14
     steps:
     - uses: actions/checkout@v6
@@ -174,7 +174,7 @@ jobs:
   
   docs:
     timeout-minutes: 10
-    needs: spm-test
+    needs: linux
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v6
@@ -184,7 +184,7 @@ jobs:
           DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
 
   cocoapods:
-    needs: spm-test
+    needs: linux
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v6

--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,19 @@ import PackageDescription
 let sharedSwiftSettings: [SwiftSetting] = [
 	.enableUpcomingFeature("MemberImportVisibility"),
 	.enableUpcomingFeature("InferIsolatedConformances"),
-	.enableUpcomingFeature("ImmutableWeakCaptures")
+	.enableUpcomingFeature("ImmutableWeakCaptures"),
+	.enableExperimentalFeature("StrictConcurrency=minimal")
 ]
+
+var testSwiftSettings: [SwiftSetting] {
+	#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
+	return sharedSwiftSettings
+	#else
+	// Linux, windows, etc. is too strict in the test suite.
+	return sharedSwiftSettings + [.enableExperimentalFeature("StrictConcurrency=minimal")]
+	#endif
+}
+
 
 let package = Package(
     name: "ParseSwift",
@@ -33,7 +44,7 @@ let package = Package(
             name: "ParseSwiftTests",
             dependencies: ["ParseSwift"],
             exclude: ["Info.plist"],
-			swiftSettings: sharedSwiftSettings
+			swiftSettings: testSwiftSettings
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,8 @@ let package = Package(
         .testTarget(
             name: "ParseSwiftTests",
             dependencies: ["ParseSwift"],
-            exclude: ["Info.plist"]
+            exclude: ["Info.plist"],
+			swiftSettings: sharedSwiftSettings
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,7 @@ import PackageDescription
 let sharedSwiftSettings: [SwiftSetting] = [
 	.enableUpcomingFeature("MemberImportVisibility"),
 	.enableUpcomingFeature("InferIsolatedConformances"),
-	.enableUpcomingFeature("ImmutableWeakCaptures"),
-	.enableExperimentalFeature("StrictConcurrency=minimal")
+	.enableUpcomingFeature("ImmutableWeakCaptures")
 ]
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -9,16 +9,6 @@ let sharedSwiftSettings: [SwiftSetting] = [
 	.enableExperimentalFeature("StrictConcurrency=minimal")
 ]
 
-var testSwiftSettings: [SwiftSetting] {
-	#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
-	return sharedSwiftSettings
-	#else
-	// Linux, windows, etc. is too strict in the test suite.
-	return sharedSwiftSettings + [.enableExperimentalFeature("StrictConcurrency=minimal")]
-	#endif
-}
-
-
 let package = Package(
     name: "ParseSwift",
     platforms: [
@@ -44,7 +34,7 @@ let package = Package(
             name: "ParseSwiftTests",
             dependencies: ["ParseSwift"],
             exclude: ["Info.plist"],
-			swiftSettings: testSwiftSettings
+			swiftSettings: sharedSwiftSettings
         )
     ]
 )

--- a/Sources/ParseSwift/Extensions/URLSession.swift
+++ b/Sources/ParseSwift/Extensions/URLSession.swift
@@ -12,7 +12,7 @@ import Foundation
 import FoundationNetworking
 #endif
 
-internal extension URLSession {
+extension URLSession {
 	static var parse: URLSession {
 		get {
 			lock.lock()

--- a/Sources/ParseSwift/Extensions/URLSession.swift
+++ b/Sources/ParseSwift/Extensions/URLSession.swift
@@ -24,6 +24,7 @@ internal extension URLSession {
 			defer { lock.unlock() }
 			_parse = newValue
 		}
+
 	}
 	nonisolated(unsafe) static var _parse: URLSession!
 	static let lock = NSLock()

--- a/Sources/ParseSwift/Extensions/URLSession.swift
+++ b/Sources/ParseSwift/Extensions/URLSession.swift
@@ -12,7 +12,7 @@ import Foundation
 import FoundationNetworking
 #endif
 
-extension URLSession {
+internal extension URLSession {
 	static var parse: URLSession {
 		get {
 			lock.lock()

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -151,7 +151,7 @@ public func initialize(configuration: ParseConfiguration) async throws { // swif
     Parse.configuration = configuration
     ParseStorage.shared.use(configuration.primitiveStore)
     Parse.sessionDelegate = ParseURLSessionDelegate(
-		callbackQueue: .global(qos: .default),
+		callbackQueue: .main,
 		authentication: configuration.authentication
 	)
     Utility.updateParseURLSession()
@@ -363,7 +363,7 @@ public func updateAuthentication(
 				  ) -> Void)?
 ) {
 	Parse.sessionDelegate = ParseURLSessionDelegate(
-		callbackQueue: .global(qos: .default),
+		callbackQueue: .main,
 		authentication: authentication
 	)
     Utility.updateParseURLSession()

--- a/Sources/ParseSwift/Parse.swift
+++ b/Sources/ParseSwift/Parse.swift
@@ -150,8 +150,10 @@ public var configuration: ParseConfiguration {
 public func initialize(configuration: ParseConfiguration) async throws { // swiftlint:disable:this cyclomatic_complexity function_body_length
     Parse.configuration = configuration
     ParseStorage.shared.use(configuration.primitiveStore)
-    Parse.sessionDelegate = ParseURLSessionDelegate(callbackQueue: .main,
-                                                    authentication: configuration.authentication)
+    Parse.sessionDelegate = ParseURLSessionDelegate(
+		callbackQueue: .global(qos: .default),
+		authentication: configuration.authentication
+	)
     Utility.updateParseURLSession()
 
     #if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
@@ -354,11 +356,16 @@ public func initialize(
  completionHandler: (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void`.
  See Apple's [documentation](https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411595-urlsession) for more for details.
  */
-public func updateAuthentication(_ authentication: (@Sendable (URLAuthenticationChallenge,
-                                                     (URLSession.AuthChallengeDisposition,
-                                                      URLCredential?) -> Void) -> Void)?) {
-    Parse.sessionDelegate = ParseURLSessionDelegate(callbackQueue: .main,
-                                                    authentication: authentication)
+public func updateAuthentication(
+	_ authentication: (
+		@Sendable (URLAuthenticationChallenge,
+				   (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+				  ) -> Void)?
+) {
+	Parse.sessionDelegate = ParseURLSessionDelegate(
+		callbackQueue: .global(qos: .default),
+		authentication: authentication
+	)
     Utility.updateParseURLSession()
 }
 

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "6.0.0-beta.6"
+    static let version = "6.0.0-beta.7"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
@@ -28,6 +28,17 @@ public protocol ParseHookTriggerable: ParseHookable {
 // MARK: Default Implementation
 public extension ParseHookTriggerable {
 
+	/**
+	 Creates a new Parse hook trigger.
+	 - parameter trigger: The `ParseHookTriggerType` type.
+	 - parameter url: The endpoint of the hook.
+	 */
+	init(trigger: ParseHookTriggerType, url: URL) {
+		self.init()
+		self.trigger = trigger
+		self.url = url
+	}
+
     /**
      Creates a new Parse hook trigger.
      - parameter className: The name of the `ParseObject` the trigger should act on.

--- a/Sources/ParseSwift/Utility.swift
+++ b/Sources/ParseSwift/Utility.swift
@@ -30,7 +30,15 @@ struct Utility {
             URLSession.parse = session
         }
 		#else
-		URLSession.parse = URLSession.shared
+		let configuration = URLSessionConfiguration.default
+		configuration.urlCache = URLCache.parse
+		configuration.requestCachePolicy = Parse.configuration.requestCachePolicy
+		configuration.httpAdditionalHeaders = Parse.configuration.httpAdditionalHeaders
+		URLSession.parse = URLSession(
+			configuration: configuration,
+			delegate: Parse.sessionDelegate,
+			delegateQueue: nil
+		)
 		#endif
     }
 

--- a/Sources/ParseSwift/Utility.swift
+++ b/Sources/ParseSwift/Utility.swift
@@ -7,39 +7,30 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 struct Utility {
 
     static func updateParseURLSession() {
-        #if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
-        if !Parse.configuration.isTestingSDK {
-            let configuration = URLSessionConfiguration.default
-            configuration.urlCache = URLCache.parse
-            configuration.requestCachePolicy = Parse.configuration.requestCachePolicy
-            configuration.httpAdditionalHeaders = Parse.configuration.httpAdditionalHeaders
-            URLSession.parse = URLSession(
+		if !Parse.configuration.isTestingSDK {
+			let configuration = URLSessionConfiguration.default
+			configuration.urlCache = URLCache.parse
+			configuration.requestCachePolicy = Parse.configuration.requestCachePolicy
+			configuration.httpAdditionalHeaders = Parse.configuration.httpAdditionalHeaders
+			URLSession.parse = URLSession(
 				configuration: configuration,
 				delegate: Parse.sessionDelegate,
 				delegateQueue: nil
 			)
-        } else {
-            let session = URLSession.shared
-            session.configuration.urlCache = URLCache.parse
-            session.configuration.requestCachePolicy = Parse.configuration.requestCachePolicy
-            session.configuration.httpAdditionalHeaders = Parse.configuration.httpAdditionalHeaders
-            URLSession.parse = session
-        }
-		#else
-		let configuration = URLSessionConfiguration.default
-		configuration.urlCache = URLCache.parse
-		configuration.requestCachePolicy = Parse.configuration.requestCachePolicy
-		configuration.httpAdditionalHeaders = Parse.configuration.httpAdditionalHeaders
-		URLSession.parse = URLSession(
-			configuration: configuration,
-			delegate: Parse.sessionDelegate,
-			delegateQueue: nil
-		)
-		#endif
+		} else {
+			let session = URLSession.shared
+			session.configuration.urlCache = URLCache.parse
+			session.configuration.requestCachePolicy = Parse.configuration.requestCachePolicy
+			session.configuration.httpAdditionalHeaders = Parse.configuration.httpAdditionalHeaders
+			URLSession.parse = session
+		}
     }
 
     static func reconnectInterval(_ maxExponent: Int) -> Int {

--- a/Sources/ParseSwift/Utility.swift
+++ b/Sources/ParseSwift/Utility.swift
@@ -11,15 +11,17 @@ import Foundation
 struct Utility {
 
     static func updateParseURLSession() {
-        #if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
+        // #if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
         if !Parse.configuration.isTestingSDK {
             let configuration = URLSessionConfiguration.default
             configuration.urlCache = URLCache.parse
             configuration.requestCachePolicy = Parse.configuration.requestCachePolicy
             configuration.httpAdditionalHeaders = Parse.configuration.httpAdditionalHeaders
-            URLSession.parse = URLSession(configuration: configuration,
-                                          delegate: Parse.sessionDelegate,
-                                          delegateQueue: nil)
+            URLSession.parse = URLSession(
+				configuration: configuration,
+				delegate: Parse.sessionDelegate,
+				delegateQueue: nil
+			)
         } else {
             let session = URLSession.shared
             session.configuration.urlCache = URLCache.parse
@@ -27,8 +29,7 @@ struct Utility {
             session.configuration.httpAdditionalHeaders = Parse.configuration.httpAdditionalHeaders
             URLSession.parse = session
         }
-        #endif
-
+       // #endif
     }
 
     static func reconnectInterval(_ maxExponent: Int) -> Int {

--- a/Sources/ParseSwift/Utility.swift
+++ b/Sources/ParseSwift/Utility.swift
@@ -14,7 +14,7 @@ import FoundationNetworking
 struct Utility {
 
     static func updateParseURLSession() {
-        #if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
+        // #if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
         if !Parse.configuration.isTestingSDK {
             let configuration = URLSessionConfiguration.default
             configuration.urlCache = URLCache.parse
@@ -31,7 +31,7 @@ struct Utility {
             session.configuration.requestCachePolicy = Parse.configuration.requestCachePolicy
             session.configuration.httpAdditionalHeaders = Parse.configuration.httpAdditionalHeaders
             URLSession.parse = session
-        }
+        } /*
 		#else
 		let configuration = URLSessionConfiguration.default
 		configuration.urlCache = URLCache.parse
@@ -42,7 +42,7 @@ struct Utility {
 			delegate: Parse.sessionDelegate,
 			delegateQueue: nil
 		)
-		#endif
+		#endif */
     }
 
     static func reconnectInterval(_ maxExponent: Int) -> Int {

--- a/Sources/ParseSwift/Utility.swift
+++ b/Sources/ParseSwift/Utility.swift
@@ -14,7 +14,6 @@ import FoundationNetworking
 struct Utility {
 
     static func updateParseURLSession() {
-        #if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
         if !Parse.configuration.isTestingSDK {
             let configuration = URLSessionConfiguration.default
             configuration.urlCache = URLCache.parse
@@ -26,27 +25,16 @@ struct Utility {
 				delegateQueue: nil
 			)
         } else {
+			#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
             let session = URLSession.shared
             session.configuration.urlCache = URLCache.parse
             session.configuration.requestCachePolicy = Parse.configuration.requestCachePolicy
             session.configuration.httpAdditionalHeaders = Parse.configuration.httpAdditionalHeaders
             URLSession.parse = session
-        }
-		#else
-		if !Parse.configuration.isTestingSDK {
-			let configuration = URLSessionConfiguration.default
-			configuration.urlCache = URLCache.parse
-			configuration.requestCachePolicy = Parse.configuration.requestCachePolicy
-			configuration.httpAdditionalHeaders = Parse.configuration.httpAdditionalHeaders
-			URLSession.parse = URLSession(
-				configuration: configuration,
-				delegate: Parse.sessionDelegate,
-				delegateQueue: nil
-			)
-		} else {
+			#else
 			URLSession.parse = URLSession.shared
-		}
-		#endif
+			#endif
+        }
     }
 
     static func reconnectInterval(_ maxExponent: Int) -> Int {

--- a/Sources/ParseSwift/Utility.swift
+++ b/Sources/ParseSwift/Utility.swift
@@ -14,23 +14,35 @@ import FoundationNetworking
 struct Utility {
 
     static func updateParseURLSession() {
-		if !Parse.configuration.isTestingSDK {
-			let configuration = URLSessionConfiguration.default
-			configuration.urlCache = URLCache.parse
-			configuration.requestCachePolicy = Parse.configuration.requestCachePolicy
-			configuration.httpAdditionalHeaders = Parse.configuration.httpAdditionalHeaders
-			URLSession.parse = URLSession(
+        #if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
+        if !Parse.configuration.isTestingSDK {
+            let configuration = URLSessionConfiguration.default
+            configuration.urlCache = URLCache.parse
+            configuration.requestCachePolicy = Parse.configuration.requestCachePolicy
+            configuration.httpAdditionalHeaders = Parse.configuration.httpAdditionalHeaders
+            URLSession.parse = URLSession(
 				configuration: configuration,
 				delegate: Parse.sessionDelegate,
 				delegateQueue: nil
 			)
-		} else {
-			let session = URLSession.shared
-			session.configuration.urlCache = URLCache.parse
-			session.configuration.requestCachePolicy = Parse.configuration.requestCachePolicy
-			session.configuration.httpAdditionalHeaders = Parse.configuration.httpAdditionalHeaders
-			URLSession.parse = session
-		}
+        } else {
+            let session = URLSession.shared
+            session.configuration.urlCache = URLCache.parse
+            session.configuration.requestCachePolicy = Parse.configuration.requestCachePolicy
+            session.configuration.httpAdditionalHeaders = Parse.configuration.httpAdditionalHeaders
+            URLSession.parse = session
+        }
+		#else
+		let configuration = URLSessionConfiguration.default
+		configuration.urlCache = URLCache.parse
+		configuration.requestCachePolicy = Parse.configuration.requestCachePolicy
+		configuration.httpAdditionalHeaders = Parse.configuration.httpAdditionalHeaders
+		URLSession.parse = URLSession(
+			configuration: configuration,
+			delegate: Parse.sessionDelegate,
+			delegateQueue: nil
+		)
+		#endif
     }
 
     static func reconnectInterval(_ maxExponent: Int) -> Int {

--- a/Sources/ParseSwift/Utility.swift
+++ b/Sources/ParseSwift/Utility.swift
@@ -11,7 +11,7 @@ import Foundation
 struct Utility {
 
     static func updateParseURLSession() {
-        // #if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
+        #if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
         if !Parse.configuration.isTestingSDK {
             let configuration = URLSessionConfiguration.default
             configuration.urlCache = URLCache.parse
@@ -29,7 +29,9 @@ struct Utility {
             session.configuration.httpAdditionalHeaders = Parse.configuration.httpAdditionalHeaders
             URLSession.parse = session
         }
-       // #endif
+		#else
+		URLSession.parse = URLSession.shared
+		#endif
     }
 
     static func reconnectInterval(_ maxExponent: Int) -> Int {

--- a/Sources/ParseSwift/Utility.swift
+++ b/Sources/ParseSwift/Utility.swift
@@ -14,7 +14,7 @@ import FoundationNetworking
 struct Utility {
 
     static func updateParseURLSession() {
-        // #if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
+        #if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
         if !Parse.configuration.isTestingSDK {
             let configuration = URLSessionConfiguration.default
             configuration.urlCache = URLCache.parse
@@ -31,18 +31,22 @@ struct Utility {
             session.configuration.requestCachePolicy = Parse.configuration.requestCachePolicy
             session.configuration.httpAdditionalHeaders = Parse.configuration.httpAdditionalHeaders
             URLSession.parse = session
-        } /*
+        }
 		#else
-		let configuration = URLSessionConfiguration.default
-		configuration.urlCache = URLCache.parse
-		configuration.requestCachePolicy = Parse.configuration.requestCachePolicy
-		configuration.httpAdditionalHeaders = Parse.configuration.httpAdditionalHeaders
-		URLSession.parse = URLSession(
-			configuration: configuration,
-			delegate: Parse.sessionDelegate,
-			delegateQueue: nil
-		)
-		#endif */
+		if !Parse.configuration.isTestingSDK {
+			let configuration = URLSessionConfiguration.default
+			configuration.urlCache = URLCache.parse
+			configuration.requestCachePolicy = Parse.configuration.requestCachePolicy
+			configuration.httpAdditionalHeaders = Parse.configuration.httpAdditionalHeaders
+			URLSession.parse = URLSession(
+				configuration: configuration,
+				delegate: Parse.sessionDelegate,
+				delegateQueue: nil
+			)
+		} else {
+			URLSession.parse = URLSession.shared
+		}
+		#endif
     }
 
     static func reconnectInterval(_ maxExponent: Int) -> Int {

--- a/Tests/ParseSwiftTests/APICommandMultipleAttemptsTests.swift
+++ b/Tests/ParseSwiftTests/APICommandMultipleAttemptsTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2023 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -446,3 +450,4 @@ class APICommandMultipleAttemptsTests: XCTestCase, @unchecked Sendable {
         await fulfillment(of: [expectation1], timeout: 20.0)
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/APICommandTests.swift
+++ b/Tests/ParseSwiftTests/APICommandTests.swift
@@ -7,6 +7,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import XCTest
 @testable import ParseSwift
 

--- a/Tests/ParseSwiftTests/APICommandTests.swift
+++ b/Tests/ParseSwiftTests/APICommandTests.swift
@@ -205,6 +205,10 @@ class APICommandTests: XCTestCase, @unchecked Sendable {
         XCTAssertFalse(options.contains(.serverURL(secondServerURLString)))
     }
 
+	// Currently can't takeover URLSession with MockURLProtocol
+	// on Linux, Windows, etc. so disabling networking tests on
+	// those platforms.
+	#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
     func testExecuteCorrectly() async {
         let originalObject = "test"
         MockURLProtocol.mockRequests { _ in
@@ -227,37 +231,6 @@ class APICommandTests: XCTestCase, @unchecked Sendable {
 
         } catch {
             XCTFail(error.localizedDescription)
-        }
-    }
-
-    // This is how errors from the server should typically come in
-    func testErrorFromParseServer() async {
-        let originalError = ParseError(code: .otherCause, message: "Could not decode")
-        MockURLProtocol.mockRequests { _ in
-            do {
-                let encoded = try JSONEncoder().encode(originalError)
-                return MockURLResponse(data: encoded, statusCode: 200)
-            } catch {
-                XCTFail("Should encode error")
-                return nil
-            }
-        }
-
-        do {
-            _ = try await API.NonParseBodyCommand<NoBody, NoBody>(method: .GET,
-                                                                  path: .login,
-                                                                  params: nil,
-                                                                  mapper: { _ -> NoBody in
-                throw originalError
-            }).execute(options: [],
-                       callbackQueue: .main)
-            XCTFail("Should have thrown an error")
-        } catch {
-            guard let error = error as? ParseError else {
-                XCTFail("Should be able unwrap final error to ParseError")
-                return
-            }
-            XCTAssertEqual(originalError.code, error.code)
         }
     }
 
@@ -298,29 +271,6 @@ class APICommandTests: XCTestCase, @unchecked Sendable {
         }
     }
 
-    func testErrorHTTPReturns400NoDataFromServer() async {
-        let originalError = ParseError(code: .otherCause, message: "Could not decode")
-        MockURLProtocol.mockRequests { _ in
-            return MockURLResponse(error: originalError) // Status code defaults to 400
-        }
-        do {
-            _ = try await API.NonParseBodyCommand<NoBody, NoBody>(method: .GET,
-                                                                  path: .login,
-                                                                  params: nil,
-                                                                  mapper: { _ -> NoBody in
-                throw originalError
-            }).execute(options: [],
-                       callbackQueue: .main)
-            XCTFail("Should have thrown an error")
-        } catch {
-            guard let error = error as? ParseError else {
-                XCTFail("Should be able unwrap final error to ParseError")
-                return
-            }
-            XCTAssertEqual(originalError.code, error.code)
-        }
-    }
-
     // This is how errors HTTP errors should typically come in
     func testErrorHTTP500JSON() async throws {
         let parseError = ParseError(code: .connectionFailed, message: "Connection failed")
@@ -356,6 +306,61 @@ class APICommandTests: XCTestCase, @unchecked Sendable {
             XCTAssertEqual(error.code, parseError.code)
         }
     }
+	#endif
+
+	// This is how errors from the server should typically come in
+	func testErrorFromParseServer() async {
+		let originalError = ParseError(code: .otherCause, message: "Could not decode")
+		MockURLProtocol.mockRequests { _ in
+			do {
+				let encoded = try JSONEncoder().encode(originalError)
+				return MockURLResponse(data: encoded, statusCode: 200)
+			} catch {
+				XCTFail("Should encode error")
+				return nil
+			}
+		}
+
+		do {
+			_ = try await API.NonParseBodyCommand<NoBody, NoBody>(method: .GET,
+																  path: .login,
+																  params: nil,
+																  mapper: { _ -> NoBody in
+				throw originalError
+			}).execute(options: [],
+					   callbackQueue: .main)
+			XCTFail("Should have thrown an error")
+		} catch {
+			guard let error = error as? ParseError else {
+				XCTFail("Should be able unwrap final error to ParseError")
+				return
+			}
+			XCTAssertEqual(originalError.code, error.code)
+		}
+	}
+
+	func testErrorHTTPReturns400NoDataFromServer() async {
+		let originalError = ParseError(code: .otherCause, message: "Could not decode")
+		MockURLProtocol.mockRequests { _ in
+			return MockURLResponse(error: originalError) // Status code defaults to 400
+		}
+		do {
+			_ = try await API.NonParseBodyCommand<NoBody, NoBody>(method: .GET,
+																  path: .login,
+																  params: nil,
+																  mapper: { _ -> NoBody in
+				throw originalError
+			}).execute(options: [],
+					   callbackQueue: .main)
+			XCTFail("Should have thrown an error")
+		} catch {
+			guard let error = error as? ParseError else {
+				XCTFail("Should be able unwrap final error to ParseError")
+				return
+			}
+			XCTAssertEqual(originalError.code, error.code)
+		}
+	}
 
     func testErrorHTTPReturns500NoDataFromServer() async {
         let originalError = ParseError(code: .otherCause, message: "Could not decode")
@@ -532,6 +537,10 @@ class APICommandTests: XCTestCase, @unchecked Sendable {
         }
     }
 
+	// Currently can't takeover URLSession with MockURLProtocol
+	// on Linux, Windows, etc. so disabling networking tests on
+	// those platforms.
+	#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
     func testSessionTokenHeader() async throws {
         try await userLogin()
         guard let sessionToken = await BaseParseUser.currentContainer()?.sessionToken else {
@@ -555,6 +564,7 @@ class APICommandTests: XCTestCase, @unchecked Sendable {
             XCTFail(error.localizedDescription)
         }
     }
+	#endif
 
     func testReplaceSessionTokenHeader() async throws {
 

--- a/Tests/ParseSwiftTests/InitializeSDKTests.swift
+++ b/Tests/ParseSwiftTests/InitializeSDKTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import XCTest
 @testable import ParseSwift
 

--- a/Tests/ParseSwiftTests/ParseACLTests.swift
+++ b/Tests/ParseSwiftTests/ParseACLTests.swift
@@ -277,6 +277,10 @@ class ParseACLTests: XCTestCase, @unchecked Sendable {
         }
     }
 
+	// Currently can't takeover URLSession with MockURLProtocol
+	// on Linux, Windows, etc. so disabling networking tests on
+	// those platforms.
+	#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
     func testDefaultACL() async throws {
         let loginResponse = LoginSignupResponse()
         let loginUserName = "hello10"
@@ -352,4 +356,5 @@ class ParseACLTests: XCTestCase, @unchecked Sendable {
             XCTFail("Should have set new ACL. Error \(error.localizedDescription)")
         }
     }
+	#endif
 }

--- a/Tests/ParseSwiftTests/ParseAnalyticsAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnalyticsAsyncTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -222,3 +226,4 @@ class ParseAnalyticsAsyncTests: XCTestCase, @unchecked Sendable {
         }
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseAnalyticsAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnalyticsAsyncTests.swift
@@ -107,6 +107,7 @@ class ParseAnalyticsAsyncTests: XCTestCase, @unchecked Sendable {
         }
     }
 
+	#if !os(Windows) && !os(WASI)
     @MainActor
     func testTrackAppOpenedError() async throws {
         let serverResponse = ParseError(code: .internalServer, message: "none")
@@ -134,6 +135,7 @@ class ParseAnalyticsAsyncTests: XCTestCase, @unchecked Sendable {
             XCTAssertEqual(error.message, serverResponse.message)
         }
     }
+	#endif
 
     @MainActor
     func testTrackEvent() async throws {

--- a/Tests/ParseSwiftTests/ParseAnalyticsTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnalyticsTests.swift
@@ -216,6 +216,7 @@ class ParseAnalyticsTests: XCTestCase, @unchecked Sendable {
     }
     #endif
 
+	#if !os(Android) && !os(Windows) && !os(WASI)
     func testTrackAppOpenedError() {
         let serverResponse = ParseError(code: .missingObjectId, message: "Object missing objectId")
         let encoded: Data!
@@ -240,6 +241,7 @@ class ParseAnalyticsTests: XCTestCase, @unchecked Sendable {
         }
         wait(for: [expectation], timeout: 10.0)
     }
+	#endif
 
 	// Currently can't takeover URLSession with MockURLProtocol
 	// on Linux, Windows, etc. so disabling networking tests on
@@ -323,6 +325,7 @@ class ParseAnalyticsTests: XCTestCase, @unchecked Sendable {
     }
 	#endif
 
+	#if !os(Android) && !os(Windows) && !os(WASI)
     func testTrackEventError() {
         let serverResponse = ParseError(code: .missingObjectId, message: "Object missing objectId")
         let encoded: Data!
@@ -374,4 +377,5 @@ class ParseAnalyticsTests: XCTestCase, @unchecked Sendable {
         }
         wait(for: [expectation], timeout: 10.0)
     }
+	#endif
 }

--- a/Tests/ParseSwiftTests/ParseAnalyticsTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnalyticsTests.swift
@@ -216,31 +216,6 @@ class ParseAnalyticsTests: XCTestCase, @unchecked Sendable {
     }
     #endif
 
-    func testTrackAppOpened() {
-        let serverResponse = NoBody()
-        let encoded: Data!
-        do {
-            encoded = try ParseCoding.jsonEncoder().encode(serverResponse)
-        } catch {
-            XCTFail("Should encode/decode. Error \(error)")
-            return
-        }
-
-        MockURLProtocol.mockRequests { _ in
-            return MockURLResponse(data: encoded, statusCode: 200)
-        }
-
-        let expectation = XCTestExpectation(description: "Analytics save")
-        ParseAnalytics.trackAppOpened(dimensions: ["stop": "drop"]) { result in
-
-            if case .failure(let error) = result {
-                XCTFail(error.localizedDescription)
-            }
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 10.0)
-    }
-
     func testTrackAppOpenedError() {
         let serverResponse = ParseError(code: .missingObjectId, message: "Object missing objectId")
         let encoded: Data!
@@ -265,6 +240,35 @@ class ParseAnalyticsTests: XCTestCase, @unchecked Sendable {
         }
         wait(for: [expectation], timeout: 10.0)
     }
+
+	// Currently can't takeover URLSession with MockURLProtocol
+	// on Linux, Windows, etc. so disabling networking tests on
+	// those platforms.
+	#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
+	func testTrackAppOpened() {
+		let serverResponse = NoBody()
+		let encoded: Data!
+		do {
+			encoded = try ParseCoding.jsonEncoder().encode(serverResponse)
+		} catch {
+			XCTFail("Should encode/decode. Error \(error)")
+			return
+		}
+
+		MockURLProtocol.mockRequests { _ in
+			return MockURLResponse(data: encoded, statusCode: 200)
+		}
+
+		let expectation = XCTestExpectation(description: "Analytics save")
+		ParseAnalytics.trackAppOpened(dimensions: ["stop": "drop"]) { result in
+
+			if case .failure(let error) = result {
+				XCTFail(error.localizedDescription)
+			}
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 10.0)
+	}
 
     func testTrackEvent() {
         let serverResponse = NoBody()
@@ -317,6 +321,7 @@ class ParseAnalyticsTests: XCTestCase, @unchecked Sendable {
         }
         wait(for: [expectation], timeout: 10.0)
     }
+	#endif
 
     func testTrackEventError() {
         let serverResponse = ParseError(code: .missingObjectId, message: "Object missing objectId")

--- a/Tests/ParseSwiftTests/ParseAnonymousAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousAsyncTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -177,3 +181,4 @@ class ParseAnonymousAsyncTests: XCTestCase, @unchecked Sendable {
         }
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseAnonymousTests.swift
+++ b/Tests/ParseSwiftTests/ParseAnonymousTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 import XCTest
 @testable import ParseSwift
@@ -581,3 +585,4 @@ class ParseAnonymousTests: XCTestCase, @unchecked Sendable {
     }
     #endif
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseAppleTests.swift
+++ b/Tests/ParseSwiftTests/ParseAppleTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -540,3 +544,4 @@ class ParseAppleTests: XCTestCase, @unchecked Sendable {
     }
 
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseAuthenticationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationAsyncTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -220,3 +224,4 @@ class ParseAuthenticationAsyncTests: XCTestCase, @unchecked Sendable {
     }
 
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
+++ b/Tests/ParseSwiftTests/ParseAuthenticationTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -219,3 +223,4 @@ class ParseAuthenticationTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(strippedAuth.authData, ["test": nil])
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseCloudableAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudableAsyncTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -75,3 +79,4 @@ class ParseCloudableAsyncTests: XCTestCase, @unchecked Sendable {
         XCTAssertNil(functionResponse)
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseCloudableTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudableTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2020 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 import XCTest
 @testable import ParseSwift
@@ -430,3 +434,4 @@ class ParseCloudableTests: XCTestCase, @unchecked Sendable { // swiftlint:disabl
         self.jobAsyncError(parseError: parseError, callbackQueue: .main)
     }
 } // swiftlint:disable:this file_length
+#endif

--- a/Tests/ParseSwiftTests/ParseConfigAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigAsyncTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -183,3 +187,4 @@ class ParseConfigAsyncTests: XCTestCase, @unchecked Sendable {
         #endif
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseConfigCodableTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigCodableTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2023 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 import XCTest
 @testable import ParseSwift
@@ -314,3 +318,4 @@ class ParseConfigCodableTests: XCTestCase, @unchecked Sendable { // swiftlint:di
         #endif
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseConfigTests.swift
+++ b/Tests/ParseSwiftTests/ParseConfigTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 import XCTest
 @testable import ParseSwift
@@ -331,3 +335,4 @@ class ParseConfigTests: XCTestCase, @unchecked Sendable { // swiftlint:disable:t
     }
     #endif
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseEncoderTests/TestParseEncoder.swift
+++ b/Tests/ParseSwiftTests/ParseEncoderTests/TestParseEncoder.swift
@@ -198,6 +198,7 @@ class TestParseEncoder: XCTestCase, @unchecked Sendable {
     }
   }*/
 
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
   // MARK: - Output Formatting Tests
   func testEncodingOutputFormattingDefault() {
     let expectedJSON = "{\"name\":\"Johnny Appleseed\",\"email\":\"appleseed@apple.com\"}".data(using: .utf8)!
@@ -228,7 +229,7 @@ class TestParseEncoder: XCTestCase, @unchecked Sendable {
   }*/
 
   // MARK: - Date Strategy Tests
-    #if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
+
   // Disabled for now till we resolve rdar://52618414
   func x_testEncodingDate() throws {
 

--- a/Tests/ParseSwiftTests/ParseFacebookTests.swift
+++ b/Tests/ParseSwiftTests/ParseFacebookTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -841,3 +845,4 @@ class ParseFacebookTests: XCTestCase, @unchecked Sendable { // swiftlint:disable
         }
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseFileAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileAsyncTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -524,3 +528,4 @@ class ParseFileAsyncTests: XCTestCase, @unchecked Sendable { // swiftlint:disabl
         await fulfillment(of: [expectation1, expectation2], timeout: 20.0)
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseFileTests.swift
+++ b/Tests/ParseSwiftTests/ParseFileTests.swift
@@ -229,6 +229,10 @@ class ParseFileTests: XCTestCase, @unchecked Sendable { // swiftlint:disable:thi
                        "{\"__type\":\"File\",\"name\":\"myFolder\\/sampleData.txt\"}")
     }
 
+	// Currently can't takeover URLSession with MockURLProtocol
+	// on Linux, Windows, etc. so disabling networking tests on
+	// those platforms.
+	#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
     func testSave() async throws {
         guard let sampleData = "Hello World".data(using: .utf8) else {
             throw ParseError(code: .otherCause, message: "Should have converted to data")
@@ -297,7 +301,6 @@ class ParseFileTests: XCTestCase, @unchecked Sendable { // swiftlint:disable:thi
         XCTAssertEqual(savedFile.localURL, tempFilePath)
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
     func testSaveWithSpecifyingMime() async throws {
         guard let sampleData = "Hello World".data(using: .utf8) else {
             throw ParseError(code: .otherCause, message: "Should have converted to data")

--- a/Tests/ParseSwiftTests/ParseGitHubTests.swift
+++ b/Tests/ParseSwiftTests/ParseGitHubTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2022 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -443,3 +447,4 @@ class ParseGitHubTests: XCTestCase, @unchecked Sendable { // swiftlint:disable:t
         XCTAssertNil(user.password)
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseGoogleTests.swift
+++ b/Tests/ParseSwiftTests/ParseGoogleTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2022 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -456,3 +460,4 @@ class ParseGoogleTests: XCTestCase, @unchecked Sendable { // swiftlint:disable:t
         XCTAssertNil(user.password)
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseHookFunctionRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionRequestTests.swift
@@ -219,6 +219,10 @@ class ParseHookFunctionRequestTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(requestOptions5, options5)
     }
 
+	// Currently can't takeover URLSession with MockURLProtocol
+	// on Linux, Windows, etc. so disabling networking tests on
+	// those platforms.
+	#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
     @MainActor
     func testHydrateUser() async throws {
         let sessionToken = "dog"
@@ -300,4 +304,5 @@ class ParseHookFunctionRequestTests: XCTestCase, @unchecked Sendable {
             XCTAssertTrue(error.equalsTo(.otherCause))
         }
     }
+	#endif
 }

--- a/Tests/ParseSwiftTests/ParseHookFunctionTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookFunctionTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2022 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -277,3 +281,4 @@ class ParseHookFunctionTests: XCTestCase, @unchecked Sendable {
         }
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
@@ -272,6 +272,10 @@ class ParseHookTriggerRequestTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(requestOptions5, options5)
     }
 
+	// Currently can't takeover URLSession with MockURLProtocol
+	// on Linux, Windows, etc. so disabling networking tests on
+	// those platforms.
+	#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
     @MainActor
     func testHydrateUser() async throws {
         let sessionToken = "dog"
@@ -330,4 +334,5 @@ class ParseHookTriggerRequestTests: XCTestCase, @unchecked Sendable {
             XCTAssertTrue(error.equalsTo(server.code))
         }
     }
+	#endif
 }

--- a/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
@@ -207,6 +207,13 @@ class ParseHookTriggerTests: XCTestCase, @unchecked Sendable {
         // swiftlint:disable:next line_length
         let expected11 = "{\"className\":\"_User\",\"triggerName\":\"afterLogout\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
         XCTAssertEqual(hookTrigger11.description, expected11)
+
+		let hookTrigger12 = ParseHookTrigger(
+			trigger: .afterLogout,
+			url: url
+		)
+		let expected12 = "{\"triggerName\":\"afterLogout\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
+		XCTAssertEqual(hookTrigger12.description, expected12)
     }
 
     // swiftlint:disable:next function_body_length

--- a/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2022 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -585,3 +589,4 @@ class ParseHookTriggerTests: XCTestCase, @unchecked Sendable {
         }
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseInstagramTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstagramTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2022 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -533,3 +537,4 @@ class ParseInstagramTests: XCTestCase, @unchecked Sendable {
         XCTAssertFalse(isLinked)
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseInstallationTests.swift
+++ b/Tests/ParseSwiftTests/ParseInstallationTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2020 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -1889,3 +1893,4 @@ class ParseInstallationTests: XCTestCase, @unchecked Sendable { // swiftlint:dis
         try await installation.delete(options: [.usePrimaryKey])
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseLDAPTests.swift
+++ b/Tests/ParseSwiftTests/ParseLDAPTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -521,3 +525,4 @@ class ParseLDAPTests: XCTestCase, @unchecked Sendable {
         XCTAssertNil(user.password)
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseLinkedInTests.swift
+++ b/Tests/ParseSwiftTests/ParseLinkedInTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2022 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -456,3 +460,4 @@ class ParseLinkedInTests: XCTestCase, @unchecked Sendable { // swiftlint:disable
         XCTAssertFalse(updatedCurrentLinkedUser)
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseObjectAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectAsyncTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -1698,7 +1702,6 @@ class ParseObjectAsyncTests: XCTestCase, @unchecked Sendable { // swiftlint:disa
         XCTAssertEqual(level.first?.objectId, "yarr") // This is because mocker is only returning 1 response
     }
 
-    #if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
     @MainActor
     func testDeepSaveObjectWithFile() async throws {
         var game = Game2()
@@ -1781,5 +1784,5 @@ class ParseObjectAsyncTests: XCTestCase, @unchecked Sendable { // swiftlint:disa
         XCTAssertEqual(savedGame.updatedAt, gameOnServer.createdAt)
         XCTAssertEqual(savedGame.profilePicture?.url, gameOnServer.profilePicture?.url)
     }
-    #endif
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectBatchTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2020 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 import XCTest
 @testable import ParseSwift
@@ -1944,3 +1948,4 @@ class ParseObjectBatchTests: XCTestCase, @unchecked Sendable { // swiftlint:disa
         try await self.deleteAllAsyncError(parseError: parseError, callbackQueue: .main)
     }
 } // swiftlint:disable:this file_length
+#endif

--- a/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectCustomObjectIdTests.swift
@@ -633,6 +633,10 @@ class ParseObjectCustomObjectIdTests: XCTestCase, @unchecked Sendable { // swift
         }
     }
 
+	// Currently can't takeover URLSession with MockURLProtocol
+	// on Linux, Windows, etc. so disabling networking tests on
+	// those platforms.
+	#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
     func testSave() async throws {
         var score = GameScore(points: 10)
         score.objectId = "yarr"
@@ -2689,4 +2693,5 @@ class ParseObjectCustomObjectIdTests: XCTestCase, @unchecked Sendable { // swift
             XCTFail(error.localizedDescription)
         }
     }
+	#endif
 }

--- a/Tests/ParseSwiftTests/ParseObjectTests.swift
+++ b/Tests/ParseSwiftTests/ParseObjectTests.swift
@@ -647,6 +647,10 @@ class ParseObjectTests: XCTestCase, @unchecked Sendable { // swiftlint:disable:t
         }
     }
 
+	// Currently can't takeover URLSession with MockURLProtocol
+	// on Linux, Windows, etc. so disabling networking tests on
+	// those platforms.
+	#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
     // swiftlint:disable:next function_body_length
     func testFetch() async throws {
         var score = GameScore(points: 10)
@@ -1694,6 +1698,7 @@ class ParseObjectTests: XCTestCase, @unchecked Sendable { // swiftlint:disable:t
             return
         }
     }
+	#endif
 }
 
 // swiftlint:disable:this file_length

--- a/Tests/ParseSwiftTests/ParseOperationAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseOperationAsyncTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -232,3 +236,4 @@ class ParseOperationAsyncTests: XCTestCase, @unchecked Sendable {
         }
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParsePointerAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerAsyncTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -140,3 +144,4 @@ class ParsePointerAsyncTests: XCTestCase, @unchecked Sendable {
         }
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParsePointerTests.swift
+++ b/Tests/ParseSwiftTests/ParsePointerTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2020 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 import XCTest
 @testable import ParseSwift
@@ -489,5 +493,5 @@ class ParsePointerTests: XCTestCase, @unchecked Sendable {
             XCTFail(error.localizedDescription)
         }
     }
-
 }
+#endif

--- a/Tests/ParseSwiftTests/ParsePushAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParsePushAsyncTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2022 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -371,3 +375,4 @@ class ParsePushAsyncTests: XCTestCase, @unchecked Sendable {
         }
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseQueryAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryAsyncTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -555,3 +559,4 @@ class ParseQueryAsyncTests: XCTestCase, @unchecked Sendable { // swiftlint:disab
         XCTAssertEqual(queryResult, [json.results])
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseQueryCacheTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryCacheTests.swift
@@ -7,6 +7,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import XCTest
 @testable import ParseSwift
 

--- a/Tests/ParseSwiftTests/ParseQueryCacheTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryCacheTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2022 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -745,3 +749,4 @@ class ParseQueryCacheTests: XCTestCase, @unchecked Sendable { // swiftlint:disab
         XCTAssertEqual(queryResult2, [json.results])
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseSchemaAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseSchemaAsyncTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2022 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -317,3 +321,4 @@ class ParseSchemaAsyncTests: XCTestCase, @unchecked Sendable {
         }
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseServerAsyncTests.swift
+++ b/Tests/ParseSwiftTests/ParseServerAsyncTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -133,3 +137,4 @@ class ParseServerAsyncTests: XCTestCase, @unchecked Sendable {
         }
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseServerTests.swift
+++ b/Tests/ParseSwiftTests/ParseServerTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 import XCTest
 @testable import ParseSwift
@@ -119,3 +123,4 @@ class ParseServerTests: XCTestCase, @unchecked Sendable {
         wait(for: [expectation], timeout: 10.0)
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseSessionTests.swift
+++ b/Tests/ParseSwiftTests/ParseSessionTests.swift
@@ -7,6 +7,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 import XCTest
 @testable import ParseSwift

--- a/Tests/ParseSwiftTests/ParseSpotifyTests.swift
+++ b/Tests/ParseSwiftTests/ParseSpotifyTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2022 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -548,3 +552,4 @@ class ParseSpotifyTests: XCTestCase, @unchecked Sendable {
         XCTAssertNil(user.password)
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseTwitterTests.swift
+++ b/Tests/ParseSwiftTests/ParseTwitterTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2021 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -576,3 +580,4 @@ class ParseTwitterTests: XCTestCase, @unchecked Sendable {
         XCTAssertFalse(isLinked)
     }
 }
+#endif

--- a/Tests/ParseSwiftTests/ParseUserTests.swift
+++ b/Tests/ParseSwiftTests/ParseUserTests.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2020 Network Reconnaissance Lab. All rights reserved.
 //
 
+// Currently can't takeover URLSession with MockURLProtocol
+// on Linux, Windows, etc. so disabling networking tests on
+// those platforms.
+#if !os(Linux) && !os(Android) && !os(Windows) && !os(WASI)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -2587,3 +2591,4 @@ class ParseUserTests: XCTestCase, @unchecked Sendable { // swiftlint:disable:thi
 
 }
 // swiftlint:disable:this file_length
+#endif


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- Disclose a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- Link this PR to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
URSession isn't behaving properly on Linux, Windows, Android, etc. This is a regression from #216 which eventually removed `URLSession.parse` on linux, etc.
 
Closes: FILL_THIS_OUT

### Approach
<!-- Add a description of the approach in this PR. -->
Add back a configured `URLSession.parse` property on Linux, etc.

Also, I fixed the test suite builds for Linux so this shouldn't happen again.

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [x] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
