### PR TITLE
feat: Add missing hook triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,18 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/6.0.0-beta.1...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/6.0.0...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
 
-### 6.0.0-beta.1
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.12.3...6.0.0-beta.1), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/6.0.0-beta.1/documentation/parseswift)
+### 6.0.0
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.12.3...6.0.0), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/6.0.0/documentation/parseswift)
 
 __Breaking Changes__
 * Update SDK to be Swift 6.0+ compliant. This includes making all objects `Sendable` and reducing the possibility of data races. Added WASM support. Multiple batches now perform asynchronously ([#208](https://github.com/netreconlab/Parse-Swift/pull/208)), thanks to [Corey Baker](https://github.com/cbaker6).
 * Remove all deprecated code and warnings ([#211](https://github.com/netreconlab/Parse-Swift/pull/211)), thanks to [Corey Baker](https://github.com/cbaker6).
+
+__New features__
+* Add missing hook tiggers: `beforePasswordResetRequest` for `ParseUser`, and `beforeFind` and `afterFind` for `ParseFile` ([#224](https://github.com/netreconlab/Parse-Swift/pull/224)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 5.12.3
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.12.2...5.12.3), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.12.3/documentation/parseswift)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ __Breaking Changes__
 * Remove all deprecated code and warnings ([#211](https://github.com/netreconlab/Parse-Swift/pull/211)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 __New features__
-* Add missing hook tiggers: `beforePasswordResetRequest` for `ParseUser`, and `beforeFind` and `afterFind` for `ParseFile` ([#224](https://github.com/netreconlab/Parse-Swift/pull/224)), thanks to [Corey Baker](https://github.com/cbaker6).
+* Add missing hook triggers: `beforePasswordResetRequest` for `ParseUser`, and `beforeFind` and `afterFind` for `ParseFile` ([#224](https://github.com/netreconlab/Parse-Swift/pull/224)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 5.12.3
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/5.12.2...5.12.3), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/5.12.3/documentation/parseswift)

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -49,33 +49,33 @@ enum Method: String {
  The types of Parse Hook Triggers available.
  */
 public enum ParseHookTriggerType: String, Codable, Sendable {
-    /// Occurs before login of a `ParseUser`.
-    case beforeLogin
-    /// Occurs after login of a `ParseUser`.
-    case afterLogin
-    /// Occurs after logout of a `ParseUser`.
-    case afterLogout
+	/// Occurs before login of a `ParseUser`.
+	case beforeLogin
+	/// Occurs after login of a `ParseUser`.
+	case afterLogin
+	/// Occurs after logout of a `ParseUser`.
+	case afterLogout
 	/// Occurs before password is reset on a `ParseUser`.
 	/// - warning: Requires Parse Server 8.5.0+.
 	case beforePasswordResetRequest
 	/// Occurs before saving a `ParseObject`, `ParseFile`, or `ParseConfig`.
-    case beforeSave
-    /// Occurs after saving a `ParseObject`, `ParseFile`, or `ParseConfig`.
-    case afterSave
-    /// Occurs before deleting a `ParseObject` or `ParseFile`.
-    case beforeDelete
-    /// Occurs after deleting a `ParseObject` or `ParseFile`.
-    case afterDelete
-    /// Occurs before finding a `ParseObject` or `ParseFile`.
-    case beforeFind
-    /// Occurs after finding a `ParseObject` or `ParseFile`.
-    case afterFind
-    /// Occurs before a `ParseLiveQuery` connection is made.
-    case beforeConnect
-    /// Occurs before a `ParseLiveQuery` subscription is made.
-    case beforeSubscribe
-    /// Occurs after a `ParseLiveQuery` event.
-    case afterEvent
+	case beforeSave
+	/// Occurs after saving a `ParseObject`, `ParseFile`, or `ParseConfig`.
+	case afterSave
+	/// Occurs before deleting a `ParseObject` or `ParseFile`.
+	case beforeDelete
+	/// Occurs after deleting a `ParseObject` or `ParseFile`.
+	case afterDelete
+	/// Occurs before finding a `ParseObject` or `ParseFile`.
+	case beforeFind
+	/// Occurs after finding a `ParseObject` or `ParseFile`.
+	case afterFind
+	/// Occurs before a `ParseLiveQuery` connection is made.
+	case beforeConnect
+	/// Occurs before a `ParseLiveQuery` subscription is made.
+	case beforeSubscribe
+	/// Occurs after a `ParseLiveQuery` event.
+	case afterEvent
 }
 
 /**

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -55,7 +55,10 @@ public enum ParseHookTriggerType: String, Codable, Sendable {
     case afterLogin
     /// Occurs after logout of a `ParseUser`.
     case afterLogout
-    /// Occurs before saving a `ParseObject`, `ParseFile`, or `ParseConfig`.
+	/// Occurs before password is reset on a `ParseUser`.
+	/// - warning: Requires Parse Server 8.5.0+.
+	case beforePasswordResetRequest
+	/// Occurs before saving a `ParseObject`, `ParseFile`, or `ParseConfig`.
     case beforeSave
     /// Occurs after saving a `ParseObject`, `ParseFile`, or `ParseConfig`.
     case afterSave
@@ -63,9 +66,9 @@ public enum ParseHookTriggerType: String, Codable, Sendable {
     case beforeDelete
     /// Occurs after deleting a `ParseObject` or `ParseFile`.
     case afterDelete
-    /// Occurs before finding a `ParseObject`.
+    /// Occurs before finding a `ParseObject` or `ParseFile`.
     case beforeFind
-    /// Occurs after finding a `ParseObject`.
+    /// Occurs after finding a `ParseObject` or `ParseFile`.
     case afterFind
     /// Occurs before a `ParseLiveQuery` connection is made.
     case beforeConnect
@@ -86,7 +89,7 @@ public enum ParseHookTriggerObject: Sendable {
     /// Trigger on `ParseFile`'s.
     case file
     /// Trigger on `ParseConfig` updates.
-    /// - warning: Requires Parse Server 7.3.0-alpha.6+.
+    /// - warning: Requires Parse Server 7.3.0+.
     case config
     /// Trigger on `ParseLiveQuery` connections.
     case liveQueryConnect

--- a/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
@@ -93,7 +93,7 @@ public extension ParseHookTriggerable {
         switch object {
         case .objectType(let parseObject):
             switch trigger {
-            case .beforeLogin, .afterLogin, .afterLogout:
+			case .beforeLogin, .afterLogin, .afterLogout, .beforePasswordResetRequest:
                 guard parseObject is (any ParseUser.Type) else {
                     throw notSupportedError
                 }
@@ -111,7 +111,7 @@ public extension ParseHookTriggerable {
             )
         case .object(let parseObject):
             switch trigger {
-            case .beforeLogin, .afterLogin, .afterLogout:
+			case .beforeLogin, .afterLogin, .afterLogout, .beforePasswordResetRequest:
                 guard parseObject is (any ParseUser) else {
                     throw notSupportedError
                 }
@@ -129,7 +129,8 @@ public extension ParseHookTriggerable {
             )
         case .file:
             switch trigger {
-            case .beforeSave, .afterSave, .beforeDelete, .afterDelete:
+            case .beforeSave, .afterSave, .beforeDelete,
+					.afterDelete, .beforeFind, .afterFind:
                 break // No op
             default:
                 throw notSupportedError

--- a/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
+++ b/Sources/ParseSwift/Protocols/ParseHookTriggerable.swift
@@ -90,78 +90,79 @@ public extension ParseHookTriggerable {
             message: "This object \"\(object)\" currently does not support the hook trigger \"\(trigger)\""
         )
 
-        switch object {
-        case .objectType(let parseObject):
-            switch trigger {
+		switch object {
+		case .objectType(let parseObject):
+			switch trigger {
+			case .beforeLogin, .afterLogin, .afterLogout,
+					.beforePasswordResetRequest:
+				guard parseObject is (any ParseUser.Type) else {
+					throw notSupportedError
+				}
+			case .beforeSave, .afterSave, .beforeDelete,
+					.afterDelete, .beforeFind, .afterFind,
+					.beforeSubscribe, .afterEvent:
+				break // No op
+			default:
+				throw notSupportedError
+			}
+			self.init(
+				className: object.className,
+				trigger: trigger,
+				url: url
+			)
+		case .object(let parseObject):
+			switch trigger {
 			case .beforeLogin, .afterLogin, .afterLogout, .beforePasswordResetRequest:
-                guard parseObject is (any ParseUser.Type) else {
-                    throw notSupportedError
-                }
-            case .beforeSave, .afterSave, .beforeDelete,
-                    .afterDelete, .beforeFind, .afterFind,
-                    .beforeSubscribe, .afterEvent:
-                break // No op
-            default:
-                throw notSupportedError
-            }
-            self.init(
-                className: object.className,
-                trigger: trigger,
-                url: url
-            )
-        case .object(let parseObject):
-            switch trigger {
-			case .beforeLogin, .afterLogin, .afterLogout, .beforePasswordResetRequest:
-                guard parseObject is (any ParseUser) else {
-                    throw notSupportedError
-                }
-            case .beforeSave, .afterSave, .beforeDelete,
-                    .afterDelete, .beforeFind, .afterFind,
-                    .beforeSubscribe, .afterEvent:
-                break // No op
-            default:
-                throw notSupportedError
-            }
-            self.init(
-                className: object.className,
-                trigger: trigger,
-                url: url
-            )
-        case .file:
-            switch trigger {
-            case .beforeSave, .afterSave, .beforeDelete,
+				guard parseObject is (any ParseUser) else {
+					throw notSupportedError
+				}
+			case .beforeSave, .afterSave, .beforeDelete,
+					.afterDelete, .beforeFind, .afterFind,
+					.beforeSubscribe, .afterEvent:
+				break // No op
+			default:
+				throw notSupportedError
+			}
+			self.init(
+				className: object.className,
+				trigger: trigger,
+				url: url
+			)
+		case .file:
+			switch trigger {
+			case .beforeSave, .afterSave, .beforeDelete,
 					.afterDelete, .beforeFind, .afterFind:
-                break // No op
-            default:
-                throw notSupportedError
-            }
-            self.init(
-                className: object.className,
-                trigger: trigger,
-                url: url
-            )
-        case .config:
-            switch trigger {
-            case .beforeSave, .afterSave:
-                break // No op
-            default:
-                throw notSupportedError
-            }
-            self.init(
-                className: object.className,
-                trigger: trigger,
-                url: url
-            )
-        case .liveQueryConnect:
-            guard trigger == .beforeConnect else {
-                throw notSupportedError
-            }
-            self.init(
-                className: object.className,
-                trigger: trigger,
-                url: url
-            )
-        }
+				break // No op
+			default:
+				throw notSupportedError
+			}
+			self.init(
+				className: object.className,
+				trigger: trigger,
+				url: url
+			)
+		case .config:
+			switch trigger {
+			case .beforeSave, .afterSave:
+				break // No op
+			default:
+				throw notSupportedError
+			}
+			self.init(
+				className: object.className,
+				trigger: trigger,
+				url: url
+			)
+		case .liveQueryConnect:
+			guard trigger == .beforeConnect else {
+				throw notSupportedError
+			}
+			self.init(
+				className: object.className,
+				trigger: trigger,
+				url: url
+			)
+		}
     }
 }
 

--- a/Sources/ParseSwift/Types/ParseHookTriggerRequest.swift
+++ b/Sources/ParseSwift/Types/ParseHookTriggerRequest.swift
@@ -28,6 +28,8 @@ public struct ParseHookTriggerRequest<U: ParseCloudUser>: ParseHookTriggerReques
     public var file: ParseFile?
     /// The size of the file in bytes.
     public var fileSize: Int?
+	/// Force `ParseFile` download.
+	public var forceDownload: Bool?
     var log: AnyCodable?
     var context: AnyCodable?
 
@@ -37,7 +39,7 @@ public struct ParseHookTriggerRequest<U: ParseCloudUser>: ParseHookTriggerReques
         case trigger = "triggerName"
         case user, installationId, headers,
              log, context, file, fileSize,
-             clients
+             clients, forceDownload
     }
 }
 

--- a/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerRequestTests.swift
@@ -74,24 +74,29 @@ class ParseHookTriggerRequestTests: XCTestCase, @unchecked Sendable {
     }
 
     func testCoding() async throws {
-        let triggerRequest = ParseHookTriggerRequest<User>(primaryKey: true,
-                                                           ipAddress: "1.1.1.1",
-                                                           headers: ["yolo": "me"],
-                                                           trigger: .beforeDelete,
-                                                           file: ParseFile(data: Data()),
-                                                           fileSize: 0)
+        let triggerRequest = ParseHookTriggerRequest<User>(
+			primaryKey: true,
+			ipAddress: "1.1.1.1",
+			headers: ["yolo": "me"],
+			trigger: .beforeDelete,
+			file: ParseFile(data: Data()),
+			fileSize: 0,
+			forceDownload: true
+		)
         // swiftlint:disable:next line_length
-        let expected = "{\"file\":{\"__type\":\"File\",\"name\":\"file\"},\"fileSize\":0,\"headers\":{\"yolo\":\"me\"},\"ip\":\"1.1.1.1\",\"master\":true,\"triggerName\":\"beforeDelete\"}"
+        let expected = "{\"file\":{\"__type\":\"File\",\"name\":\"file\"},\"fileSize\":0,\"forceDownload\":true,\"headers\":{\"yolo\":\"me\"},\"ip\":\"1.1.1.1\",\"master\":true,\"triggerName\":\"beforeDelete\"}"
         XCTAssertEqual(triggerRequest.description, expected)
     }
 
     func testCodingObject() async throws {
         let object = User(objectId: "geez")
-        let triggerRequest = ParseHookTriggerObjectRequest<User, User>(primaryKey: true,
-                                                                       ipAddress: "1.1.1.1",
-                                                                       headers: ["yolo": "me"],
-                                                                       trigger: .beforeDelete,
-                                                                       object: object)
+        let triggerRequest = ParseHookTriggerObjectRequest<User, User>(
+			primaryKey: true,
+			ipAddress: "1.1.1.1",
+			headers: ["yolo": "me"],
+			trigger: .beforeDelete,
+			object: object
+		)
         // swiftlint:disable:next line_length
         let expected = "{\"headers\":{\"yolo\":\"me\"},\"ip\":\"1.1.1.1\",\"master\":true,\"object\":{\"objectId\":\"geez\"},\"triggerName\":\"beforeDelete\"}"
         XCTAssertEqual(triggerRequest.description, expected)

--- a/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
+++ b/Tests/ParseSwiftTests/ParseHookTriggerTests.swift
@@ -272,6 +272,13 @@ class ParseHookTriggerTests: XCTestCase, @unchecked Sendable {
                 url: url
             )
         )
+		XCTAssertThrowsError(
+			try ParseHookTrigger(
+				object: ParseHookTriggerObject.objectType(GameScore.self),
+				trigger: .beforePasswordResetRequest,
+				url: url
+			)
+		)
     }
 
     @MainActor


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- Disclose a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- Link this PR to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

Closes: FILL_THIS_OUT

### Approach
<!-- Add a description of the approach in this PR. -->
This pull request adds missing hook triggers to the Parse-Swift SDK, specifically adding support for `beforePasswordResetRequest` for `ParseUser` objects and extending `beforeFind`/`afterFind` triggers to support `ParseFile` objects. Additionally, it adds a `forceDownload` property to `ParseHookTriggerRequest`.

**Changes:**
- Added `beforePasswordResetRequest` trigger for ParseUser with Parse Server 8.5.0+ requirement
- Extended `beforeFind` and `afterFind` triggers to support ParseFile objects
- Added `forceDownload` property to `ParseHookTriggerRequest` for controlling ParseFile download behavior

### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
