### PR TITLE
fix: All view models always run on MainActor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,12 @@ jobs:
       run: brew install swiftlint
     - name: Create and set the default keychain
       run: |
-        security create-keychain -p "" temporary
-        security default-keychain -s temporary
-        security unlock-keychain -p "" temporary
-        security set-keychain-settings -lut 7200 temporary
+        KEYCHAIN_NAME="temporary-${GITHUB_RUN_ID}"
+        security delete-keychain "$KEYCHAIN_NAME" 2>/dev/null || true
+        security create-keychain -p "" "$KEYCHAIN_NAME"
+        security default-keychain -s "$KEYCHAIN_NAME"
+        security unlock-keychain -p "" "$KEYCHAIN_NAME"
+        security set-keychain-settings -lut 7200 "$KEYCHAIN_NAME"
     - name: Build-Test
       run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace Parse.xcworkspace -scheme ParseSwift -derivedDataPath DerivedData -destination ${{ matrix.destination }} ${{ matrix.action }} 2>&1 | xcbeautify --renderer github-actions
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,12 @@ jobs:
     - uses: actions/checkout@v6
     - name: Create and set the default keychain
       run: |
-        security create-keychain -p "" temporary
-        security default-keychain -s temporary
-        security unlock-keychain -p "" temporary
-        security set-keychain-settings -lut 7200 temporary
+        KEYCHAIN_NAME="temporary-${GITHUB_RUN_ID}"
+        security delete-keychain "$KEYCHAIN_NAME" 2>/dev/null || true
+        security create-keychain -p "" "$KEYCHAIN_NAME"
+        security default-keychain -s "$KEYCHAIN_NAME"
+        security unlock-keychain -p "" "$KEYCHAIN_NAME"
+        security set-keychain-settings -lut 7200 "$KEYCHAIN_NAME"
     - name: Build-Test
       run: set -o pipefail && env NSUnbufferedIO=YES swift test --enable-code-coverage 2>&1 | xcbeautify --renderer github-actions
       env:
@@ -100,7 +102,7 @@ jobs:
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE_LATEST }}
 
-  xcode-test-oldest:
+  spm-test-oldest:
     timeout-minutes: 25
     needs: linux
     runs-on: macos-15
@@ -108,10 +110,12 @@ jobs:
     - uses: actions/checkout@v6
     - name: Create and set the default keychain
       run: |
-        security create-keychain -p "" temporary
-        security default-keychain -s temporary
-        security unlock-keychain -p "" temporary
-        security set-keychain-settings -lut 7200 temporary
+        KEYCHAIN_NAME="temporary-${GITHUB_RUN_ID}"
+        security delete-keychain "$KEYCHAIN_NAME" 2>/dev/null || true
+        security create-keychain -p "" "$KEYCHAIN_NAME"
+        security default-keychain -s "$KEYCHAIN_NAME"
+        security unlock-keychain -p "" "$KEYCHAIN_NAME"
+        security set-keychain-settings -lut 7200 "$KEYCHAIN_NAME"
     - name: Build-Test
       run: set -o pipefail && env NSUnbufferedIO=YES swift test --enable-code-coverage 2>&1 | xcbeautify --renderer github-actions
       env:
@@ -121,7 +125,7 @@ jobs:
       id: coverage-files
       with:
         format: lcov
-        search-paths: ./DerivedData
+        search-paths: ./.build
         ignore-conversion-failures: true
       env:
           DEVELOPER_DIR: ${{ env.CI_XCODE_OLDEST }}
@@ -158,7 +162,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   android:
-    timeout-minutes: 15
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   release:
     types: [published]
 env:
-  CI_XCODE_LATEST: '/Applications/Xcode_26.1.app/Contents/Developer'
+  CI_XCODE_LATEST: '/Applications/Xcode_26.2.app/Contents/Developer'
 
 jobs:
   cocoapods:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 # Parse-Swift Changelog
 
 ### main
