### PR TITLE
fix: Remove ParseHookTriggerable init that won't work with server

### DIFF
--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "6.0.0-beta.7"
+    static let version = "6.0.0-beta.8"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
@@ -28,17 +28,6 @@ public protocol ParseHookTriggerable: ParseHookable {
 // MARK: Default Implementation
 public extension ParseHookTriggerable {
 
-	/**
-	 Creates a new Parse hook trigger.
-	 - parameter trigger: The `ParseHookTriggerType` type.
-	 - parameter url: The endpoint of the hook.
-	 */
-	init(trigger: ParseHookTriggerType, url: URL) {
-		self.init()
-		self.trigger = trigger
-		self.url = url
-	}
-
     /**
      Creates a new Parse hook trigger.
      - parameter className: The name of the `ParseObject` the trigger should act on.

--- a/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
@@ -207,13 +207,6 @@ class ParseHookTriggerTests: XCTestCase, @unchecked Sendable {
         // swiftlint:disable:next line_length
         let expected11 = "{\"className\":\"_User\",\"triggerName\":\"afterLogout\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
         XCTAssertEqual(hookTrigger11.description, expected11)
-
-		let hookTrigger12 = ParseHookTrigger(
-			trigger: .afterLogout,
-			url: url
-		)
-		let expected12 = "{\"triggerName\":\"afterLogout\",\"url\":\"https:\\/\\/api.example.com\\/foo\"}"
-		XCTAssertEqual(hookTrigger12.description, expected12)
     }
 
     // swiftlint:disable:next function_body_length


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- Disclose a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- Link this PR to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->
Regression from #219.

Closes: FILL_THIS_OUT

### Approach
<!-- Add a description of the approach in this PR. -->
This PR removes a broken API initializer from `ParseHookTriggerable` that allowed creating hook triggers without specifying a className, which would not work with Parse Server since all hook triggers require an associated class.

**Changes:**
- Removed `ParseHookTriggerable.init(trigger:url:)` initializer that created invalid hook triggers missing the required className parameter
- Removed corresponding test case that validated the broken initializer
- Bumped version from 6.0.0-beta.7 to 6.0.0-beta.8

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