-[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/6.0.1...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/6.0.3...main), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/main/documentation/parseswift)
 * _Contributing to this repo? Add info about your change here to be included in the next release_
+
+### 6.0.3
+[Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/6.0.2...6.0.3), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/6.0.3/documentation/parseswift)
+
+__Fixes__
+* All view models run on the `@MainActor` ([#229](https://github.com/netreconlab/Parse-Swift/pull/229)), thanks to [Corey Baker](https://github.com/cbaker6).
 
 ### 6.0.1
 [Full Changelog](https://github.com/netreconlab/Parse-Swift/compare/6.0.0...6.0.1), [Documentation](https://swiftpackageindex.com/netreconlab/Parse-Swift/6.0.1/documentation/parseswift)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ import PackageDescription
 let package = Package(
     name: "YOUR_PROJECT_NAME",
     dependencies: [
-        .package(url: "https://github.com/netreconlab/Parse-Swift", .upToNextMajor(from: "6.0.0"))
+        .package(url: "https://github.com/netreconlab/Parse-Swift", .upToNextMajor(from: "6.0.3"))
     ],
     targets: [
         .target(

--- a/Scripts/generate-documentation
+++ b/Scripts/generate-documentation
@@ -104,7 +104,7 @@ mv Parse.xcworkspace "$TEMP_WORKSPACE_DIR/Parse.xcworkspace"
 
 xcodebuild clean build -scheme ParseSwift \
     -destination generic/platform=iOS \
-    OTHER_SWIFT_FLAGS="-emit-symbol-graph -emit-symbol-graph-dir '$SGFS_DIR'" | xcpretty
+    OTHER_SWIFT_FLAGS="-emit-symbol-graph -emit-symbol-graph-dir '$SGFS_DIR'" 2>&1 | xcbeautify
 
 mv "$TEMP_WORKSPACE_DIR/Parse.xcworkspace" ./Parse.xcworkspace
 rm -r "$TEMP_WORKSPACE_DIR"

--- a/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
+++ b/Sources/ParseSwift/LiveQuery/ParseLiveQuery.swift
@@ -672,6 +672,7 @@ extension ParseLiveQuery {
 // MARK: Subscribing
 extension ParseLiveQuery {
 
+	@MainActor
 	func subscribe<T>(_ query: Query<T>) async throws -> Subscription<T> {
         try await subscribe(Subscription(query: query))
     }
@@ -776,6 +777,7 @@ public extension Query {
      - returns: The subscription that has just been registered.
      - throws: An error of type `ParseError`.
      */
+	@MainActor
     func subscribe(_ client: ParseLiveQuery) async throws -> Subscription<ResultType> {
         try await client.subscribe(Subscription(query: self))
     }

--- a/Sources/ParseSwift/LiveQuery/Subscription.swift
+++ b/Sources/ParseSwift/LiveQuery/Subscription.swift
@@ -21,7 +21,7 @@ import Combine
  [documentation](https://developer.apple.com/documentation/combine/observableobject)
  for more details.
  */
-open class Subscription<T: ParseObject>: QueryViewModel<T>, QuerySubscribable {
+open class Subscription<T: ParseObject>: QueryViewModel<T>, QuerySubscribable, @unchecked Sendable {
 
 	private let eventLock = NSLock()
 	private let subscribedLock = NSLock()

--- a/Sources/ParseSwift/LiveQuery/Subscription.swift
+++ b/Sources/ParseSwift/LiveQuery/Subscription.swift
@@ -21,7 +21,7 @@ import Combine
  [documentation](https://developer.apple.com/documentation/combine/observableobject)
  for more details.
  */
-open class Subscription<T: ParseObject>: QueryViewModel<T>, QuerySubscribable, @unchecked Sendable {
+open class Subscription<T: ParseObject>: QueryViewModel<T>, QuerySubscribable {
 
 	private let eventLock = NSLock()
 	private let subscribedLock = NSLock()

--- a/Sources/ParseSwift/ParseConstants.swift
+++ b/Sources/ParseSwift/ParseConstants.swift
@@ -10,7 +10,7 @@ import Foundation
 
 enum ParseConstants {
     static let sdk = "swift"
-    static let version = "6.0.1"
+    static let version = "6.0.3"
     static let fileManagementDirectory = "parse/"
     static let fileManagementPrivateDocumentsDirectory = "Private Documents/"
     static let fileManagementLibraryDirectory = "Library/"

--- a/Sources/ParseSwift/Protocols/CloudObservable.swift
+++ b/Sources/ParseSwift/Protocols/CloudObservable.swift
@@ -15,6 +15,7 @@ import FoundationNetworking
  This protocol describes the interface for creating a view model for `ParseCloud` functions and jobs.
  You can use this protocol on any custom class of yours, instead of `CloudViewModel`, if it fits your use case better.
  */
+@MainActor
 public protocol CloudObservable: ObservableObject {
 
     /// The `ParseObject` associated with this view model.
@@ -30,14 +31,12 @@ public protocol CloudObservable: ObservableObject {
      when the result of its execution.
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
     */
-    @MainActor
     func runFunction(options: API.Options) async
 
     /**
      Starts a Cloud Code Job *asynchronously* and updates the view model with the result and jobStatusId of the job.
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
     */
-    @MainActor
     func startJob(options: API.Options) async
 }
 #endif

--- a/Sources/ParseSwift/Protocols/QueryObservable.swift
+++ b/Sources/ParseSwift/Protocols/QueryObservable.swift
@@ -13,7 +13,6 @@ import Foundation
  This protocol describes the interface for creating a view model for a `Query`.
  You can use this protocol on any custom class of yours, instead of `QueryViewModel`, if it fits your use case better.
  */
-@MainActor
 public protocol QueryObservable: ObservableObject {
 
     /// The `ParseObject` associated with this view model.
@@ -33,7 +32,7 @@ public protocol QueryObservable: ObservableObject {
 
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
     */
-    @MainActor
+	@MainActor
     func find(options: API.Options) async
 
     /**
@@ -44,6 +43,7 @@ public protocol QueryObservable: ObservableObject {
      - warning: The items are processed in an unspecified order. The query may not have any sort
      order, and may not use limit or skip.
     */
+	@MainActor
     func findAll(batchLimit: Int?,
                  options: API.Options) async
 
@@ -53,6 +53,7 @@ public protocol QueryObservable: ObservableObject {
       - warning: This method mutates the query. It will reset the limit to `1`.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
     */
+	@MainActor
     func first(options: API.Options) async
 
     /**
@@ -61,6 +62,7 @@ public protocol QueryObservable: ObservableObject {
 
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
     */
+	@MainActor
     func count(options: API.Options) async
 
     /**
@@ -72,6 +74,7 @@ public protocol QueryObservable: ObservableObject {
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
         - warning: This has not been tested thoroughly.
     */
+	@MainActor
     func aggregate(_ pipeline: [[String: Encodable & Sendable]],
                    options: API.Options) async
 }

--- a/Sources/ParseSwift/Protocols/QueryObservable.swift
+++ b/Sources/ParseSwift/Protocols/QueryObservable.swift
@@ -13,6 +13,7 @@ import Foundation
  This protocol describes the interface for creating a view model for a `Query`.
  You can use this protocol on any custom class of yours, instead of `QueryViewModel`, if it fits your use case better.
  */
+@MainActor
 public protocol QueryObservable: ObservableObject {
 
     /// The `ParseObject` associated with this view model.
@@ -43,7 +44,6 @@ public protocol QueryObservable: ObservableObject {
      - warning: The items are processed in an unspecified order. The query may not have any sort
      order, and may not use limit or skip.
     */
-    @MainActor
     func findAll(batchLimit: Int?,
                  options: API.Options) async
 
@@ -53,7 +53,6 @@ public protocol QueryObservable: ObservableObject {
       - warning: This method mutates the query. It will reset the limit to `1`.
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
     */
-    @MainActor
     func first(options: API.Options) async
 
     /**
@@ -62,7 +61,6 @@ public protocol QueryObservable: ObservableObject {
 
       - parameter options: A set of header options sent to the server. Defaults to an empty set.
     */
-    @MainActor
     func count(options: API.Options) async
 
     /**
@@ -74,7 +72,6 @@ public protocol QueryObservable: ObservableObject {
         - parameter options: A set of header options sent to the server. Defaults to an empty set.
         - warning: This has not been tested thoroughly.
     */
-    @MainActor
     func aggregate(_ pipeline: [[String: Encodable & Sendable]],
                    options: API.Options) async
 }

--- a/Sources/ParseSwift/Types/CloudViewModel.swift
+++ b/Sources/ParseSwift/Types/CloudViewModel.swift
@@ -15,7 +15,7 @@ import Combine
  [documentation](https://developer.apple.com/documentation/combine/observableobject)
  for more details.
  */
-open class CloudViewModel<T: ParseCloudable>: CloudObservable, @unchecked Sendable {
+open class CloudViewModel<T: ParseCloudable>: CloudObservable {
 
 	private let resultsLock = NSLock()
 	private let cloudCodeLock = NSLock()
@@ -87,7 +87,6 @@ open class CloudViewModel<T: ParseCloudable>: CloudObservable, @unchecked Sendab
         self._cloudCode = cloudCode
     }
 
-    @MainActor
     public func runFunction(options: API.Options = []) async {
         do {
             self.results = try await cloudCode.runFunction(options: options)
@@ -96,7 +95,6 @@ open class CloudViewModel<T: ParseCloudable>: CloudObservable, @unchecked Sendab
         }
     }
 
-    @MainActor
     public func startJob(options: API.Options = []) async {
         do {
             self.results = try await cloudCode.startJob(options: options)
@@ -107,6 +105,7 @@ open class CloudViewModel<T: ParseCloudable>: CloudObservable, @unchecked Sendab
 }
 
 // MARK: CloudCodeViewModel
+@MainActor
 public extension ParseCloudable {
 
     /**
@@ -114,7 +113,8 @@ public extension ParseCloudable {
      as the view model can be used as a SwiftUI publisher. Meaning it can serve
      indepedently as a ViewModel in MVVM.
      */
-    var viewModel: CloudViewModel<Self> {
+
+	var viewModel: CloudViewModel<Self> {
         CloudViewModel(cloudCode: self)
     }
 
@@ -125,7 +125,7 @@ public extension ParseCloudable {
      - parameter query: Any query.
      - returns: The view model for this query.
      */
-    static func viewModel(_ cloudCode: Self) -> CloudViewModel<Self> {
+	static func viewModel(_ cloudCode: Self) -> CloudViewModel<Self> {
         CloudViewModel(cloudCode: cloudCode)
     }
 }

--- a/Sources/ParseSwift/Types/CloudViewModel.swift
+++ b/Sources/ParseSwift/Types/CloudViewModel.swift
@@ -15,7 +15,7 @@ import Combine
  [documentation](https://developer.apple.com/documentation/combine/observableobject)
  for more details.
  */
-open class CloudViewModel<T: ParseCloudable>: CloudObservable {
+open class CloudViewModel<T: ParseCloudable>: CloudObservable, @unchecked Sendable {
 
 	private let resultsLock = NSLock()
 	private let cloudCodeLock = NSLock()

--- a/Sources/ParseSwift/Types/QueryViewModel.swift
+++ b/Sources/ParseSwift/Types/QueryViewModel.swift
@@ -16,7 +16,7 @@ import Combine
  [documentation](https://developer.apple.com/documentation/combine/observableobject)
  for more details.
  */
-open class QueryViewModel<T: ParseObject>: QueryObservable, @unchecked Sendable {
+open class QueryViewModel<T: ParseObject>: QueryObservable {
 
 	private let resultsLock = NSLock()
 	private let countLock = NSLock()
@@ -97,7 +97,6 @@ open class QueryViewModel<T: ParseObject>: QueryObservable, @unchecked Sendable 
         self.query = query
     }
 
-    @MainActor
     open func find(options: API.Options = []) async {
         do {
             self.results = try await query.find(options: options)
@@ -106,7 +105,6 @@ open class QueryViewModel<T: ParseObject>: QueryObservable, @unchecked Sendable 
         }
     }
 
-    @MainActor
     open func findAll(batchLimit: Int? = nil,
                       options: API.Options = []) async {
         do {
@@ -117,7 +115,6 @@ open class QueryViewModel<T: ParseObject>: QueryObservable, @unchecked Sendable 
         }
     }
 
-    @MainActor
     open func first(options: API.Options = []) async {
         do {
             let result = try await query.first(options: options)
@@ -127,7 +124,6 @@ open class QueryViewModel<T: ParseObject>: QueryObservable, @unchecked Sendable 
         }
     }
 
-    @MainActor
     open func count(options: API.Options = []) async {
         do {
             self.count = try await query.count(options: options)
@@ -136,7 +132,6 @@ open class QueryViewModel<T: ParseObject>: QueryObservable, @unchecked Sendable 
         }
     }
 
-    @MainActor
     open func aggregate(_ pipeline: [[String: Encodable & Sendable]],
                         options: API.Options = []) async {
         do {
@@ -148,6 +143,7 @@ open class QueryViewModel<T: ParseObject>: QueryObservable, @unchecked Sendable 
 }
 
 // MARK: QueryViewModel
+@MainActor
 public extension Query {
 
     /**

--- a/Sources/ParseSwift/Types/QueryViewModel.swift
+++ b/Sources/ParseSwift/Types/QueryViewModel.swift
@@ -16,7 +16,7 @@ import Combine
  [documentation](https://developer.apple.com/documentation/combine/observableobject)
  for more details.
  */
-open class QueryViewModel<T: ParseObject>: QueryObservable {
+open class QueryViewModel<T: ParseObject>: QueryObservable, @unchecked Sendable {
 
 	private let resultsLock = NSLock()
 	private let countLock = NSLock()

--- a/Sources/ParseSwift/Types/QueryViewModel.swift
+++ b/Sources/ParseSwift/Types/QueryViewModel.swift
@@ -21,6 +21,7 @@ open class QueryViewModel<T: ParseObject>: QueryObservable, @unchecked Sendable 
 	private let resultsLock = NSLock()
 	private let countLock = NSLock()
 	private let errorLock = NSLock()
+	private let queryLock = NSLock()
 	private var _results = [Object]() {
 		willSet {
 			self.objectWillChange.send()
@@ -42,11 +43,34 @@ open class QueryViewModel<T: ParseObject>: QueryObservable, @unchecked Sendable 
 			}
 		}
 	}
+	private var _query: Query<T> {
+		willSet {
+			if newValue != _query {
+				_results.removeAll()
+				_count = 0
+				self.objectWillChange.send()
+			}
+		}
+	}
 
-    public var query: Query<T>
+	public var query: Query<T> {
+		get {
+			queryLock.lock()
+			defer { queryLock.unlock() }
+			return _query
+		}
+
+		set {
+			queryLock.lock()
+			defer { queryLock.unlock() }
+			_query = newValue
+		}
+	}
+
     public typealias Object = T
 
     /// Updates and notifies when the new results have been retrieved.
+	@MainActor
 	open var results: [Object] {
 		get {
 			resultsLock.lock()
@@ -64,6 +88,7 @@ open class QueryViewModel<T: ParseObject>: QueryObservable, @unchecked Sendable 
     }
 
     /// Updates and notifies when the count of the results have been retrieved.
+	@MainActor
 	open var count: Int {
 		get {
 			countLock.lock()
@@ -79,6 +104,7 @@ open class QueryViewModel<T: ParseObject>: QueryObservable, @unchecked Sendable 
     }
 
     /// Updates and notifies when there is an error retrieving the results.
+	@MainActor
     open var error: ParseError? {
 		get {
 			errorLock.lock()
@@ -94,9 +120,10 @@ open class QueryViewModel<T: ParseObject>: QueryObservable, @unchecked Sendable 
     }
 
     required public init(query: Query<T>) {
-        self.query = query
+        self._query = query
     }
 
+	@MainActor
     open func find(options: API.Options = []) async {
         do {
             self.results = try await query.find(options: options)
@@ -105,6 +132,7 @@ open class QueryViewModel<T: ParseObject>: QueryObservable, @unchecked Sendable 
         }
     }
 
+	@MainActor
     open func findAll(batchLimit: Int? = nil,
                       options: API.Options = []) async {
         do {
@@ -115,6 +143,7 @@ open class QueryViewModel<T: ParseObject>: QueryObservable, @unchecked Sendable 
         }
     }
 
+	@MainActor
     open func first(options: API.Options = []) async {
         do {
             let result = try await query.first(options: options)
@@ -124,6 +153,7 @@ open class QueryViewModel<T: ParseObject>: QueryObservable, @unchecked Sendable 
         }
     }
 
+	@MainActor
     open func count(options: API.Options = []) async {
         do {
             self.count = try await query.count(options: options)
@@ -132,6 +162,7 @@ open class QueryViewModel<T: ParseObject>: QueryObservable, @unchecked Sendable 
         }
     }
 
+	@MainActor
     open func aggregate(_ pipeline: [[String: Encodable & Sendable]],
                         options: API.Options = []) async {
         do {

--- a/Tests/ParseSwiftTests/ParseCloudViewModelTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudViewModelTests.swift
@@ -12,7 +12,7 @@ import XCTest
 @testable import ParseSwift
 
 @MainActor
-class ParseCloudViewModelTests: XCTestCase {
+class ParseCloudViewModelTests: XCTestCase, @unchecked Sendable {
     struct Cloud: ParseCloudable, Sendable {
         typealias ReturnType = String? // swiftlint:disable:this nesting
 

--- a/Tests/ParseSwiftTests/ParseCloudViewModelTests.swift
+++ b/Tests/ParseSwiftTests/ParseCloudViewModelTests.swift
@@ -11,7 +11,8 @@ import Foundation
 import XCTest
 @testable import ParseSwift
 
-class ParseCloudViewModelTests: XCTestCase, @unchecked Sendable {
+@MainActor
+class ParseCloudViewModelTests: XCTestCase {
     struct Cloud: ParseCloudable, Sendable {
         typealias ReturnType = String? // swiftlint:disable:this nesting
 

--- a/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
+++ b/Tests/ParseSwiftTests/ParseLiveQueryTests.swift
@@ -693,6 +693,7 @@ class ParseLiveQueryTests: XCTestCase, @unchecked Sendable {
         }
     }
 
+	@MainActor
     func testSubscribeNotConnected() async throws {
         let query = GameScore.query("points" > 9)
         let subscription = try await query.subscribe()
@@ -745,6 +746,7 @@ class ParseLiveQueryTests: XCTestCase, @unchecked Sendable {
         }
     }
 
+	@MainActor
     func testSubscribeConnected() async throws {
         let query = GameScore.query("points" > 9)
         let installationId = try await BaseParseInstallation.current().installationId
@@ -1560,6 +1562,7 @@ class ParseLiveQueryTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(client.status, .socketNotEstablished)
     }
 
+	@MainActor
     func testEventEnter() async throws {
         let query = GameScore.query("points" > 9)
         let installationId = try await BaseParseInstallation.current().installationId
@@ -1608,6 +1611,7 @@ class ParseLiveQueryTests: XCTestCase, @unchecked Sendable {
         }
     }
 
+	@MainActor
     func testEventLeave() async throws {
         let query = GameScore.query("points" > 9)
         let installationId = try await BaseParseInstallation.current().installationId
@@ -1659,6 +1663,7 @@ class ParseLiveQueryTests: XCTestCase, @unchecked Sendable {
         await fulfillment(of: [expectation1], timeout: 20.0)
     }
 
+	@MainActor
     func testEventCreate() async throws {
         let query = GameScore.query("points" > 9)
         let installationId = try await BaseParseInstallation.current().installationId
@@ -1710,6 +1715,7 @@ class ParseLiveQueryTests: XCTestCase, @unchecked Sendable {
         await fulfillment(of: [expectation1], timeout: 20.0)
     }
 
+	@MainActor
     func testEventUpdate() async throws {
         let query = GameScore.query("points" > 9)
         let installationId = try await BaseParseInstallation.current().installationId
@@ -1761,6 +1767,7 @@ class ParseLiveQueryTests: XCTestCase, @unchecked Sendable {
         await fulfillment(of: [expectation1], timeout: 20.0)
     }
 
+	@MainActor
     func testEventDelete() async throws {
         let query = GameScore.query("points" > 9)
         let installationId = try await BaseParseInstallation.current().installationId
@@ -1811,6 +1818,7 @@ class ParseLiveQueryTests: XCTestCase, @unchecked Sendable {
         await fulfillment(of: [expectation1], timeout: 20.0)
     }
 
+	@MainActor
     func testSubscriptionUpdate() async throws {
         let query = GameScore.query("points" > 9)
         let installationId = try await BaseParseInstallation.current().installationId
@@ -1903,6 +1911,7 @@ class ParseLiveQueryTests: XCTestCase, @unchecked Sendable {
         XCTAssertEqual(pending.count, 0)
     }
 
+	@MainActor
     func testResubscribing() async throws {
         let query = GameScore.query("points" > 9)
         let installationId = try await BaseParseInstallation.current().installationId

--- a/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
@@ -12,7 +12,7 @@ import XCTest
 @testable import ParseSwift
 
 @MainActor
-class ParseQueryViewModelTests: XCTestCase {
+class ParseQueryViewModelTests: XCTestCase, @unchecked Sendable {
     struct GameScore: ParseObject {
         //: These are required by ParseObject
         var objectId: String?

--- a/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
+++ b/Tests/ParseSwiftTests/ParseQueryViewModelTests.swift
@@ -11,7 +11,8 @@ import Foundation
 import XCTest
 @testable import ParseSwift
 
-class ParseQueryViewModelTests: XCTestCase, @unchecked Sendable {
+@MainActor
+class ParseQueryViewModelTests: XCTestCase {
     struct GameScore: ParseObject {
         //: These are required by ParseObject
         var objectId: String?


### PR DESCRIPTION
### New Pull Request Checklist
<!--
    Please check the following boxes [x] before submitting your issue.
    Click the "Preview" tab for better readability.
    Thanks for contributing to Parse-Swift!
-->

- Disclose a [vulnerability](https://github.com/netreconlab/Parse-Swift/security/policy).
- Link this PR to an [issue](https://github.com/netreconlab/Parse-Swift/issues?q=is%3Aissue).

### Issue Description
<!-- Add a brief description of the issue this PR solves. -->

All view models should always run on the MainActor.

Closes: FILL_THIS_OUT

### Approach
<!-- Add a description of the approach in this PR. -->
There’s a build issue on Swift <6.2 preventing the initiation of the Subscription class, the workaround is here https://github.com/netreconlab/Parse-Swift/pull/229/commits/77bb8dd0e3d0543d1e55200a6c2b3ceef236cce1


### TODOs before merging
<!--
    Add TODOs that need to be completed before merging this PR.
    Delete TODOs that do not apply to this PR.
-->

- [ ] Add tests
- [ ] Add entry to changelog
- [ ] Add changes to documentation (guides, repository pages, in-code descriptions)
